### PR TITLE
Subscribefix

### DIFF
--- a/bittensor/config.py
+++ b/bittensor/config.py
@@ -13,7 +13,7 @@ from bittensor.axon import Axon
 from bittensor.session import Session, KeyError
 from bittensor.dendrite import Dendrite
 from bittensor.metagraph import Metagraph
-from bittensor.metadata import Metadata
+from bittensor.nucleus import Nucleus
 from bittensor.subtensor.interface import Keypair, KeypairRepresenter
 
 
@@ -62,6 +62,7 @@ class Config:
         Dendrite.add_args(parser)
         Metagraph.add_args(parser)
         Session.add_args(parser)
+        Nucleus.add_args(parser)
        
         # 2. Parse.
         params = parser.parse_known_args()[0]
@@ -86,6 +87,8 @@ class Config:
             Session.check_config(config)
             Metagraph.check_config(config)
             Axon.check_config(config)
+            Nucleus.check_config(config)
+
         except KeyFileError:
             quit()
 

--- a/bittensor/metagraph.py
+++ b/bittensor/metagraph.py
@@ -28,27 +28,27 @@ def ip_to_int(str_val):
 
 
 class EmitSuccess (Exception):
-    """ Raised when try_async_emit emits weights successfully with known result """
+    """ Raised when try_async_emit emits successfully with known result. """
     pass
 
 class EmitNoOp(Exception):
-    """ Raised when calling emit does not change weights on chain. """
+    """ Raised when try_async_emit has no weights to change on chain. """
     pass
 
 class EmitUnknownError (Exception):
-    """ UnknownError during emit. """
+    """ UnknownError error thrown during try_async_emit. """
     pass
 
 class EmitValueError (Exception):
-    """ Raised during emission when passed weights are not properly set."""
+    """ Raised during try_async_emit when passed weights are not properly set."""
     pass
 
 class EmitTimeoutError (Exception):
-    """ Raised during emission during a timeout """
+    """ Raised during try_async_emit after a wait_for_inclusion timeout. """
     pass
 
 class EmitResultUnknown(Exception):
-    """ Called when an emit step end without a known result, for instance, if the user has wait_for_inclusion = False """
+    """ Raised when try_async_emit returns without known result, notably when the call has wait_for_inclusion = False """
     pass
 
 class ChainState():

--- a/bittensor/metagraph.py
+++ b/bittensor/metagraph.py
@@ -560,13 +560,13 @@ class Metagraph():
         Failures are logged but do not break the process. 
 
         Args:
-            weights: (:obj:`torch.FloatTensor` of shape :obj:`(metagraph.n)`):
+            Weights: (:obj:`torch.FloatTensor` of shape :obj:`(metagraph.n)`):
                 weights to set on chain of length self.state.n
 
-            wait_for_inclusion: (bool, default: False):
+            Wait_for_inclusion: (bool, default: False):
                 if true, the call waits for inclusion in the block before continuing.
 
-            timeout: (int, default = 12 sec):
+            Timeout: (int, default = 12 sec):
                 time to wait for inclusion before raising a caught error.
         """
         loop = asyncio.get_event_loop()
@@ -574,17 +574,16 @@ class Metagraph():
         loop.run_until_complete(self.async_emit(weights, wait_for_inclusion, timeout))
 
     async def async_emit(self, weights: torch.FloatTensor, wait_for_inclusion = False, timeout = 12) -> bool:
-        r""" Checks before emitting the passed weights to the chain. Optionally waits for inclusion.
+        r""" Calls _try_async_emit, logs results based on raised exception. Only fails on an uncaught Exception.
+        
         Args:
             weights: (:obj:`torch.FloatTensor` of shape :obj:`(metagraph.n)`):
-                weights to set on chain.
+                Weights to set on chain.
             wait_for_inclusion: (bool):
-                if true, the call waits for block-inclusion before continuing or throws error after timeout.
+                If true, the call waits for block-inclusion before continuing or throws error after timeout.
             timeout: (int, default = 12 sec):
-                time to wait for inclusion before raising a caught error.
-        Raises:
-            EmitError:
-                Error raised if the emission process produces an error or a timeout
+                Time to wait for inclusion before raising a caught error.
+ 
         """
         try:
             # --- Try emit, optionally wait ----
@@ -602,7 +601,7 @@ class Metagraph():
 
         except EmitUnknownError as e:
             # ---- Unknown error ----
-            logger.error("Unknown error during emission: {}", EmitValueError)
+            logger.error("Unknown error during emission: {}", e)
 
         except EmitTimeoutError as e:
             # ---- Timeout while waiting for inclusion ----
