### PR TITLE
Removed push production candidate to dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,12 +116,3 @@ workflows:
       - "Run Integration Tests":
               requires:
                 - "Build Bittensor"
-      - "Push Production candidate to DockerHub":
-              requires:
-                - "Build Bittensor"
-                - "Run Unit Tests"
-                - "Run Integration Tests"
-              filters:
-                branches:
-                  only:
-                    - master

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,1 +1,0 @@
-FROM bittensor/bittensor


### PR DESCRIPTION
circleci presently failing because its trying to push production candidate to dockerhub. but we already removed docker support.

