### PR TITLE
Adhi/pkm fixes

### DIFF
--- a/bittensor/routers/pkm.py
+++ b/bittensor/routers/pkm.py
@@ -41,7 +41,10 @@ class PKMRouter():
         if config == None:
             config = PKMRouter.build_config()
         self.config = config
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if config.device and config.device == "cpu":
+            self.device = torch.device("cpu")
+        else:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         # UIDs -> Keys.
         self.keys = PKMKeys(self.config.router.key_dim)
         # Query -> Keys

--- a/bittensor/routers/pkm.py
+++ b/bittensor/routers/pkm.py
@@ -41,7 +41,7 @@ class PKMRouter():
         if config == None:
             config = PKMRouter.build_config()
         self.config = config
-        if config.device and config.device == "cpu":
+        if self.config.session.force_cpu:
             self.device = torch.device("cpu")
         else:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -133,7 +133,7 @@ class PKMRouter():
 
         # query: (torch.FloatTensor): projection of the query on to the key dimension.
         # query.shape = [batch_size, config.router.key_dim]
-        # On Cuda if it's available.
+        # On Cuda if it's available. 
         query = self.projection( query )
 
         # scores: (torch.FloatTensor): cartesian product between keys and projection.

--- a/bittensor/synapse.py
+++ b/bittensor/synapse.py
@@ -43,7 +43,7 @@ class Synapse(nn.Module):
         if config == None:
             config = Synapse.build_config()
         self.config = config
-        if config.device and config.device == "cpu":
+        if self.config.session.force_cpu:
             self.device = torch.device("cpu")
         else:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/bittensor/synapse.py
+++ b/bittensor/synapse.py
@@ -43,7 +43,10 @@ class Synapse(nn.Module):
         if config == None:
             config = Synapse.build_config()
         self.config = config
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if config.device and config.device == "cpu":
+            self.device = torch.device("cpu")
+        else:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     @staticmethod   
     def build_config() -> Munch:

--- a/examples/IMAGE/cifar.py
+++ b/examples/IMAGE/cifar.py
@@ -90,6 +90,7 @@ class Session():
         parser.add_argument('--session.trial_uid', default=str(time.time()).split('.')[0], type=str, help='Saved models go in session.root_dir / session.name / session.trial_uid')
         parser.add_argument('--session.record_log', default=True, help='Record all logs when running this session')
         parser.add_argument('--session.config_file', type=str, help='config file to run this neuron, if not using cmd line arguments.')
+        parser.add_argument('--session.force_cpu', default=False, type=bool, help='Force models to run on CPU in a machine with GPU by setting this to True')
         bittensor.neuron.Neuron.add_args(parser)
         DPNSynapse.add_args(parser)
 

--- a/examples/IMAGE/cifar.py
+++ b/examples/IMAGE/cifar.py
@@ -36,7 +36,7 @@ class Session():
     
         # ---- Model ----
         self.model = DPNSynapse( config ) # Feedforward neural network with PKMRouter.
-        if config.device and config.device == "cpu":
+        if self.config.session.force_cpu:
             self.device = torch.device("cpu")
         else:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/examples/IMAGE/cifar.py
+++ b/examples/IMAGE/cifar.py
@@ -36,7 +36,10 @@ class Session():
     
         # ---- Model ----
         self.model = DPNSynapse( config ) # Feedforward neural network with PKMRouter.
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if config.device and config.device == "cpu":
+            self.device = torch.device("cpu")
+        else:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model.to( self.device ) # Set model to device
         
         # ---- Optimizer ---- 

--- a/examples/IMAGE/ffnn_grunt.py
+++ b/examples/IMAGE/ffnn_grunt.py
@@ -40,7 +40,10 @@ class Session():
 
         # ---- Build FFNN Model ----
         self.model = FFNNSynapse( self.config )
-        self.model.to(torch.device("cuda" if torch.cuda.is_available() else "cpu"))
+        if config.device and config.device == "cpu":
+            self.device = torch.device("cpu")
+        else:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.neuron.axon.serve( self.model )
 
         # ---- Optimizer ----

--- a/examples/IMAGE/ffnn_grunt.py
+++ b/examples/IMAGE/ffnn_grunt.py
@@ -40,7 +40,7 @@ class Session():
 
         # ---- Build FFNN Model ----
         self.model = FFNNSynapse( self.config )
-        if config.device and config.device == "cpu":
+        if self.config.session.force_cpu:
             self.device = torch.device("cpu")
         else:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/examples/IMAGE/ffnn_grunt.py
+++ b/examples/IMAGE/ffnn_grunt.py
@@ -80,6 +80,7 @@ class Session():
         parser.add_argument('--session.trial_uid', default=str(time.time()).split('.')[0], type=str, help='Saved models go in session.root_dir / session.name / session.uid')
         parser.add_argument('--session.record_log', default=True, help='Record all logs when running this session')
         parser.add_argument('--session.config_file', type=str, help='config file to run this neuron, if not using cmd line arguments.')
