### PR TITLE
176035336 keys

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -1,9 +1,8 @@
 from loguru import logger
 import os
 import sys
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
 from transformers import GPT2Tokenizer
-import bittensor.exceptions.handlers.rollbar as rollbar
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -13,7 +12,7 @@ from bittensor.session import Session
 __version__ = '0.0.0'
 __blocktime__ = 6 # seconds
 __network_dim__ = 512
-__tokenizer__ = GPT2Tokenizer.from_pretrained("gpt2")
+__tokenizer__ = GPT2Tokenizer.from_pretrained("gpt2", local_files_only=True)
 __tokenizer__.pad_token = '[PAD]'
 __tokenizer__.mask_token = -100
 __vocab_size__ = 204483

--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -30,7 +30,10 @@ logger.configure(**logger_config)
 
 # Initialize the global bittensor session object.
 session = None
-def init(config: Config, keypair: Keypair):
+def init(config: Config):
     global session
-    session = Session(config, keypair)
+
+    session = Session(config)
     return session
+
+

--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -12,7 +12,7 @@ from bittensor.session import Session
 __version__ = '0.0.0'
 __blocktime__ = 6 # seconds
 __network_dim__ = 512
-__tokenizer__ = GPT2Tokenizer.from_pretrained("gpt2", local_files_only=True)
+__tokenizer__ = GPT2Tokenizer.from_pretrained("gpt2", local_files_only=False)
 __tokenizer__.pad_token = '[PAD]'
 __tokenizer__.mask_token = -100
 __vocab_size__ = 204483

--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -39,7 +39,7 @@ class Axon(bittensor_grpc.BittensorServicer):
     It recieves Forward and Backward requests and process the corresponding Synapse.call_forward and Synapse.call_backward.
     
     """
-    def __init__(self, config, keypair):
+    def __init__(self, config):
         r""" Initializes a new Axon endpoint with passed config and keypair.
             Args:
                 config (:obj:`Munch`, `required`): 
@@ -48,7 +48,7 @@ class Axon(bittensor_grpc.BittensorServicer):
                     bittensor keypair.
         """
         self._config = config
-        self.__keypair = keypair
+        self.__keypair = config.session.keypair
 
         # Background threaded processing object.
         self._nucleus = Nucleus(config)

--- a/bittensor/config.py
+++ b/bittensor/config.py
@@ -38,6 +38,8 @@ class MustPassNeuronPath(Exception):
 class Config:
     @staticmethod
     def toString(items) -> str:
+
+        print(items.toDict())
         return "\n" + yaml.dump(items.toDict())
 
     @staticmethod   

--- a/bittensor/config.py
+++ b/bittensor/config.py
@@ -14,6 +14,7 @@ from bittensor.session import Session
 from bittensor.dendrite import Dendrite
 from bittensor.metagraph import Metagraph
 from bittensor.metadata import Metadata
+from bittensor.session import KeyFileError
 
 class InvalidConfigFile(Exception):
     pass
@@ -78,12 +79,17 @@ class Config:
                 head[split_keys[-1]] = arg_val
 
         # 4. Run session checks.
-        config = Dendrite.check_config(config)
-        config = Session.check_config(config)
-        config = Metagraph.check_config(config)
-        config = Metadata.check_config(config)
-        config = Axon.check_config(config)
-        return config
+        try:
+            config = Dendrite.check_config(config)
+            config = Session.check_config(config)
+            config = Metagraph.check_config(config)
+            config = Metadata.check_config(config)
+            config = Axon.check_config(config)
+            return config
+        except KeyFileError:
+            quit()
+
+
             
     @staticmethod
     def load_from_relative_path(path: str)  -> Munch:

--- a/bittensor/crypto/__init__.py
+++ b/bittensor/crypto/__init__.py
@@ -24,3 +24,8 @@ def __generate_key(password):
     kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), salt=__SALT, length=32, iterations=10000000, backend=default_backend())
     key = base64.urlsafe_b64encode(kdf.derive(password.encode()))
     return key
+
+
+
+def is_encrypted(data):
+    return data[:6] == b"gAAAAA"

--- a/bittensor/crypto/__init__.py
+++ b/bittensor/crypto/__init__.py
@@ -1,0 +1,26 @@
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+import base64
+
+__SALT = b"Iguesscyborgslikemyselfhaveatendencytobeparanoidaboutourorigins"
+
+def encrypt(data, password):
+
+    key = __generate_key(password)
+
+    cipher_suite = Fernet(key)
+    return cipher_suite.encrypt(data)
+
+def decrypt_keypair(data, password):
+
+    key = __generate_key(password)
+
+    cipher_suite = Fernet(key)
+    return cipher_suite.decrypt(data)
+
+def __generate_key(password):
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), salt=__SALT, length=32, iterations=10000000, backend=default_backend())
+    key = base64.urlsafe_b64encode(kdf.derive(password.encode()))
+    return key

--- a/bittensor/dendrite.py
+++ b/bittensor/dendrite.py
@@ -50,14 +50,10 @@ class Dendrite(nn.Module):
         >>>     responses[0].backward() # Backprop through dendrite.
     """
 
-    def __init__(
-            self,
-            config,
-            keypair,
-    ):
+    def __init__(self, config):
         super().__init__()
         self._config = config
-        self.__keypair = keypair
+        self.__keypair = config.session.keypair
         self._remotes = {}
 
     @staticmethod   

--- a/bittensor/metagraph.py
+++ b/bittensor/metagraph.py
@@ -13,7 +13,7 @@ import traceback
 from munch import Munch
 from loguru import logger
 from bittensor import bittensor_pb2
-from bittensor.subtensor import WSClient
+from bittensor.subtensor.client import WSClient
 from typing import List, Tuple, List
 
 from bittensor.exceptions.handlers import rollbar

--- a/bittensor/metagraph.py
+++ b/bittensor/metagraph.py
@@ -133,7 +133,7 @@ class TorchChainState():
 
 class Metagraph():
 
-    def __init__(self, config, keypair):
+    def __init__(self, config):
         r"""Initializes a new Metagraph subtensor interface.
         Args:
             config (bittensor.Config):
@@ -143,7 +143,7 @@ class Metagraph():
         """
         # Protected vars
         self._config = config
