### PR TITLE
Deploy BT on digitalocean

### DIFF
--- a/bittensor/dendrite.py
+++ b/bittensor/dendrite.py
@@ -151,7 +151,10 @@ class _RemoteModuleCall(torch.autograd.Function):
         try:
             response = ctx.caller.stub.Forward(request)                
             # Deserialize outputs and return.
-            outputs = PyTorchSerializer.deserialize_tensor(response.tensors[0])
+            if len(response.tensors) > 0:
+                outputs = PyTorchSerializer.deserialize_tensor(response.tensors[0])
+            else:
+                raise grpc._channel._InactiveRpcError
         except grpc._channel._InactiveRpcError as ire:
             #logger.error("Could not forward() to peer: {}".format(ire))
             outputs = torch.zeros((inputs.size(0), bittensor.__network_dim__))

--- a/bittensor/dendrite.py
+++ b/bittensor/dendrite.py
@@ -86,7 +86,10 @@ class RemoteSynapse(nn.Module):
         self.local_neuron_key = config.neuron_key       
         # Loop back if the synapse is local.
         if synapse.address == config.remote_ip:
-            self.endpoint = 'localhost:' + synapse.port
+            ip = "localhost:"
+            if config.remote_ip == "host.docker.internal":
+                ip = "host.docker.internal:"
+            self.endpoint = ip + synapse.port
         else:
             self.endpoint = synapse.address + ':' + synapse.port
         # TODO(const): should accept defaults. config = bittensor.config_or_defaults(config) 

--- a/bittensor/exceptions/ResponseExceptions.py
+++ b/bittensor/exceptions/ResponseExceptions.py
@@ -1,0 +1,3 @@
+class EmptyTensorException (Exception):
+    """ Raised when tensor included in the response is unexpectedly empty """
+    pass

--- a/start_bittensor.sh
+++ b/start_bittensor.sh
@@ -20,7 +20,7 @@ function print_help () {
   echo " -l, --logdir         Logging directory."
   echo " -p, --port           Bind side port for accepting requests."
   echo " -c, --chain_endpoint Bittensor chain endpoint."
-  echo " -ax, --axon_port      Axon terminal bind port."
+  echo " -ax, --axon_port     The bootstrapping peer's axon port."
   echo " -m, --metagraph_port Metagraph bind port."
   echo " -s, --metagraph_size Metagraph cache size."
   echo " -b, --bootstrap      Metagraph boot peer."
@@ -186,7 +186,7 @@ function start_local_service() {
         exit 0
     }
 
-    trap teardown INT SIGHUP SIGINT SIGTERM ERR EXIT
+    trap teardown INT SIGHUP SIGINT SIGTERM ERR
 
     # Build start command
     bittensor_script="./scripts/bittensor.sh"
@@ -210,11 +210,10 @@ function start_local_service() {
       --mount type=bind,source="$(pwd)"/examples,target=/bittensor/examples \
       $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG /bin/bash -c "$COMMAND"
 
-    log "=== follow logs ==="
-
     if [ $logging == 'true' ]; then
       log "=== follow logs ==="
       docker logs bittensor-$identity --follow
+      trap teardown EXIT
     fi
 }
 
@@ -293,6 +292,7 @@ function start_remote_service() {
   if [ $logging == 'true' ]; then
     log "=== follow logs ==="
     docker logs bittensor-$identity --follow
+    trap teardown EXIT
   fi
 
 }

--- a/start_bittensor.sh
+++ b/start_bittensor.sh
@@ -197,10 +197,22 @@ function start_local_service() {
 
     log "=== run docker container locally ==="
     log "=== container image: $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG ==="
-    docker run --rm --name bittensor-$identity -d -t \
-      -p $port:$dest_port \
-      -p $axon_port:$axon_port \
-      $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG /bin/bash -c "$COMMAND"
+    if [ $remote_ip == 'host.docker.internal' ]; then
+      docker run --rm --name bittensor-$identity -d -t \
+        --network=host \
+        --mount type=bind,source="$(pwd)"/scripts,target=/bittensor/scripts \
+        --mount type=bind,source="$(pwd)"/data,target=/bittensor/data \
+        --mount type=bind,source="$(pwd)"/examples,target=/bittensor/examples \
+        $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG /bin/bash -c "$COMMAND"
+    else
+      docker run --rm --name bittensor-$identity -d -t \
+        -p $port:$dest_port \
+        -p $axon_port:$axon_port \
+        --mount type=bind,source="$(pwd)"/scripts,target=/bittensor/scripts \
+        --mount type=bind,source="$(pwd)"/data,target=/bittensor/data \
+        --mount type=bind,source="$(pwd)"/examples,target=/bittensor/examples \
+        $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG /bin/bash -c "$COMMAND"
+    fi
 
     log "=== follow logs ==="
     docker logs bittensor-$identity --follow


### PR DESCRIPTION
This PR enables us to deploy BT nodes on digitalocean for more large scale experimenting. 
Following container logs is now also an optional argument behind the command line argument `logging`. 

Node can be started with:
`./start_bittensor.sh -m <metagraph_port> -t <digital_ocean_token> --logging true`

Subsequent nodes can be started with
`./start_bittensor.sh --axon_port <bootstrap peer's axon port> --bootstrap <bootstrap peer's IP:port address> --token <digital_ocean_token>`


closes #48 