### PR TITLE
Fixes docker ports issue

### DIFF
--- a/examples/mnist/main.py
+++ b/examples/mnist/main.py
@@ -198,8 +198,9 @@ def main(hparams):
                 writer.add_scalar('train_loss', float(loss.item()), global_step)
             
                 n = len(train_loader.dataset)
-                logger.info('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}\tDistill Loss: {:.6f}'.format(
-                    epoch, (batch_idx * batch_size_train), n, (100. * batch_idx * batch_size_train)/n, loss.item(), dist_loss.item()))
+                logger.info('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}\tDistill Loss: {:.6f}\tnP|nS: {}|{}'.format(
+                    epoch, (batch_idx * batch_size_train), n, (100. * batch_idx * batch_size_train)/n, loss.item(), dist_loss.item(), len(metagraph.peers), 
+                            len(metagraph.synapses)))
 
     # Test loop.
     # Evaluates the local model on the hold-out set.


### PR DESCRIPTION
Presently there's an issue with docker and metagraph in which it's not possible to actually run multiple instances due to misalignment of ports between instances. This is partly due to the way docker is built and due to a couple of bugs in metagraph.py.