### PR TITLE
Added total stake calculation

### DIFF
--- a/bin/bittensor-cli
+++ b/bin/bittensor-cli
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import asyncio
@@ -155,9 +155,12 @@ class CommandExecutor:
         print("--===[[ STAKES ]]===--")
         t = PrettyTable(["UID", "IP", "STAKE"])
         t.align = 'l'
+        total_stake = 0.0
         for neuron in neurons:
             t.add_row([neuron.uid, neuron.ip, neuron.stake])
+            total_stake += neuron.stake.__float__()
         print(t.get_string())
+        print("Total stake: ", total_stake)
 
     async def unstake_all(self):
         await self.connect()

--- a/bin/bittensor-cli
+++ b/bin/bittensor-cli
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import argparse
 import asyncio


### PR DESCRIPTION
This basic PR adds the total stake calculation to the `bittensor-cli overview` call. This is useful in case you have multiple servers running on the same wallet.