-        self.__keypair = keypair
+        self.__keypair = config.session.keypair
 
         # Client for talking to chain.
         self.subtensor_client = WSClient(self._config.metagraph.chain_endpoint, self.__keypair)

--- a/bittensor/session.py
+++ b/bittensor/session.py
@@ -9,7 +9,7 @@ from bittensor.dendrite import Dendrite
 from bittensor.axon import Axon
 from bittensor.metagraph import Metagraph
 from bittensor.utils.asyncio import Asyncio
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
 from bittensor.metadata import Metadata
 from bittensor.exceptions.handlers import rollbar
 from loguru import logger

--- a/bittensor/session.py
+++ b/bittensor/session.py
@@ -13,7 +13,14 @@ from bittensor.subtensor.interface import Keypair
 from bittensor.metadata import Metadata
 from bittensor.exceptions.handlers import rollbar
 from loguru import logger
-import asyncio
+from bittensor.crypto import is_encrypted
+from bittensor.utils import Cli
+from bittensor.crypto import decrypt_keypair
+from cryptography.exceptions import InvalidSignature, InvalidKey
+from cryptography.fernet import InvalidToken
+import json
+
+
 import os
 
 class FailedConnectToChain(Exception):
@@ -31,39 +38,77 @@ class FailedToPollChain(Exception):
 class KeyFileError(Exception):
     pass
 
+class KeyError(Exception):
+    pass
+
+
+
 class Session:
-    def __init__(self, config, keypair: Keypair):
-        self.config = config 
-        self.__keypair = keypair
-        self.metagraph = Metagraph(self.config, self.__keypair)
-        self.axon = Axon(self.config, self.__keypair)
-        self.dendrite = Dendrite(self.config, self.__keypair)
+    def __init__(self, config):
+        self.config = config
+        self.metagraph = Metagraph(self.config)
+        self.axon = Axon(self.config)
+        self.dendrite = Dendrite(self.config)
         self.tbwriter = Metadata(self.config)
 
     @staticmethod   
     def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        parser.add_argument('--session.key', required=False, default='~/.bittensor/key', help="Path to the bittensor key file")
+        parser.add_argument('--session.keyfile', required=False, default='~/.bittensor/key', help="Path to the bittensor key file")
         return parser
 
     @staticmethod   
     def check_config(config: Munch) -> Munch:
-        Session.__check_key_path(config.session.key)
+        Session.__check_key_path(config.session.keyfile)
 
     @staticmethod
     def __check_key_path(path):
         path = os.path.expanduser(path)
         if not os.path.exists(path):
-            logger.error("--session.key {} does not exist", path)
+            logger.error("--session.keyfile {} does not exist", path)
             raise KeyFileError
 
         if not os.path.isfile(path):
-            logger.error("--session.key {} is not a file", path)
+            logger.error("--session.keyfile {} is not a file", path)
             raise KeyFileError
 
         if not os.access(path, os.R_OK):
-            logger.error("--session.key {} is not readable", path)
+            logger.error("--session.keyfile {} is not readable", path)
             raise KeyFileError
 
+    @staticmethod
+    def load_keypair(config):
+        logger.info("Loading keypair")
+        keyfile = os.path.expanduser(config.session.keyfile)
+        with open(keyfile, 'rb') as file:
+            data = file.read()
+
+            if is_encrypted(data):
+                data = Session.decrypt_data(data)
+
+            keypair = Session.load_keypair_from_data(data)
+            config.session.keypair = keypair
+
+    @staticmethod
+    def load_keypair_from_data(data) -> Keypair:
+        try:
+            data = json.loads(data)
+            if "secretSeed" not in data:
+                raise KeyFileError("Keyfile corrupt")
+
+            return Keypair.create_from_seed(data['secretSeed'])
+        except BaseException as e:
+            logger.debug(e)
+            logger.error("Invalid keypair")
+            raise KeyError
+
+    @staticmethod
+    def decrypt_data(data):
+        try:
+            password = Cli.ask_password()
+            return decrypt_keypair(data, password)
+        except (InvalidSignature, InvalidKey, InvalidToken):
+            logger.error("Invalid password")
+            raise KeyError
 
     def __del__(self):
         self.stop()

--- a/bittensor/subtensor/__init__.py
+++ b/bittensor/subtensor/__init__.py
@@ -1,3 +1,0 @@
-from .interface import SubstrateWSInterface
-from .interface import Keypair
-from .client import WSClient

--- a/bittensor/subtensor/client/__init__.py
+++ b/bittensor/subtensor/client/__init__.py
@@ -1,4 +1,4 @@
-from bittensor.subtensor import SubstrateWSInterface, Keypair
+from bittensor.subtensor.interface import SubstrateWSInterface, Keypair
 import netaddr
 from loguru import logger
 

--- a/bittensor/subtensor/interface/__init__.py
+++ b/bittensor/subtensor/interface/__init__.py
@@ -252,6 +252,17 @@ class Keypair:
     def __repr__(self):
         return '<Keypair (ss58_address={})>'.format(self.ss58_address)
 
+    def toDict(self):
+        return {
+            'accountId': self.public_key,
+            'publicKey': self.public_key,
+            'secretPhrase': self.mnemonic,
+            'secretSeed': "0x" + self.seed_hex,
+            'ss58Address': self.ss58_address
+        }
+
+
+
 
 
 

--- a/bittensor/subtensor/interface/__init__.py
+++ b/bittensor/subtensor/interface/__init__.py
@@ -18,7 +18,7 @@
 import asyncio
 from hashlib import blake2b
 import binascii
-import json
+import json, yaml
 from loguru import logger
 import re
 
@@ -250,7 +250,7 @@ class Keypair:
             raise ConfigurationError("Crypto type not supported")
 
     def __repr__(self):
-        return '<Keypair (ss58_address={})>'.format(self.ss58_address)
+        return '(ss58_address={})'.format(self.ss58_address)
 
     def toDict(self):
         return {
@@ -261,8 +261,14 @@ class Keypair:
             'ss58Address': self.ss58_address
         }
 
+def KeypairRepresenter(dumper, data):
+    serializedData = data.__repr__()
+
+    logger.debug(serializedData)
+    return dumper.represent_scalar('Keypair', serializedData)
 
 
+yaml.add_representer(Keypair, KeypairRepresenter)
 
 
 

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -1,1 +1,6 @@
+import getpass
 