@@ -626,13 +625,13 @@ class Metagraph():
         r""" Makes emit checks, emits to chain, and raises one of the following errors.
         Args:
             weights: (:obj:`torch.FloatTensor` of shape :obj:`(metagraph.n)`):
-                weights to set on chain.
+                Weights to set on chain.
 
             wait_for_inclusion: (bool):
-                if true, the call waits for block-inclusion before continuing or throws error after timeout.
+                If true, the call waits for block-inclusion before continuing or throws error after timeout.
 
             timeout: (int, default = 12 sec):
-                time to wait for inclusion before raising a caught error.
+                Time to wait for inclusion before raising a caught error.
 
         Raises:
             EmitSuccess (Exception):

--- a/bittensor/session.py
+++ b/bittensor/session.py
@@ -8,6 +8,7 @@ from bittensor.synapse import Synapse
 from bittensor.dendrite import Dendrite
 from bittensor.axon import Axon
 from bittensor.metagraph import Metagraph
+from bittensor.nucleus import Nucleus
 from bittensor.utils.asyncio import Asyncio
 from bittensor.subtensor.interface import Keypair
 from bittensor.metadata import Metadata
@@ -42,12 +43,12 @@ class KeyError(Exception):
     pass
 
 
-
 class Session:
     def __init__(self, config):
         self.config = config
         self.metagraph = Metagraph(self.config)
-        self.axon = Axon(self.config)
+        self.nucleus = Nucleus(self.config)
+        self.axon = Axon(self.config, self.nucleus)
         self.dendrite = Dendrite(self.config)
 
     @staticmethod   

--- a/bittensor/session.py
+++ b/bittensor/session.py
@@ -42,7 +42,6 @@ class KeyFileError(Exception):
 class KeyError(Exception):
     pass
 
-
 class Session:
     def __init__(self, config):
         self.config = config
@@ -185,7 +184,11 @@ class Session:
 
         logger.info('Subscribe to chain ...')
         try:
-            self.metagraph.subscribe(10)
+            is_subscribed = self.metagraph.subscribe(12)
+            if is_subscribed == False:
+                logger.error('SESSION: Error while subscribing to the chain endpoint: {}', e)
+                raise FailedToEnterSession
+
         except Exception as e:
             logger.error('SESSION: Error while subscribing to the chain endpoint: {}', e)
             raise FailedToEnterSession

--- a/tests/unit_tests/bittensor_tests/test_axon.py
+++ b/tests/unit_tests/bittensor_tests/test_axon.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from bittensor.config import Config
+from bittensor.nucleus import Nucleus
 from bittensor.subtensor.interface import Keypair
 from bittensor.synapse import Synapse
 from bittensor.serializer import PyTorchSerializer, torch_dtype_to_bittensor_dtype, bittensor_dtype_to_torch_dtype
@@ -29,7 +30,8 @@ mnemonic = Keypair.generate_mnemonic()
 keypair = Keypair.create_from_mnemonic(mnemonic)
 config.session.keypair = keypair
 
-axon = bittensor.axon.Axon(config)
+nucleus = Nucleus(config)
+axon = bittensor.axon.Axon(config, nucleus)
 synapse = Synapse(config, None)
 
 def test_serve():
@@ -41,7 +43,7 @@ def test_serve():
 
 def test_forward_not_implemented():
     axon.serve(synapse)
-    axon._nucleus.forward = MagicMock(return_value=[None, 'not implemented', bittensor_pb2.ReturnCode.NotImplemented])
+    nucleus.forward = MagicMock(return_value=[None, 'not implemented', bittensor_pb2.ReturnCode.NotImplemented])
     x = torch.rand(3, 3, bittensor.__network_dim__)
     request = bittensor_pb2.TensorMessage(
         version=bittensor.__version__,
@@ -93,7 +95,7 @@ def test_forward_success():
         public_key=keypair.public_key,
         tensors=[PyTorchSerializer.serialize_tensor(x)]
     )
-    axon._nucleus.forward = MagicMock(return_value=[x, 'success', bittensor_pb2.ReturnCode.Success])
+    nucleus.forward = MagicMock(return_value=[x, 'success', bittensor_pb2.ReturnCode.Success])
 
     response = axon.Forward(request, None)
     assert response.return_code == bittensor_pb2.ReturnCode.Success
@@ -155,7 +157,7 @@ def test_backward_success():
         public_key=keypair.public_key,
         tensors=[PyTorchSerializer.serialize_tensor(x), PyTorchSerializer.serialize_tensor(x)]
     )
-    axon._nucleus.backward = MagicMock(return_value=[x, 'success', bittensor_pb2.ReturnCode.Success])
+    nucleus.backward = MagicMock(return_value=[x, 'success', bittensor_pb2.ReturnCode.Success])
     response = axon.Backward(request, None)
 
     assert response.return_code == bittensor_pb2.ReturnCode.Success


### PR DESCRIPTION
--- Includes a fix for the subscription error, the peer now attempts scubscription multipl times to avoid the priority issues. Also includes a minor fix to the async_chain_weights function


-- Stops the session from borking when an emission throws a priority error, now silently retries until timeout. The priority error is caused by a nonce match issue between two transactions with no fees and the same nonce. This will force a single one of them to back off and retry at a later time.