### PR TITLE
config file fix

### DIFF
--- a/bittensor/config.py
+++ b/bittensor/config.py
@@ -43,7 +43,7 @@ class Config:
         config_file = None
         config = Munch()
         if 'session.config_file' in vars(params).keys():
-            config_file = vars(params)['neuron.config_file']
+            config_file = vars(params)['session.config_file']
         
         if config_file:
             config = Config.load_from_relative_path(config_file)


### PR DESCRIPTION
Fixes erroneous checking for wrong subtype of config file. Should be session.config_file, not neuron.