### PR TITLE
Fixed loading

### DIFF
--- a/bittensor/receptor.py
+++ b/bittensor/receptor.py
@@ -23,6 +23,7 @@ import os
 import time
 import torch
 import torch.nn as nn
+import traceback
 
 from termcolor import colored
 from loguru import logger

--- a/examples/IMAGE/cifar.py
+++ b/examples/IMAGE/cifar.py
@@ -130,7 +130,7 @@ class Session():
                 test_loss, test_accuracy = self.test()
 
                 # ---- Emit ----
-                self.neuron.metagraph.set_weights(self.row, wait_for_inclusion = ) # Sets my row-weights on the chain.
+                self.neuron.metagraph.set_weights(self.row, wait_for_inclusion = True) # Sets my row-weights on the chain.
                         
                 # ---- Sync ----  
                 self.neuron.metagraph.sync() # Pulls the latest metagraph state (with my update.)

--- a/examples/IMAGE/cifar.py
+++ b/examples/IMAGE/cifar.py
@@ -124,7 +124,7 @@ class Session():
                 # If model has borked for some reason, we need to make sure it doesn't emit weights
                 # Instead, reload into previous version of model
                 if torch.any(torch.isnan(torch.cat([param.view(-1) for param in self.model.parameters()]))):
-                    self.model, self.optimizer = self.model_toolbox.load_model()
+                    self.model, self.optimizer = self.model_toolbox.load_model(self.config)
                 
                 # ---- Test ----
                 test_loss, test_accuracy = self.test()

--- a/examples/IMAGE/ffnn_grunt.py
+++ b/examples/IMAGE/ffnn_grunt.py
@@ -119,7 +119,7 @@ class Session():
                 # If model has borked for some reason, we need to make sure it doesn't emit weights
                 # Instead, reload into previous version of model
                 if torch.any(torch.isnan(torch.cat([param.view(-1) for param in self.model.parameters()]))):
-                    self.model, self.optimizer = self.model_toolbox.load_model()
+                    self.model, self.optimizer = self.model_toolbox.load_model(self.config)
 
                 # ---- Serve latest model ----
                 self.neuron.axon.serve( self.model ) # Serve the newest model.

--- a/examples/IMAGE/mnist.py
+++ b/examples/IMAGE/mnist.py
@@ -121,7 +121,7 @@ class Session():
                 # If model has borked for some reason, we need to make sure it doesn't emit weights
                 # Instead, reload into previous version of model
                 if torch.any(torch.isnan(torch.cat([param.view(-1) for param in self.model.parameters()]))):
-                    self.model, self.optimizer = self.model_toolbox.load_model()
+                    self.model, self.optimizer = self.model_toolbox.load_model(self.config)
                     continue
 
                 # ---- Test ----

--- a/examples/TEXT/bert_mlm.py
+++ b/examples/TEXT/bert_mlm.py
@@ -156,7 +156,7 @@ class Session():
                     # If model has borked for some reason, we need to make sure it doesn't emit weights
                     # Instead, reload into previous version of model
                     if torch.any(torch.isnan(torch.cat([param.view(-1) for param in self.model.parameters()]))):
-                        self.model, self.optimizer = self.model_toolbox.load_model()    
+                        self.model, self.optimizer = self.model_toolbox.load_model(self.config)    
                         continue
 
                     # ---- Emitting weights ----

--- a/examples/TEXT/bert_nsp.py
+++ b/examples/TEXT/bert_nsp.py
@@ -159,7 +159,7 @@ class Session():
                     # If model has borked for some reason, we need to make sure it doesn't emit weights
                     # Instead, reload into previous version of model
                     if torch.any(torch.isnan(torch.cat([param.view(-1) for param in self.model.parameters()]))):
-                        self.model, self.optimizer = self.model_toolbox.load_model()     
+                        self.model, self.optimizer = self.model_toolbox.load_model(self.config)     
                         continue               
 
                     # ---- Emit row-weights ----

--- a/examples/TEXT/gpt2_genesis.py
+++ b/examples/TEXT/gpt2_genesis.py
@@ -20,7 +20,6 @@ import random
 
 from termcolor import colored
 from munch import Munch
-from datasets import load_dataset
 from loguru import logger
 from torch.utils.tensorboard import SummaryWriter
 from bittensor.utils.model_utils import ModelToolbox
@@ -163,7 +162,7 @@ class Session():
                 # If model has borked for some reason, we need to make sure it doesn't emit weights
                 # Instead, reload into previous version of model
                 if torch.any(torch.isnan(torch.cat([param.view(-1) for param in self.model.parameters()]))):
-                    self.model, self.optimizer = self.model_toolbox.load_model()
+                    self.model, self.optimizer = self.model_toolbox.load_model(self.config)
                     continue
 
                 # ---- Emitting weights ----

--- a/examples/TEXT/gpt2_wiki.py
+++ b/examples/TEXT/gpt2_wiki.py
@@ -128,7 +128,7 @@ class Session():
                     # If model has borked for some reason, we need to make sure it doesn't emit weights
                     # Instead, reload into previous version of model
                     if torch.any(torch.isnan(torch.cat([param.view(-1) for param in self.model.parameters()]))):
-                        self.model, self.optimizer = self.model_toolbox.load_model()
+                        self.model, self.optimizer = self.model_toolbox.load_model(self.config)
                         continue
 
                     # ---- Emitting weights ----


### PR DESCRIPTION
Due to some weird merge conflict resolution, load_model() is being called without a config every time we encounter NaNs, this fixes the issue as well as a missing traceback import in `receptor.py`