+        parser.add_argument('--session.force_cpu', default=False, type=bool, help='Force models to run on CPU in a machine with GPU by setting this to True')
         bittensor.neuron.Neuron.add_args(parser)
         FFNNSynapse.add_args(parser)
 

--- a/examples/IMAGE/mnist.py
+++ b/examples/IMAGE/mnist.py
@@ -85,6 +85,7 @@ class Session():
         parser.add_argument('--session.trial_uid', default=str(time.time()).split('.')[0], type=str, help='Saved models go in session.root_dir / session.name / session.uid')
         parser.add_argument('--session.record_log', default=True, help='Record all logs when running this session')
         parser.add_argument('--session.config_file', type=str, help='config file to run this neuron, if not using cmd line arguments.')
+        parser.add_argument('--session.force_cpu', default=False, type=bool, help='Force models to run on CPU in a machine with GPU by setting this to True')
         bittensor.neuron.Neuron.add_args(parser)
         FFNNSynapse.add_args(parser)
 

--- a/examples/IMAGE/mnist.py
+++ b/examples/IMAGE/mnist.py
@@ -37,7 +37,7 @@ class Session():
     
         # ---- Model ----
         self.model = FFNNSynapse( config ) # Feedforward neural network with PKMRouter.
-        if config.device and config.device == "cpu":
+        if self.config.session.force_cpu:
             self.device = torch.device("cpu")
         else:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/examples/IMAGE/mnist.py
+++ b/examples/IMAGE/mnist.py
@@ -37,7 +37,10 @@ class Session():
     
         # ---- Model ----
         self.model = FFNNSynapse( config ) # Feedforward neural network with PKMRouter.
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if config.device and config.device == "cpu":
+            self.device = torch.device("cpu")
+        else:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model.to( self.device ) # Set model to device
         
         # ---- Optimizer ---- 

--- a/examples/TEXT/bert_mlm.py
+++ b/examples/TEXT/bert_mlm.py
@@ -69,6 +69,11 @@ class Session():
 
         # ---- Model ----
         self.model = BertMLMSynapse( self.config )
+        if config.device and config.device == "cpu":
+            self.device = torch.device("cpu")
+        else:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.model.to( self.device ) # Set model to device
 
         # ---- Optimizer ----
         self.optimizer = torch.optim.SGD(self.model.parameters(), lr = self.config.session.learning_rate, momentum=self.config.session.momentum)

--- a/examples/TEXT/bert_mlm.py
+++ b/examples/TEXT/bert_mlm.py
@@ -132,6 +132,7 @@ class Session():
         parser.add_argument('--session.trial_uid', default=str(time.time()).split('.')[0], type=str, help='Saved models go in session.root_dir / session.name / session.uid')
         parser.add_argument('--session.record_log', default=True, help='Record all logs when running this session')
         parser.add_argument('--session.config_file', type=str, help='config file to run this neuron, if not using cmd line arguments.')
+        parser.add_argument('--session.force_cpu', default=False, type=bool, help='Force models to run on CPU in a machine with GPU by setting this to True')
         BertMLMSynapse.add_args(parser)
         bittensor.neuron.Neuron.add_args(parser)
 

--- a/examples/TEXT/bert_mlm.py
+++ b/examples/TEXT/bert_mlm.py
@@ -69,7 +69,7 @@ class Session():
 
         # ---- Model ----
         self.model = BertMLMSynapse( self.config )
-        if config.device and config.device == "cpu":
+        if self.config.session.force_cpu:
             self.device = torch.device("cpu")
         else:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/examples/TEXT/bert_nsp.py
+++ b/examples/TEXT/bert_nsp.py
@@ -76,6 +76,11 @@ class Session():
 
         # ---- Model ----
         self.model = BertNSPSynapse( self.config )
+        if config.device and config.device == "cpu":
+            self.device = torch.device("cpu")
+        else:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.model.to( self.device ) # Set model to device
 
         # ---- Optimizer ----
         self.optimizer = torch.optim.SGD(self.model.parameters(), lr = self.config.session.learning_rate, momentum=self.config.session.momentum)

--- a/examples/TEXT/bert_nsp.py
+++ b/examples/TEXT/bert_nsp.py
@@ -76,7 +76,7 @@ class Session():
 
         # ---- Model ----
         self.model = BertNSPSynapse( self.config )
-        if config.device and config.device == "cpu":
+        if self.config.session.force_cpu:
             self.device = torch.device("cpu")
         else:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/examples/TEXT/bert_nsp.py
+++ b/examples/TEXT/bert_nsp.py
@@ -123,6 +123,7 @@ class Session():
         parser.add_argument('--session.trial_uid', default=str(time.time()).split('.')[0], type=str, help='Saved models go in session.root_dir / session.name / session.uid')
         parser.add_argument('--session.record_log', default=True, help='Record all logs when running this session')
         parser.add_argument('--session.config_file', type=str, help='config file to run this neuron, if not using cmd line arguments.')
