### PR TITLE
Handle GPU devices + Rehoboam testing fix

### DIFF
--- a/bittensor/neuron.py
+++ b/bittensor/neuron.py
@@ -7,7 +7,6 @@ import torch.nn as nn
 # Import protos.
 from bittensor import bittensor_pb2
 import bittensor
-import bittensor
 
 class Neuron(nn.Module):
     """ Auto-grad friendly Torch NN module which maintains a connection to a network of other neuons connected across the web. 

--- a/bittensor/serializer.py
+++ b/bittensor/serializer.py
@@ -126,7 +126,7 @@ class PyTorchSerializer(SerializerBase):
             bittensor_pb2.Tensor: Serialized tensor as bittensor_pb2.proto. 
         """
         # Using numpy intermediary because deserializing with pickle can run arbitray code on your machine.
-        data_buffer = tensor.numpy().tobytes()
+        data_buffer = tensor.cpu().numpy().tobytes()
         tensor_def = PyTorchSerializer.todef(tensor)
         proto = bittensor_pb2.Tensor(
                     version = bittensor.__version__,

--- a/bittensor/utils/dispatcher.py
+++ b/bittensor/utils/dispatcher.py
@@ -49,7 +49,6 @@ class Dispatcher(object):
 
         # calculate num samples that each expert gets
         part_sizes = list((gates != 0.0).sum(0).cpu().numpy())
-
         # expand according to batch index so we can just split by _part_sizes
         x_expanded = x[batch_index].squeeze(1).to(self.device)
         return torch.split(x_expanded, part_sizes, dim=0)

--- a/bittensor/utils/router.py
+++ b/bittensor/utils/router.py
@@ -21,6 +21,10 @@ class Router ():
 
         # Object for dispatching / combining gated inputs
         self.dispatcher = bittensor.Dispatcher()
+
+        # Device
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        
         
     def route (self, inputs: torch.Tensor, synapses: List[bittensor_pb2.Synapse]) -> Tuple[List[torch.Tensor], torch.Tensor]:
         # Get synapses from the metagraph.

--- a/examples/mnist/main.py
+++ b/examples/mnist/main.py
@@ -149,7 +149,6 @@ def main(hparams):
 
             # Train.
             output = local + remote
-
             loss = F.nll_loss(output, target.to(net.device))
             loss.backward()
             optimizer.step()
@@ -182,6 +181,7 @@ def main(hparams):
                 pred = output.data.max(1, keepdim=True)[1].to(net.device)
                 correct += pred.eq(target.data.view_as(pred).to(net.device)).sum()
 
+        import pdb; pdb.set_trace()
         test_loss /= len(test_loader.dataset)
         logger.info('Test set: Avg. loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(
         test_loss, correct, len(test_loader.dataset),

--- a/examples/mnist/main.py
+++ b/examples/mnist/main.py
@@ -19,16 +19,17 @@ class Net(bittensor.Synapse):
     """
     def __init__(self):
         super(Net, self).__init__()
-        self.conv1 = nn.Conv2d(1, 6, kernel_size=5, stride=1)
-        self.average1 = nn.AvgPool2d(2, stride=2)
-        self.conv2 = nn.Conv2d(6, 16, kernel_size=5, stride=1)
-        self.average2 = nn.AvgPool2d(2, stride=2)
-        self.conv3 = nn.Conv2d(16, 120, kernel_size=4, stride=1)
-        self.conv2_drop = nn.Dropout2d()
-        self.flatten=Flatten()
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.conv1 = nn.Conv2d(1, 6, kernel_size=5, stride=1).to(self.device)
+        self.average1 = nn.AvgPool2d(2, stride=2).to(self.device)
+        self.conv2 = nn.Conv2d(6, 16, kernel_size=5, stride=1).to(self.device)
+        self.average2 = nn.AvgPool2d(2, stride=2).to(self.device)
+        self.conv3 = nn.Conv2d(16, 120, kernel_size=4, stride=1).to(self.device)
+        self.conv2_drop = nn.Dropout2d().to(self.device)
+        self.flatten=Flatten().to(self.device)
         
-        self.fc1 = nn.Linear(120, 82)
-        self.fc2 = nn.Linear(82, 10)
+        self.fc1 = nn.Linear(120, 82).to(self.device)
+        self.fc2 = nn.Linear(82, 10).to(self.device)
         #self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
         #self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
         #self.conv2_drop = nn.Dropout2d()
@@ -56,17 +57,18 @@ class Net(bittensor.Synapse):
     
     
     def forward(self, x):
-        x = x.view(-1, 1, 28, 28)
-        x = torch.tanh(self.conv1(x))
-        x = self.average1(x)
-        x = torch.tanh(self.conv2(x))
-        x = self.average2(x)
-        x = torch.tanh(self.conv3(x))
-        x = x.view(-1, x.shape[1])
-        x = F.dropout(x, training=self.training)
-        x = F.relu(self.fc1(x))
-        x = F.relu(self.fc2(x))
-        x = F.log_softmax(x)
+        x = x.to(self.device)
+        x = x.view(-1, 1, 28, 28).to(self.device)
+        x = torch.tanh(self.conv1(x)).to(self.device)
+        x = self.average1(x).to(self.device)
+        x = torch.tanh(self.conv2(x)).to(self.device)
+        x = self.average2(x).to(self.device)
+        x = torch.tanh(self.conv3(x)).to(self.device)
+        x = x.view(-1, x.shape[1]).to(self.device)
+        x = F.dropout(x, training=self.training).to(self.device)
+        x = F.relu(self.fc1(x)).to(self.device)
+        x = F.relu(self.fc2(x)).to(self.device)
+        x = F.log_softmax(x).to(self.device)
         return x
     
 class Flatten(nn.Module):
@@ -134,9 +136,8 @@ def main(hparams):
         correct = 0
         for batch_idx, (data, target) in enumerate(train_loader):
             optimizer.zero_grad()
-            
             # Flatten mnist inputs
-            inputs = torch.flatten(data, start_dim=1)
+            inputs = torch.flatten(data, start_dim=1).to(net.device)
             # Query the remote network.
             synapses = neuron.synapses() # Returns a list of synapses on the network.
             requests, scores = router.route(inputs, synapses) # routes inputs to network.
@@ -149,13 +150,13 @@ def main(hparams):
             # Train.
             output = local + remote
 
-            loss = F.nll_loss(output, target)
+            loss = F.nll_loss(output, target.to(net.device))
             loss.backward()
             optimizer.step()
             global_step += 1
             
             # Set network weights.
-            weights = neuron.getweights(synapses)
+            weights = neuron.getweights(synapses).to(net.device)
             weights = (0.99) * weights + 0.01 * torch.mean(scores, dim=0)
             neuron.setweights(synapses, weights)
 
@@ -177,9 +178,9 @@ def main(hparams):
         with torch.no_grad():
             for data, target in test_loader:
                 output = net(data)
-                test_loss += F.nll_loss(output, target, size_average=False).item()
-                pred = output.data.max(1, keepdim=True)[1]
-                correct += pred.eq(target.data.view_as(pred)).sum()
+                test_loss += F.nll_loss(output, target.to(net.device), size_average=False).item()
+                pred = output.data.max(1, keepdim=True)[1].to(net.device)
+                correct += pred.eq(target.data.view_as(pred).to(net.device)).sum()
 
         test_loss /= len(test_loader.dataset)
         logger.info('Test set: Avg. loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(

--- a/examples/rehoboam/transformer.py
+++ b/examples/rehoboam/transformer.py
@@ -10,13 +10,14 @@ class TransformerModel(bittensor.Synapse):
     def __init__(self, ntoken, ninp, nhead, nhid, nlayers, dropout=0.5):
         super(TransformerModel, self).__init__()
         self.model_type = 'Transformer'
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.src_mask = None
-        self.pos_encoder = PositionalEncoding(ninp, dropout)
-        encoder_layers = TransformerEncoderLayer(ninp, nhead, nhid, dropout)
-        self.transformer_encoder = TransformerEncoder(encoder_layers, nlayers)
-        self.encoder = nn.Embedding(ntoken, ninp)
+        self.pos_encoder = PositionalEncoding(ninp, dropout).to(self.device)
+        encoder_layers = TransformerEncoderLayer(ninp, nhead, nhid, dropout).to(self.device)
+        self.transformer_encoder = TransformerEncoder(encoder_layers, nlayers).to(self.device)
+        self.encoder = nn.Embedding(ntoken, ninp).to(self.device)
         self.ninp = ninp
-        self.decoder = nn.Linear(ninp, ntoken)
+        self.decoder = nn.Linear(ninp, ntoken).to(self.device)
 
         self.init_weights()
 


### PR DESCRIPTION
**Context**

This PR introduces changes to rehoboam model and underlying sdk to properly handle machines with GPU capabilities.

Additionally, Rehoboam's testing has been fixed so as to properly calculate accuracy at each Epoch.

**Caveat**: Presently, this is only tested on 1 GPU. It _theoretically_ supports multiple GPUs, more testing is required to verify this.