+class Cli:
+    @staticmethod
+    def ask_password():
+        return getpass.getpass("Enter password to unlock key: ")

--- a/neurons/bert_mlm.py
+++ b/neurons/bert_mlm.py
@@ -1,3 +1,4 @@
+#!/bin/python3
 """BERT Masked Language Modelling.
 
 This file demonstrates training the BERT neuron with masked language modelling.
@@ -160,21 +161,17 @@ def main(config, session):
     
 
 if __name__ == "__main__":
-    # 1. Load bittensor config.
+    # Load bittensor config.
     parser = argparse.ArgumentParser()
     parser = add_args(parser)
     config = Config.load(parser)
     config = check_config(config)
     logger.info(Config.toString(config))
 
-    # 2. Load Keypair.
-    mnemonic = Keypair.generate_mnemonic()
-    keypair = Keypair.create_from_mnemonic(mnemonic)
-   
-    # 3. Load Session.
-    session = bittensor.init(config, keypair)
+    # Load Session.
+    session = bittensor.init(config)
 
-    # 4. Start Neuron.
+    # Start Neuron.
     with session:
         main(config, session)
             

--- a/neurons/bert_mlm.py
+++ b/neurons/bert_mlm.py
@@ -10,7 +10,7 @@ import bittensor
 import argparse
 from bittensor.config import Config
 from bittensor.utils.logging import log_outputs
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
 from bittensor.synapses.bert import BertMLMSynapse
 
 from loguru import logger

--- a/neurons/bert_nsp.py
+++ b/neurons/bert_nsp.py
@@ -10,7 +10,7 @@ import bittensor
 import argparse
 from bittensor.config import Config
 from bittensor.utils.logging import log_outputs
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
 from bittensor.synapses.bert import BertNSPSynapse
 
 

--- a/neurons/bert_nsp.py
+++ b/neurons/bert_nsp.py
@@ -1,3 +1,4 @@
+#!/bin/python3
 """BERT Next Sentence Prediction Neuron.
 
 This file demonstrates training the BERT neuron with next sentence prediction.
@@ -165,21 +166,17 @@ def main(config, session):
     
 
 if __name__ == "__main__":
-    # 1. Load bittensor config.
+    # Load bittensor config.
     parser = argparse.ArgumentParser()
     parser = add_args(parser)
     config = Config.load(parser)
     config = check_config(config)
     logger.info(Config.toString(config))
 
-    # 2. Load Keypair.
-    mnemonic = Keypair.generate_mnemonic()
-    keypair = Keypair.create_from_mnemonic(mnemonic)
-   
-    # 3. Load Session.
-    session = bittensor.init(config, keypair)
+    # Load Session.
+    session = bittensor.init(config)
 
-    # 4. Start Neuron.
+    # Start Neuron.
     with session:
         main(config, session)
             

--- a/neurons/cifar.py
+++ b/neurons/cifar.py
@@ -1,3 +1,4 @@
+#!/bin/python3
 """Training a CIFAR Neuron.
 
 This file demonstrates a training pipeline for an CIFAR Neuron.
@@ -201,21 +202,17 @@ def main(config: Munch, session: Session):
         epoch += 1
 
 if __name__ == "__main__":
-    # 1. Load bittensor config.
+    # Load bittensor config.
     parser = argparse.ArgumentParser()
     parser = add_args(parser)
     config = Config.load(parser)
     config = check_config(config)
     logger.info(Config.toString(config))
 
-    # 2. Load Keypair.
-    mnemonic = Keypair.generate_mnemonic()
-    keypair = Keypair.create_from_mnemonic(mnemonic)
-   
-    # 3. Load Session.
-    session = bittensor.init(config, keypair)
+    # Load Session.
+    session = bittensor.init(config)
 
-    # 4. Start Neuron.
+    # Start Neuron.
     with session:
         main(config, session)
 

--- a/neurons/cifar.py
+++ b/neurons/cifar.py
@@ -23,7 +23,7 @@ from loguru import logger
 import bittensor
 from bittensor import Session
 from bittensor.utils.logging import (log_outputs, log_batch_weights, log_chain_weights, log_request_sizes)
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
 from bittensor.config import Config
 from bittensor.synapse import Synapse
 from bittensor.synapses.dpn import DPNSynapse

--- a/neurons/gpt2-wiki.py
+++ b/neurons/gpt2-wiki.py
@@ -1,4 +1,5 @@
-"""GPT2 Language Modelling 
+#!/bin/python3
+"""GPT2 Language Modelling
 
 This file demonstrates training the GPT2 neuron with language modelling.
 
@@ -123,21 +124,17 @@ def main(config, session):
     
 
 if __name__ == "__main__":
-    # 1. Load bittensor config.
+    # Load bittensor config.
     parser = argparse.ArgumentParser()
     parser = add_args(parser)
     config = Config.load(parser)
     config = check_config(config)
     logger.info(Config.toString(config))
 
-    # 2. Load Keypair.
-    mnemonic = Keypair.generate_mnemonic()
-    keypair = Keypair.create_from_mnemonic(mnemonic)
-   
-    # 3. Load Session.
-    session = bittensor.init(config, keypair)
+    # Load Session.
+    session = bittensor.init(config)
 
-    # 4. Start Neuron.
+    # Start Neuron.
     with session:
         main(config, session)
 

--- a/neurons/gpt2-wiki.py
+++ b/neurons/gpt2-wiki.py
@@ -7,7 +7,7 @@ Example:
 
 """
 import bittensor
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
 from bittensor.utils.logging import (log_outputs, log_batch_weights, log_chain_weights, log_request_sizes)
 from bittensor.config import Config
 from bittensor.synapses.gpt2 import GPT2LMSynapse, nextbatch

