### PR TITLE
Fixes to CIFAR and MNIST for PIL changes

### DIFF
--- a/bittensor/metagraph.py
+++ b/bittensor/metagraph.py
@@ -90,8 +90,6 @@ class Metagraph(bittensor_grpc.MetagraphServicer):
     
     def do_gossip(self):
         """ Sends gossip query to random peer"""
-        if len(self._peers) == 0:
-            return
         synapses = self.get_synapses(1000)
         peers = self.get_peers(10)
         metagraph_address = random.choice(list(self._peers))        

--- a/examples/cifar/main.py
+++ b/examples/cifar/main.py
@@ -294,14 +294,17 @@ def main(hparams):
         with torch.no_grad():
             loss = 0.0
             correct = 0.0
-            for i, data in enumerate(testloader, 0):
+            for batch_idx, (image_inputs, targets) in enumerate(testloader, 0):
                 # Set data to correct device.
-                inputs, targets = data
-                inputs = inputs.to(device)
-                targets = targets.to(device)
+                # Encode PIL images to tensors.
+                encoded_inputs = model.encode_image(image_inputs).to(device)
+
+                # Targets to Tensor
+                targets = torch.LongTensor(targets).to(device)
 
                 # Measure loss.
-                logits = model( inputs, model.distill(inputs) )
+                embedding = model.forward( encoded_inputs, model.distill ( encoded_inputs ) )
+                logits = model.logits(embedding)
                 loss += F.nll_loss(logits, targets, size_average=False).item()
 
                 # Count accurate predictions.

--- a/examples/cifar/main.py
+++ b/examples/cifar/main.py
@@ -88,8 +88,6 @@ class CIFAR(bittensor.Synapse):
         x = self.dist_layer4(x)
         x = F.avg_pool2d(x, 4)
         x = torch.flatten(x, start_dim=1)
-        #x = self.linear(x)
-        #x = F.softmax(x)
         return x
     
     def logits (self, x):
@@ -110,8 +108,6 @@ class CIFAR(bittensor.Synapse):
         x = self.layer4(x)
         x = F.avg_pool2d(x, 4)
         x = torch.flatten(x, start_dim=1)
-        #x = self.linear(x)
-        #x = F.log_softmax(x + y)
         return x
     
     def encode_image(self, inputs: torch.Tensor) -> torch.Tensor:
@@ -243,7 +239,7 @@ def main(hparams):
 
             # Run distilled model.
             dist_output = model.distill(image_inputs)
-            dist_loss = F.kl_div(dist_output, network_input.detach())
+            dist_loss = F.mse_loss(dist_output, network_input.detach())
 
             # Distill loss
             student_output = model.forward(encoded_inputs, dist_output)

--- a/examples/mnist/main.py
+++ b/examples/mnist/main.py
@@ -51,10 +51,12 @@ class MnistSynapse(bittensor.Synapse):
         return x
         
     def forward (self, x, y = None):
+        x = x.to(self.device)
         y = self.distill(x) if y == None else y
         x = torch.cat((x, y), dim=1)
         x = F.relu(self.forward_layer1 (x))
         x = F.relu(self.forward_layer2 (x))
+        #x = F.log_softmax(x)
         return x  
     
     def encode_image(self, inputs: torch.Tensor) -> torch.Tensor:
@@ -70,7 +72,7 @@ def main(hparams):
     # Additional training params.
     batch_size_train = 64
     batch_size_test = 64
-    learning_rate = 0.1
+    learning_rate = 0.01
     momentum = 0.9
     log_interval = 10
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -112,7 +114,7 @@ def main(hparams):
     # Build the dendrite and router. 
     # The dendrite is a torch object which makes calls to synapses across the network
     # The router is responsible for learning which synapses to call.
-    dendrite = bittensor.Dendrite( config )
+    dendrite = bittensor.Dendrite( config ).to(device)
     router = bittensor.Router(x_dim = 784, key_dim = 100, topk = 10)
         
     # Build the optimizer.
@@ -148,11 +150,12 @@ def main(hparams):
             
             # Run distilled model.
             dist_output = model.distill(encoded_inputs)
-            dist_loss = F.kl_div(dist_output, network_input.detach())
+            dist_loss = F.mse_loss(dist_output, network_input.detach())
 
             # Distill loss
             student_output = model.forward(encoded_inputs, dist_output)
-            student_loss = F.nll_loss(student_output, target)
+            student_logits = model.logits(student_output)	            
+            student_loss = F.nll_loss(student_logits, targets)
             
             # Query the local network.
             local_embedding = model.forward(encoded_inputs, network_input)
@@ -160,6 +163,8 @@ def main(hparams):
             target_loss = F.nll_loss(local_logits, targets)
             
             loss = (target_loss + dist_loss + student_loss)
+
+            torch.nn.utils.clip_grad_norm_(router.parameters(), 0.5)
             loss.backward()
             optimizer.step()
             global_step += 1
@@ -179,7 +184,7 @@ def main(hparams):
             
                 n = len(train_data)
                 logger.info('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}\tDistill Loss: {:.6f}\tStudent Loss: {:.6f}\tnP|nS: {}|{}'.format(
-                    epoch, (batch_idx * batch_size_train), n, (100. * batch_idx * batch_size_train)/n, loss.item(), dist_loss.item(), student_loss.item(), len(metagraph.peers), 
+                    epoch, (batch_idx * batch_size_train), n, (100. * batch_idx * batch_size_train)/n, target_loss.item(), dist_loss.item(), student_loss.item(), len(metagraph.peers), 
                             len(metagraph.synapses)))
 
     # Test loop.

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,4 +1,6 @@
 from bittensor.serializer import PyTorchSerializer
+import bittensor.bittensor_pb2 as bittensor_pb2
+
 import numpy
 
 import torch
@@ -7,6 +9,6 @@ import torch
 def test_serialize():
     for _ in range(10):
         tensor_a = torch.rand([12, 23])
-        content = PyTorchSerializer.serialize(tensor_a)
+        content = PyTorchSerializer.serialize(tensor_a, bittensor_pb2.Modality.TENSOR)
         tensor_b = PyTorchSerializer.deserialize(content)
         torch.all(torch.eq(tensor_a, tensor_b))


### PR DESCRIPTION
This PR fixes some gradient explosion bugs introduced in MNIST due to the PIL change/merge conflict, it also brings the CIFAR model up to standard by adding the newly created encoding functionalities to it. **CIFAR reached 88% accuracy in epoch 39.** 

Additionally, this PR:
1. Fixes broken unit test due to modalities introduced to serialization function call in last merge.
2. Fixes the issue where bittensor will time out and remove itself from the metagraph after about an hour and there are no peers. 