### PR TITLE
Changed set_weight to emit

### DIFF
--- a/bittensor/metagraph.py
+++ b/bittensor/metagraph.py
@@ -417,7 +417,7 @@ class Metagraph():
         # Makes weight emission call.
         # TODO(const): make wait for inclusion work.
         try:
-            await self.subtensor_client.set_weights(keys, vals, self.__keypair, wait_for_inclusion = False)
+            await self.subtensor_client.emit(keys, vals, self.__keypair, wait_for_inclusion = False)
         except Exception as e:
             logger.warning('Failed to emit weights with error {}, and weights {}', e, list(zip(keys, vals)))
             return False

--- a/bittensor/subtensor/client/__init__.py
+++ b/bittensor/subtensor/client/__init__.py
@@ -145,13 +145,14 @@ class WSClient:
 
         return result['result']
 
-    async def emit(self, keypair):
+    async def emit(self, destinations, values, keypair, wait_for_inclusion=False):
         call = await self.substrate.compose_call(
             call_module='SubtensorModule',
-            call_function='emit'
+            call_function='emit',
+            call_params = {'dests': destinations, 'values': values}
         )
         extrinsic = await self.substrate.create_signed_extrinsic(call=call, keypair=keypair)
-        await self.substrate.submit_extrinsic(extrinsic, wait_for_inclusion=False)
+        await self.substrate.submit_extrinsic(extrinsic, wait_for_inclusion=wait_for_inclusion)
 
 
     async def neurons(self, pubkey=None):

--- a/neurons/mnist.py
+++ b/neurons/mnist.py
@@ -179,9 +179,7 @@ def main(config: Munch, session: Session):
         scheduler.step()
 
         # Test model.
-        test_loss, _ = test( 
-            epoch = epoch,
-
+        test_loss, test_accuracy = test( 
             model = model,
             session = session,
             testloader = testloader,


### PR DESCRIPTION
This PR changes it so that call the emit() function in subtensor and send it whatever destinations and weights we presently have. If there are none, the emit() call in subtensor will take care of it.