### PR TITLE
Metagraphfilter

### DIFF
--- a/bittensor/metagraph.py
+++ b/bittensor/metagraph.py
@@ -191,7 +191,7 @@ class Metagraph():
         try:
             current_block = self.substrate.get_block_number(None)
             if pubkey in self._pubkey_index_map:
-                index = self._pubkey_index_map[0]
+                index = self._pubkey_index_map[pubkey]
                 append = False
             else:
                 index = self._n

--- a/bittensor/metagraph.py
+++ b/bittensor/metagraph.py
@@ -188,63 +188,66 @@ class Metagraph():
         info from the local pubkey -> index mapping.
         
         """
-        current_block = self.substrate.get_block_number(None)
-        if pubkey in self._pubkey_index_map:
-            index = self._pubkey_index_map[0]
-            append = False
-        else:
-            index = self._n
-            self._n += 1
-            self._pubkey_index_map[pubkey] = index
-            append = True
-        stake = self.substrate.get_runtime_state(
-                    module='SubtensorModule',
-                    storage_function='Stake',
-                    params=[pubkey]
-        )['result']
-        emit = self.substrate.get_runtime_state(
-                    module='SubtensorModule',
-                    storage_function='LastEmit',
-                    params=[pubkey]
-        )['result']
-        info = self.substrate.get_runtime_state(
-                    module='SubtensorModule',
-                    storage_function='Neurons',
-                    params=[pubkey]
-        )['result']
-        w_keys = self.substrate.get_runtime_state(
-                    module='SubtensorModule',
-                    storage_function='WeightKeys',
-                    params=[pubkey]
-        )['result']
-        w_vals = self.substrate.get_runtime_state(
-                    module='SubtensorModule',
-                    storage_function='WeightVals',
-                    params=[pubkey]
-        )['result']
-        ipstr = int_to_ip(info['ip'])
-        port = int(info['port'])
-        neuron = bittensor_pb2.Neuron (
-                version=bittensor.__version__,
-                public_key=pubkey,
-                address=ipstr,
-                port=port
-        )
-        if append == False:
-            self._neurons_list[index] = neuron
-            self._stake_list[index] = int(stake)
-            self._emit_list[index] = int(emit)
-            self._weight_keys[index] = list(w_keys)
-            self._weight_vals[index] = list(w_vals)
-            self._poll_list[index] = current_block
-        else:
-            self._neurons_list.append( neuron )
-            self._stake_list.append( int(stake) )
-            self._emit_list.append( int(emit) )
-            self._weight_keys.append( list(w_keys) )
-            self._weight_vals.append( list(w_vals) )
-            self._poll_list.append( current_block )
-
+        try:
+            current_block = self.substrate.get_block_number(None)
+            if pubkey in self._pubkey_index_map:
+                index = self._pubkey_index_map[0]
+                append = False
+            else:
+                index = self._n
+                self._n += 1
+                self._pubkey_index_map[pubkey] = index
+                append = True
+            stake = self.substrate.get_runtime_state(
+                        module='SubtensorModule',
+                        storage_function='Stake',
+                        params=[pubkey]
+            )['result']
+            emit = self.substrate.get_runtime_state(
+                        module='SubtensorModule',
+                        storage_function='LastEmit',
+                        params=[pubkey]
+            )['result']
+            info = self.substrate.get_runtime_state(
+                        module='SubtensorModule',
+                        storage_function='Neurons',
+                        params=[pubkey]
+            )['result']
+            w_keys = self.substrate.get_runtime_state(
+                        module='SubtensorModule',
+                        storage_function='WeightKeys',
+                        params=[pubkey]
+            )['result']
+            w_vals = self.substrate.get_runtime_state(
+                        module='SubtensorModule',
+                        storage_function='WeightVals',
+                        params=[pubkey]
+            )['result']
+            ipstr = int_to_ip(info['ip'])
+            port = int(info['port'])
+            neuron = bittensor_pb2.Neuron (
+                    version=bittensor.__version__,
+                    public_key=pubkey,
+                    address=ipstr,
+                    port=port
+            )
+            if append == False:
+                self._neurons_list[index] = neuron
+                self._stake_list[index] = int(stake)
+                self._emit_list[index] = int(emit)
+                self._weight_keys[index] = list(w_keys)
+                self._weight_vals[index] = list(w_vals)
+                self._poll_list[index] = current_block
+            else:
+                self._neurons_list.append( neuron )
+                self._stake_list.append( int(stake) )
+                self._emit_list.append( int(emit) )
+                self._weight_keys.append( list(w_keys) )
+                self._weight_vals.append( list(w_vals) )
+                self._poll_list.append( current_block )
+        except Exception as e:
+            # Failure here if the node data is corrupted.
+            pass
 
     def _build_torch_tensors(self):
         """ Builds torch objects from python polled state.


### PR DESCRIPTION
-- This PR adds a multi step chain polling function.
1) We look for peers on the network who have submitted and emission step within config.session_settings.stale_emit_limit
2) For these peers we check to see if we have polled them recently within config.re_poll_neuron_every_blocks blocks
3) We poll remaining peers getting stake and weights information
4) We format this information into torch tensors remembering the index of peers to ensure the weights remain the correct shape

-- This PR also includes a slight fix to the polling background thread allowing it to be controlled by config.polls_every_sec
it is started and stopped within the BT session.