--- a/neurons/mnist.py
+++ b/neurons/mnist.py
@@ -1,3 +1,4 @@
+#!/bin/python3
 """Training a MNIST Neuron.
 This file demonstrates a training pipeline for an MNIST Neuron.
 Example:
@@ -201,21 +202,17 @@ def main(config: Munch, session: Session):
         epoch += 1
 
 if __name__ == "__main__":
-    # 1. Load bittensor config.
+    # Load bittensor config.
     parser = argparse.ArgumentParser()
     parser = add_args(parser)
     config = Config.load(parser)
     config = check_config(config)
     logger.info(Config.toString(config))
 
-    # 2. Load Keypair.
-    # mnemonic = Keypair.generate_mnemonic()
-    # keypair = Keypair.create_from_mnemonic(mnemonic)
-   
-    # 3. Load Session.
+    # Load Session.
     session = bittensor.init(config)
 
-    # 4. Start Neuron.
+    # Start Neuron.
     with session:
         main(config, session)
 

--- a/neurons/mnist.py
+++ b/neurons/mnist.py
@@ -209,11 +209,11 @@ if __name__ == "__main__":
     logger.info(Config.toString(config))
 
     # 2. Load Keypair.
-    mnemonic = Keypair.generate_mnemonic()
-    keypair = Keypair.create_from_mnemonic(mnemonic)
+    # mnemonic = Keypair.generate_mnemonic()
+    # keypair = Keypair.create_from_mnemonic(mnemonic)
    
     # 3. Load Session.
-    session = bittensor.init(config, keypair)
+    session = bittensor.init(config)
 
     # 4. Start Neuron.
     with session:

--- a/neurons/mnist.py
+++ b/neurons/mnist.py
@@ -20,7 +20,7 @@ from loguru import logger
 import bittensor
 from bittensor import Session
 from bittensor.utils.logging import (log_outputs, log_batch_weights, log_chain_weights, log_request_sizes)
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
 from bittensor.config import Config
 from bittensor.synapse import Synapse
 from bittensor.synapses.ffnn import FFNNSynapse

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ pytest-asyncio
 replicate
 codecov
 rollbar
+password_strength

--- a/scratchpad/keys.py
+++ b/scratchpad/keys.py
@@ -1,0 +1,67 @@
+#!/bin/python3
+
+from argparse import ArgumentParser
+from pathlib import Path
+from loguru import logger
+
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+import base64
+
+test_json = """{ 
+  "accountId": "0x96f84a32fe0fd3b5e61b68705340e50a300562a85172b97ec113e76665caaf65",
+  "publicKey": "0x96f84a32fe0fd3b5e61b68705340e50a300562a85172b97ec113e76665caaf65",
+  "secretPhrase": "duty embrace auto sketch ring fluid enough resemble insect nuclear top vital congress ship conduct lobster lunch pause clump walk wash stereo force scrap",
+  "secretSeed": "0xde2c5031d26e80c9b553b94fc7a6ba39b4b83e103689e2bfc425104d6dcaf35c",
+  "ss58Address": "5FUeoCZBwqh7bNsMB73iDDAQhmWjjzYAMkK1vUP6jXe172yp"
+}"""
+
+
+
+def generate_key(password):
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), salt=b"Iguesscyborgslikemyselfhaveatendencytobeparanoidaboutourorigins", length=32, iterations=10, backend=default_backend())
+    key = base64.urlsafe_b64encode(kdf.derive(password.encode()))
+    return key
+
+
+parser = ArgumentParser(description="Key loading test script")
+parser.add_argument("--key", required=False, default="~/.bittensor/key", help="Path to the keyfile")
+
+args = parser.parse_args()
+file = Path(args.key)
+file = file.expanduser()
+
+if not file.is_file():
+    logger.error("File {} not found.", file.__fspath__())
+
+
+password = input("Enncryption password ?")
+key = generate_key(password)
+
+
+
+
+
+clear = base64.urlsafe_b64decode(cipher_text)
+print(clear)
+
+password = input('Decryption password ?')
+key = generate_key(password)
+
+cipher_suite = Fernet(key)
+plaintext = cipher_suite.decrypt(cipher_text)
+
+
+print(plaintext.decode())
+
+
+
+
+
+
+
+
+
+

--- a/tests/integration_tests/cpu_tests/bittensor/test_mnist_node.py
+++ b/tests/integration_tests/cpu_tests/bittensor/test_mnist_node.py
@@ -8,7 +8,7 @@ Example:
 import bittensor
 from bittensor.config import Config
 from bittensor.synapses.ffnn import FFNNSynapse
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
 from bittensor.utils.logging import (log_outputs, log_batch_weights, log_chain_weights, log_request_sizes)
 
 import argparse

--- a/tests/integration_tests/subtensor_client_tests/test_connect.py
+++ b/tests/integration_tests/subtensor_client_tests/test_connect.py
@@ -1,4 +1,5 @@
-from bittensor.subtensor import WSClient, Keypair
+from bittensor.subtensor.client import WSClient
+from bittensor.subtensor.interface import Keypair
 from loguru import logger
 import pytest
 

--- a/tests/integration_tests/subtensor_client_tests/test_subscribe.py
+++ b/tests/integration_tests/subtensor_client_tests/test_subscribe.py
@@ -1,4 +1,5 @@
-from bittensor.subtensor import WSClient, Keypair
+from bittensor.subtensor.client import WSClient
+from bittensor.subtensor.interface import Keypair
 from loguru import logger
 import pytest
 

--- a/tests/unit_tests/bittensor_tests/test_axon.py
+++ b/tests/unit_tests/bittensor_tests/test_axon.py
@@ -11,10 +11,6 @@ import random
 import torch
 from munch import Munch
 
-config = Config.load()
-mnemonic = Keypair.generate_mnemonic()
-keypair = Keypair.create_from_mnemonic(mnemonic)
-
 config = {'neuron':
               {'datapath': 'data/', 'learning_rate': 0.01, 'momentum': 0.9, 'batch_size_train': 64,
                'batch_size_test': 64, 'log_interval': 10, 'sync_interval': 100, 'priority_interval': 100,
@@ -29,6 +25,8 @@ config = {'neuron':
           }
 
 config = Munch.fromDict(config)
+mnemonic = Keypair.generate_mnemonic()
+keypair = Keypair.create_from_mnemonic(mnemonic)
 config.session.keypair = keypair
 
 axon = bittensor.axon.Axon(config)

--- a/tests/unit_tests/bittensor_tests/test_axon.py
+++ b/tests/unit_tests/bittensor_tests/test_axon.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 from bittensor.config import Config
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
 from bittensor.synapse import Synapse
 from bittensor.serializer import PyTorchSerializer, torch_dtype_to_bittensor_dtype, bittensor_dtype_to_torch_dtype
 from bittensor import bittensor_pb2
@@ -9,12 +9,31 @@ import bittensor
 import unittest
 import random
 import torch
+from munch import Munch
 
 config = Config.load()
 mnemonic = Keypair.generate_mnemonic()
 keypair = Keypair.create_from_mnemonic(mnemonic)
-axon = bittensor.axon.Axon( config, keypair)
-synapse = Synapse( config, None )
+
+config = {'neuron':
+              {'datapath': 'data/', 'learning_rate': 0.01, 'momentum': 0.9, 'batch_size_train': 64,
+               'batch_size_test': 64, 'log_interval': 10, 'sync_interval': 100, 'priority_interval': 100,
+               'name': 'mnist', 'trial_id': '1608070667'},
+          'synapse': {'target_dim': 10},
+          'dendrite': {'key_dim': 100, 'topk': 10, 'stale_emit_filter': 10000, 'pass_gradients': True, 'timeout': 0.5,
+                       'do_backoff': True, 'max_backoff': 100}, 'axon': {'port': 8091, 'remote_ip': '191.97.53.53'},
+          'nucleus': {'max_workers': 5, 'queue_timeout': 5, 'queue_maxsize': 1000},
+          'metagraph': {'chain_endpoint': '206.189.254.5:12345', 'stale_emit_filter': 10000},
+          'meta_logger': {'log_dir': 'data/'},
+          'session': {'keyfile': None, 'keypair': None }
+          }
+
+config = Munch.fromDict(config)
+config.session.keypair = keypair
+
+axon = bittensor.axon.Axon(config)
+synapse = Synapse(config, None)
+
 
 def test_serve():
     assert axon.synapse == None
@@ -22,9 +41,10 @@ def test_serve():
         axon.serve(synapse)
     assert axon.synapse != None
 
+
 def test_forward_not_implemented():
     axon.serve(synapse)
-    axon._nucleus.forward = MagicMock(return_value = [None, 'not implemented', bittensor_pb2.ReturnCode.NotImplemented])
+    axon._nucleus.forward = MagicMock(return_value=[None, 'not implemented', bittensor_pb2.ReturnCode.NotImplemented])
     x = torch.rand(3, 3, bittensor.__network_dim__)
     request = bittensor_pb2.TensorMessage(
         version=bittensor.__version__,
@@ -33,6 +53,7 @@ def test_forward_not_implemented():
     )
     response = axon.Forward(request, None)
     assert response.return_code == bittensor_pb2.ReturnCode.NotImplemented
+
 
 def test_forward_not_serving():
     axon.synapse = None
@@ -43,6 +64,7 @@ def test_forward_not_serving():
     response = axon.Forward(request, None)
     assert response.return_code == bittensor_pb2.ReturnCode.NotServingSynapse
 
+
 def test_empty_forward_request():
     axon.serve(synapse)
     request = bittensor_pb2.TensorMessage(
@@ -52,10 +74,11 @@ def test_empty_forward_request():
     response = axon.Forward(request, None)
     assert response.return_code == bittensor_pb2.ReturnCode.EmptyRequest
 
+
 def test_forward_deserialization_error():
     axon.serve(synapse)
     x = dict()
-    y = dict() # Not tensors that can be deserialized.
+    y = dict()  # Not tensors that can be deserialized.
     request = bittensor_pb2.TensorMessage(
         version=bittensor.__version__,
         public_key=keypair.public_key,
@@ -63,6 +86,7 @@ def test_forward_deserialization_error():
     )
     response = axon.Forward(request, None)
     assert response.return_code == bittensor_pb2.ReturnCode.RequestDeserializationException
+
 
 def test_forward_success():
     axon.synapse = synapse
@@ -72,13 +96,14 @@ def test_forward_success():
         public_key=keypair.public_key,
         tensors=[PyTorchSerializer.serialize_tensor(x)]
     )
-    axon._nucleus.forward = MagicMock(return_value = [x, 'success', bittensor_pb2.ReturnCode.Success])
+    axon._nucleus.forward = MagicMock(return_value=[x, 'success', bittensor_pb2.ReturnCode.Success])
 
     response = axon.Forward(request, None)
     assert response.return_code == bittensor_pb2.ReturnCode.Success
     assert len(response.tensors) == 1
     assert response.tensors[0].shape == [3, 3, bittensor.__network_dim__]
     assert bittensor_dtype_to_torch_dtype(response.tensors[0].dtype) == torch.float32
+
 
 def test_backward_not_serving():
     axon.synapse = None
@@ -88,6 +113,7 @@ def test_backward_not_serving():
     )
     response = axon.Backward(request, None)
     assert response.return_code == bittensor_pb2.ReturnCode.NotServingSynapse
+
 
 def test_empty_backward_request():
     axon.serve(synapse)
@@ -114,7 +140,7 @@ def test_single_item_backward_request():
 def test_backward_deserialization_error():
     axon.serve(synapse)
     x = dict()
-    y = dict() # Not tensors that can be deserialized.
+    y = dict()  # Not tensors that can be deserialized.
     request = bittensor_pb2.TensorMessage(
         version=bittensor.__version__,
         public_key=keypair.public_key,
@@ -122,6 +148,7 @@ def test_backward_deserialization_error():
     )
     response = axon.Backward(request, None)
     assert response.return_code == bittensor_pb2.ReturnCode.RequestDeserializationException
+
 
 def test_backward_success():
     axon.serve(synapse)
@@ -131,7 +158,7 @@ def test_backward_success():
         public_key=keypair.public_key,
         tensors=[PyTorchSerializer.serialize_tensor(x), PyTorchSerializer.serialize_tensor(x)]
     )
-    axon._nucleus.backward = MagicMock(return_value = [x, 'success', bittensor_pb2.ReturnCode.Success])
+    axon._nucleus.backward = MagicMock(return_value=[x, 'success', bittensor_pb2.ReturnCode.Success])
     response = axon.Backward(request, None)
 
     assert response.return_code == bittensor_pb2.ReturnCode.Success

--- a/tests/unit_tests/bittensor_tests/test_dendrite.py
+++ b/tests/unit_tests/bittensor_tests/test_dendrite.py
@@ -5,16 +5,34 @@ import bittensor
 import pytest
 
 from bittensor.config import Config
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
 from bittensor import bittensor_pb2
 import time
+from munch import Munch
+
+config = {'neuron':
+              {'datapath': 'data/', 'learning_rate': 0.01, 'momentum': 0.9, 'batch_size_train': 64,
+               'batch_size_test': 64, 'log_interval': 10, 'sync_interval': 100, 'priority_interval': 100,
+               'name': 'mnist', 'trial_id': '1608070667'},
+          'synapse': {'target_dim': 10},
+          'dendrite': {'key_dim': 100, 'topk': 10, 'stale_emit_filter': 10000, 'pass_gradients': True, 'timeout': 0.5,
+                       'do_backoff': True, 'max_backoff': 100}, 'axon': {'port': 8091, 'remote_ip': '191.97.53.53'},
+          'nucleus': {'max_workers': 5, 'queue_timeout': 5, 'queue_maxsize': 1000},
+          'metagraph': {'chain_endpoint': '206.189.254.5:12345', 'stale_emit_filter': 10000},
+          'meta_logger': {'log_dir': 'data/'},
+          'session': {'keyfile': None, 'keypair': None }
+          }
+
+config = Munch.fromDict(config)
 
 
-config = Config.load()
 config.dendrite.do_backoff = False
 mnemonic = Keypair.generate_mnemonic()
 keypair = Keypair.create_from_mnemonic(mnemonic)
-dendrite = bittensor.dendrite.Dendrite(config, keypair)
+
+config.session.keypair = keypair
+
+dendrite = bittensor.dendrite.Dendrite(config)
 neuron = bittensor_pb2.Neuron(
     version = bittensor.__version__,
     public_key = keypair.public_key,
@@ -58,12 +76,12 @@ def test_dendrite_forward_tensor():
 
 
 def test_dendrite_backoff():
-    _config = Config.load()
+    _config = Munch.fromDict(config.copy())
     _config.dendrite.do_backoff = True
     _config.dendrite.max_backoff = 1
     _mnemonic = Keypair.generate_mnemonic()
     _keypair = Keypair.create_from_mnemonic(_mnemonic)
-    _dendrite = bittensor.dendrite.Dendrite(_config, _keypair)
+    _dendrite = bittensor.dendrite.Dendrite(_config)
     _neuron = bittensor_pb2.Neuron(
         version = bittensor.__version__,
         public_key = _keypair.public_key,

--- a/tests/unit_tests/bittensor_tests/test_nucleus.py
+++ b/tests/unit_tests/bittensor_tests/test_nucleus.py
@@ -7,13 +7,27 @@ from loguru import logger
 from unittest.mock import MagicMock
 from bittensor import bittensor_pb2
 from bittensor.config import Config
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
 from bittensor.nucleus import Nucleus
 from bittensor.synapse import Synapse
+from munch import Munch
 
-config = Config.load()
-mnemonic = Keypair.generate_mnemonic()
-keypair = Keypair.create_from_mnemonic(mnemonic)
+config = {'neuron':
+              {'datapath': 'data/', 'learning_rate': 0.01, 'momentum': 0.9, 'batch_size_train': 64,
+               'batch_size_test': 64, 'log_interval': 10, 'sync_interval': 100, 'priority_interval': 100,
+               'name': 'mnist', 'trial_id': '1608070667'},
+          'synapse': {'target_dim': 10},
+          'dendrite': {'key_dim': 100, 'topk': 10, 'stale_emit_filter': 10000, 'pass_gradients': True, 'timeout': 0.5,
+                       'do_backoff': True, 'max_backoff': 100}, 'axon': {'port': 8091, 'remote_ip': '191.97.53.53'},
+          'nucleus': {'max_workers': 5, 'queue_timeout': 5, 'queue_maxsize': 1000},
+          'metagraph': {'chain_endpoint': '206.189.254.5:12345', 'stale_emit_filter': 10000},
+          'meta_logger': {'log_dir': 'data/'},
+          'session': {'keyfile': None, 'keypair': None }
+          }
+
+config = Munch.fromDict(config)
+# mnemonic = Keypair.generate_mnemonic()
+# keypair = Keypair.create_from_mnemonic(mnemonic)
 
 
 def test_init():

--- a/tests/unit_tests/bittensor_tests/test_remote_neuron.py
+++ b/tests/unit_tests/bittensor_tests/test_remote_neuron.py
@@ -7,17 +7,33 @@ import pytest
 import torchvision
 
 from bittensor.config import Config
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
 from bittensor.dendrite import RemoteNeuron, _RemoteModuleCall
 from bittensor import bittensor_pb2_grpc as bittensor_grpc
 from bittensor import bittensor_pb2
 from unittest.mock import MagicMock
 from bittensor.serializer import PyTorchSerializer
+from munch import Munch
 
-config = Config.load()
+config = {'neuron':
+              {'datapath': 'data/', 'learning_rate': 0.01, 'momentum': 0.9, 'batch_size_train': 64,
+               'batch_size_test': 64, 'log_interval': 10, 'sync_interval': 100, 'priority_interval': 100,
+               'name': 'mnist', 'trial_id': '1608070667'},
+          'synapse': {'target_dim': 10},
+          'dendrite': {'key_dim': 100, 'topk': 10, 'stale_emit_filter': 10000, 'pass_gradients': True, 'timeout': 0.5,
+                       'do_backoff': True, 'max_backoff': 100}, 'axon': {'port': 8091, 'remote_ip': '191.97.53.53'},
+          'nucleus': {'max_workers': 5, 'queue_timeout': 5, 'queue_maxsize': 1000},
+          'metagraph': {'chain_endpoint': '206.189.254.5:12345', 'stale_emit_filter': 10000},
+          'meta_logger': {'log_dir': 'data/'},
+          'session': {'keyfile': None, 'keypair': None }
+          }
+
+config = Munch.fromDict(config)
+
 config.dendrite.do_backoff = False
 mnemonic = Keypair.generate_mnemonic()
 keypair = Keypair.create_from_mnemonic(mnemonic)
+
 neuron = bittensor_pb2.Neuron(
     version = bittensor.__version__,
     public_key = keypair.public_key,

--- a/tests/unit_tests/bittensor_tests/test_serialization.py
+++ b/tests/unit_tests/bittensor_tests/test_serialization.py
@@ -14,14 +14,32 @@ import unittest
 import bittensor
 import torchvision
 import pytest
-
+from munch import Munch
 
 class TestSerialization(unittest.TestCase):
     config = None
 
     def setUp(self):
-        self.config = Config.load()
+        config = {'neuron':
+                      {'datapath': 'data/', 'learning_rate': 0.01, 'momentum': 0.9, 'batch_size_train': 64,
+                       'batch_size_test': 64, 'log_interval': 10, 'sync_interval': 100, 'priority_interval': 100,
+                       'name': 'mnist', 'trial_id': '1608070667'},
+                  'synapse': {'target_dim': 10},
+                  'dendrite': {'key_dim': 100, 'topk': 10, 'stale_emit_filter': 10000, 'pass_gradients': True,
+                               'timeout': 0.5,
+                               'do_backoff': True, 'max_backoff': 100},
+                  'axon': {'port': 8091, 'remote_ip': '191.97.53.53'},
+                  'nucleus': {'max_workers': 5, 'queue_timeout': 5, 'queue_maxsize': 1000},
+                  'metagraph': {'chain_endpoint': '206.189.254.5:12345', 'stale_emit_filter': 10000},
+                  'meta_logger': {'log_dir': 'data/'},
+                  'session': {'keyfile': None, 'keypair': None}
+                  }
+
+        config = Munch.fromDict(config)
         mnemonic = Keypair.generate_mnemonic()
+        keypair = Keypair.create_from_mnemonic(mnemonic)
+        config.session.keypair = keypair
+
         self.keypair = Keypair.create_from_mnemonic(mnemonic)
 
     def test_serialize(self):

--- a/tests/unit_tests/bittensor_tests/test_serialization.py
+++ b/tests/unit_tests/bittensor_tests/test_serialization.py
@@ -1,7 +1,7 @@
 from bittensor.serializer import DeserializationException, SerializationException
 from bittensor.serializer import PyTorchSerializer, torch_dtype_to_bittensor_dtype, bittensor_dtype_to_torch_dtype
 from bittensor.config import Config
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
 from random import randrange
 
 from datasets import load_dataset

--- a/tests/unit_tests/bittensor_tests/test_session.py
+++ b/tests/unit_tests/bittensor_tests/test_session.py
@@ -2,15 +2,32 @@
 from loguru import logger
 import bittensor
 from bittensor.config import Config
-from bittensor.subtensor import Keypair
+from bittensor.subtensor.interface import Keypair
+from munch import Munch
 
 def new_session():
     # 1. Init Config item.
-    config = Config.load()
+    config = {'neuron':
+                  {'datapath': 'data/', 'learning_rate': 0.01, 'momentum': 0.9, 'batch_size_train': 64,
+                   'batch_size_test': 64, 'log_interval': 10, 'sync_interval': 100, 'priority_interval': 100,
+                   'name': 'mnist', 'trial_id': '1608070667'},
+              'synapse': {'target_dim': 10},
+              'dendrite': {'key_dim': 100, 'topk': 10, 'stale_emit_filter': 10000, 'pass_gradients': True,
+                           'timeout': 0.5,
+                           'do_backoff': True, 'max_backoff': 100}, 'axon': {'port': 8091, 'remote_ip': '191.97.53.53'},
+              'nucleus': {'max_workers': 5, 'queue_timeout': 5, 'queue_maxsize': 1000},
+              'metagraph': {'chain_endpoint': '206.189.254.5:12345', 'stale_emit_filter': 10000},
+              'meta_logger': {'log_dir': 'data/'},
+              'session': {'keyfile': None, 'keypair': None}
+              }
+
+    config = Munch.fromDict(config)
+
     logger.info(Config.toString(config))
     mnemonic = Keypair.generate_mnemonic()
     keypair = Keypair.create_from_mnemonic(mnemonic)
-    session = bittensor.init(config, keypair)
+    session = bittensor.init(config)
+    session.keypair = keypair
     return session
 
 def test_new_session():

--- a/tests/unit_tests/subtensor/interface/test_runtime_state.py
+++ b/tests/unit_tests/subtensor/interface/test_runtime_state.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock
 from scalecodec import ScaleBytes
 from scalecodec.metadata import MetadataDecoder
 
-from bittensor.subtensor import SubstrateWSInterface
+from bittensor.subtensor.interface import SubstrateWSInterface
 from .fixtures import metadata_v12_hex
 
 

--- a/tools/genkey.py
+++ b/tools/genkey.py
@@ -1,0 +1,173 @@
+#!/bin/python3
+
+from subtensor.interface import Keypair
+from termcolor import colored
+from bittensor.crypto import encrypt
+
+from argparse import ArgumentParser
+import json
+import os
+import stat
+
+def create_config_dir_if_not_exists():
+    config_dir = "~/.bittensor"
+    config_dir = os.path.expanduser(config_dir)
+    if os.path.exists(config_dir):
+        if os.path.isdir(config_dir):
+            return
+        else:
+            print(colored("~/.bittensor exists, but is not a directory. Aborting", 'red'))
+            quit()
+
+    os.mkdir(config_dir)
+
+def may_overwrite(file):
+    choice = input("File %s already exists. Overwrite ? (y/N) " % file)
+    if choice == "y":
+        return True
+    else:
+        return False
+
+def validate_path(keyfile):
+    keyfile = os.path.expanduser(keyfile)
+
+    if os.path.isfile(keyfile):
+        if os.access(keyfile, os.W_OK):
+            if may_overwrite(keyfile):
+                return keyfile
+            else:
+                quit()
+        else:
+            print(colored("No write access for  %s" % keyfile, 'red'))
+            quit()
+    else:
+        pdir = os.path.dirname(keyfile)
+        if os.access(pdir, os.W_OK):
+            return keyfile
+        else:
+            print(colored("No write access for  %s" % keyfile, 'red'))
+            quit()
+
+def input_password() -> str:
+    return input("Specify password for key encryption: ")
+
+def validate_password(password):
+
+
+
+    password_verification = input("Retype your password: ")
+    if password != password_verification:
+        print("Passwords do not match")
+        quit()
+
+def validate_mnemonic(mnemonic):
+    pass
+
+def regen_old_key(mnemonic):
+    pass
+
+
+def gen_new_key(words):
+    mnemonic = Keypair.generate_mnemonic(words)
+    keypair = Keypair.create_from_mnemonic(mnemonic)
+
+    return keypair
+
+
+def display_mnemonic_msg(kepair : Keypair):
+    mnemonic =kepair.mnemonic
+    mnemonic_green = colored(mnemonic, 'green')
+    print ("The mnemonic to the new key is:\n\n%s\n" % mnemonic_green)
+    print ("You can use the mnemonic to recreate the key in case it gets lost. The command to use to regenerate the key using this mnemonic is:")
+    print("python3 ./genkey.py regen --mnemonic %s" % mnemonic)
+    print('')
+    print (colored("It is important to store this mnemonic in a secure (preferable offline place), as anyone " \
+                   "who has possesion of this mnemonic can use it to regenerate the key and access your tokens", "white"))
+
+
+
+def save_keys(path, data):
+    with open(path, "wb") as keyfile:
+        keyfile.write(data)
+
+def set_file_permissions(path):
+    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+    pass
+
+def confirm_no_password():
+    print(colored('*** WARNING ***', 'white'))
+    print(colored('You have not specified the --password flag.', 'white'))
+    print(colored('This means that the generated key will be stored as plaintext in the keyfile', 'white'))
+    print(colored('The benefit of this is that you will not be prompted for a password when bittensor starts', 'white'))
+    print(colored('The drawback is that an attacker has access to the key if they have access to the account bittensor runs on', 'white'))
+    print()
+    choice = input("Do you wish to proceed? (Y/n) ")
+    if choice in ["n", "N"]:
+        return False
+
+    return True
+
+
+
+def main():
+    create_config_dir_if_not_exists()
+
+    parser = ArgumentParser(description="Generate a key for bittensor")
+    cmd_parsers = parser.add_subparsers(dest='command', required=True)
+
+    new_key_parser = cmd_parsers.add_parser('new')
+    new_key_parser.add_argument('--words',
+                                type=int,
+                                choices=[12,15,18,21,24],
+                                default=12,
+                                help="The amount of words the mnemonic representing the key will contain")
+    new_key_parser.add_argument('--password', action='store_true', help='Protect the generated bittensor key with a password')
+    new_key_parser.add_argument('--file', help='The destination path of the keyfile (default: ~/.bittensor/keys)',
+                        default='~/.bittensor/key')
+
+    regen_key_parser = cmd_parsers.add_parser('regen')
+    regen_key_parser.add_argument("--mnemonic", required=True)
+    regen_key_parser.add_argument('--password', action='store_true', help='Protect the generated bittensor key with a password')
+    regen_key_parser.add_argument('--file', help='The destination path of the keyfile (default: ~/.bittensor/keys)',
+                        default='~/.bittensor/key')
+
+
+
+
+    args = parser.parse_args()
+    keyfile = validate_path(args.file)
+
+    if not args.password and not confirm_no_password():
+        quit()
+
+    if args.command == 'new':
+        keypair = gen_new_key(args.words)
+        display_mnemonic_msg(keypair)
+    else: # Implies regen
+        validate_mnemonic(args.mnemonic)
+        keypair = regen_old_key(args.mnemonic)
+
+    data = json.dumps(keypair.toDict()).encode()
+
+    if args.password:
+        password = input_password()
+        validate_password(password)
+        print("Encrypting key, this might take a while")
+        data = encrypt(data, password)
+
+
+    save_keys(keyfile, data)
+    set_file_permissions(keyfile)
+
+
+
+
+
+
+if __name__ == '__main__':
+    main()
+
+
+
+
+

--- a/tools/genkey.py
+++ b/tools/genkey.py
@@ -62,8 +62,12 @@ def input_password():
 def validate_password(password):
     policy = PasswordPolicy.from_names(
         strength=0.66,
-        entropybits=30
+        entropybits=30,
+        length=8,
     )
+
+    if not password:
+        return False
 
     tested_pass = policy.password(password)
     result = tested_pass.test()
@@ -76,6 +80,8 @@ def validate_password(password):
     if password != password_verification:
         print("Passwords do not match")
         return False
+
+    return True
 
 def validate_generate_mnemonic(mnemonic):
     if len(mnemonic) not in [12,15,18,21,24]:
@@ -147,7 +153,7 @@ def main():
                                 default=12,
                                 help="The amount of words the mnemonic representing the key will contain")
     new_key_parser.add_argument('--password', action='store_true', help='Protect the generated bittensor key with a password')
-    new_key_parser.add_argument('--file', help='The destination path of the keyfile (default: ~/.bittensor/keys)',
+    new_key_parser.add_argument('--keyfile', help='The destination path of the keyfile (default: ~/.bittensor/keys)',
                         default='~/.bittensor/key')
 
     regen_key_parser = cmd_parsers.add_parser('regen')
@@ -160,7 +166,7 @@ def main():
 
 
     args = parser.parse_args()
-    keyfile = validate_path(args.file)
+    keyfile = validate_path(args.keyfile)
 
     if not args.password and not confirm_no_password():
         quit()


### PR DESCRIPTION
So, this PR allows a use to generate a keypair and store it in a specified location. The default is ~/.bittensor/key 

The tool can be found in the <root>/tools folder

There are two commands:
genkey.py new : this creates a new keypair
genkey.py regen : the create a keypair from the supplied mnemonic. --mnemonic specifies this

both commands can be supplied with a --password flag, which, when provided, will encrypt the keypair with a key derived from the prompted password

The --keyfile flag is use to change the default path of the keyfile

Bittensor now needs a keyfile to operate properly. During init, if the keyfile is encrypted, the user wlll be prompted for a password. If not, no user interaction is required for BT to operate, like usual.

This mean that if you want to test BT now, you'll have to issue this command, once, first:
./tools/genkey new

Then BT will run like usual, the difference is now that no random key is generated anymore, but this fixed pair is used.