+        parser.add_argument('--session.force_cpu', default=False, type=bool, help='Force models to run on CPU in a machine with GPU by setting this to True')
         BertNSPSynapse.add_args(parser)
         bittensor.neuron.Neuron.add_args(parser)
 

--- a/examples/TEXT/gpt2_genesis.py
+++ b/examples/TEXT/gpt2_genesis.py
@@ -78,6 +78,11 @@ class Session():
 
         # ---- Model ----
         self.model = GPT2LMSynapse( self.config )
+        if config.device and config.device == "cpu":
+            self.device = torch.device("cpu")
+        else:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.model.to( self.device ) # Set model to device
 
         # ---- Optimizer ----
         self.optimizer = torch.optim.SGD(self.model.parameters(), lr = self.config.session.learning_rate, momentum=self.config.session.momentum)

--- a/examples/TEXT/gpt2_genesis.py
+++ b/examples/TEXT/gpt2_genesis.py
@@ -78,7 +78,7 @@ class Session():
 
         # ---- Model ----
         self.model = GPT2LMSynapse( self.config )
-        if config.device and config.device == "cpu":
+        if self.config.session.force_cpu:
             self.device = torch.device("cpu")
         else:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -126,6 +126,7 @@ class Session():
         parser.add_argument('--session.record_log', default=True, help='Record all logs when running this session')
         parser.add_argument('--session.custom_datasets', default="./genesis_dataset/", type=str, help='Custom datasets to train on.')
         parser.add_argument('--session.config_file', type=str, help='config file to run this neuron, if not using cmd line arguments.')
+        parser.add_argument('--session.force_cpu', default=False, type=bool, help='Force models to run on CPU in a machine with GPU by setting this to True')
         GPT2LMSynapse.add_args(parser)
         bittensor.neuron.Neuron.add_args(parser)
 

--- a/examples/TEXT/gpt2_wiki.py
+++ b/examples/TEXT/gpt2_wiki.py
@@ -90,6 +90,7 @@ class Session():
         parser.add_argument('--session.trial_uid', default=str(time.time()).split('.')[0], type=str, help='Saved models go in session.root_dir / session.name / session.uid')
         parser.add_argument('--session.record_log', default=True, help='Record all logs when running this session')
         parser.add_argument('--session.config_file', type=str, help='config file to run this neuron, if not using cmd line arguments.')
+        parser.add_argument('--session.force_cpu', default=False, type=bool, help='Force models to run on CPU in a machine with GPU by setting this to True')
         GPT2LMSynapse.add_args(parser)
         bittensor.neuron.Neuron.add_args(parser)
 

--- a/examples/TEXT/gpt2_wiki.py
+++ b/examples/TEXT/gpt2_wiki.py
@@ -56,7 +56,7 @@ class Session():
         # Dataset: 74 million sentences pulled from books.
         self.dataset = load_dataset('ag_news')['train']
 
-        if config.device and config.device == "cpu":
+        if self.config.session.force_cpu:
             self.device = torch.device("cpu")
         else:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/examples/TEXT/gpt2_wiki.py
+++ b/examples/TEXT/gpt2_wiki.py
@@ -56,7 +56,10 @@ class Session():
         # Dataset: 74 million sentences pulled from books.
         self.dataset = load_dataset('ag_news')['train']
 
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if config.device and config.device == "cpu":
+            self.device = torch.device("cpu")
+        else:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
         # ---- Logging ----
         self.tensorboard = SummaryWriter(log_dir = self.config.session.full_path)

--- a/tests/integration_tests/cpu_tests/bittensor/test_mnist_node.py
+++ b/tests/integration_tests/cpu_tests/bittensor/test_mnist_node.py
@@ -35,7 +35,7 @@ class Session():
     
         # ---- Model ----
         self.model = FFNNSynapse( config ) # Feedforward neural network with PKMRouter.
-        if config.device and config.device == "cpu":
+        if self.config.session.force_cpu:
             self.device = torch.device("cpu")
         else:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/tests/integration_tests/cpu_tests/bittensor/test_mnist_node.py
+++ b/tests/integration_tests/cpu_tests/bittensor/test_mnist_node.py
@@ -35,7 +35,10 @@ class Session():
     
         # ---- Model ----
         self.model = FFNNSynapse( config ) # Feedforward neural network with PKMRouter.
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if config.device and config.device == "cpu":
+            self.device = torch.device("cpu")
+        else:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model.to( self.device ) # Set model to device
         
         # ---- Optimizer ---- 


### PR DESCRIPTION
@shibshib added device selection to 3 models which didn't have it in there.

For the rest I modified what was already written.

**Note**:
1. Some of these models have this: `torch.cuda.empty_cache()` explicitly in their `train()` method to clear memory. Not sure if this is compatible with CPUs.
2. I have written it such that the device config is specified in the depth/level 0 of the yaml. eg in line 16 below:
![image](https://user-images.githubusercontent.com/13200840/107166579-67065580-6984-11eb-9b9a-2bf1a88037ae.png)
If this is against convention, lmk and I'll modify
