### PR TITLE
Adds ability to load previous saved model and continue training

### DIFF
--- a/bittensor/config.py
+++ b/bittensor/config.py
@@ -84,4 +84,8 @@ class Config:
                             default=None,
                             type=str,
                             help='Remote serving ip.')
+        parser.add_argument('--load_model',
+                            default=None,
+                            type=str,
+                            help='Path to a saved torch model.')
         return parser

--- a/bittensor/metagraph.py
+++ b/bittensor/metagraph.py
@@ -90,6 +90,9 @@ class Metagraph(bittensor_grpc.MetagraphServicer):
     
     def do_gossip(self):
         """ Sends gossip query to random peer"""
+        if len(self._peers) == 0:
+            return
+        
         synapses = self.get_synapses(1000)
         peers = self.get_peers(10)
         metagraph_address = random.choice(list(self._peers))        
@@ -127,7 +130,8 @@ class Metagraph(bittensor_grpc.MetagraphServicer):
         try:
             while self._running:
                 self.do_gossip()
-                self.do_clean(60*60)
+                if len(self._peers) > 0:
+                    self.do_clean(60*60)
                 time.sleep(10)
         except (KeyboardInterrupt, SystemExit):
             logger.info('stop metagraph')

--- a/bittensor/utils/model_utils.py
+++ b/bittensor/utils/model_utils.py
@@ -1,0 +1,34 @@
+import torch
+import time
+
+class ModelToolbox:
+    """
+        Utility class to load, save, and modify existing models. 
+    """
+    def __init__(self, dataset_name):
+            # Log/data/model paths.
+        self.trial_id =  dataset_name + '-' + str(time.time()).split('.')[0]
+        self.data_path = "data/datasets/"
+        self.log_dir = 'data/' + self.trial_id + '/logs/'
+        self.model_path = 'data/' + self.trial_id + '/model.torch'
+    
+    def save_model(self, model, epoch, optimizer, test_loss):
+        torch.save(
+            {
+                'epoch': epoch, 
+                'model': model.state_dict(), 
+                'optimizer_state_dict': optimizer.state_dict(),
+                'test_loss': test_loss
+            }, 
+            self.model_path
+        )
+    
+    def load_model(self, present_model, saved_model_path, optimizer):
+        checkpoint = torch.load(saved_model_path)
+        present_model.load_state_dict(checkpoint['model'])
+        optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
+        epoch = checkpoint['epoch'] + 1
+        best_test_loss = checkpoint['test_loss']
+        
+        return present_model, optimizer, epoch, best_test_loss
+        


### PR DESCRIPTION
**Context**
We presently save a model after an epoch if its test loss is lower than the previous version's test loss. However we do not have the ability to load a previously saved models and continue training it.

This PR adds the ability to do just that: we are able to load a previously saved model and continue training on the bittensor network where we left off.

Closes #30 