### PR TITLE
[#176175273]

### DIFF
--- a/bittensor/config.py
+++ b/bittensor/config.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import validators
 import yaml
+import stat
 from munch import Munch
 
 from bittensor.axon import Axon
@@ -56,6 +57,10 @@ class Config:
         """
         if parser == None:
             parser = argparse.ArgumentParser()
+
+        # 0. Check for and create .bittensor directory
+        Config.check_and_create_config_dir()
+
             
         # 1. Load args from bittensor backend components.
         Axon.add_args(parser)
@@ -95,11 +100,27 @@ class Config:
 
         #5. Load key
         try:
-            Session.load_keypair(config)
+            Session.load_hotkeypair(config)
+            Session.load_cold_key(config)
         except KeyError:
             quit()
 
         return config
+
+    @staticmethod
+    def check_and_create_config_dir():
+        path = "~/.bittensor"
+        path = os.path.expanduser(path)
+
+        if not os.path.isdir(path):
+            Config.create_config_dir(path)
+
+
+    @staticmethod
+    def create_config_dir(path):
+        logger.info("Creating {} config dir", path)
+        os.makedirs(path, exist_ok=True)
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
             
     @staticmethod


### PR DESCRIPTION
- ~/.bittensor dir is created when it does not exist
- Its permissions are set to user access only
- Hotkey is now auto generated when it does not already exist in ~/.bittensor/hotkey
- Permissions are set to user r/w only
- A public cold key should be put in ~/.bittensor/coldkey, but can be specified with the --session.coldkeyfile argument
- The cold key should take the format 0x[a-z0-9]{64}