### PR TITLE
gradient clipping on miners

### DIFF
--- a/miners/IMAGE/cifar/cifar.py
+++ b/miners/IMAGE/cifar/cifar.py
@@ -27,6 +27,7 @@ from bittensor.utils.model_utils import ModelToolbox
 from munch import Munch
 from loguru import logger
 from synapses.dpn import DPNSynapse
+from torch.nn.utils import clip_grad_norm_
 
 class Miner():
 
@@ -81,6 +82,7 @@ class Miner():
     def add_args(parser: argparse.ArgumentParser):    
         parser.add_argument('--miner.learning_rate', default=0.01, type=float, help='Training initial learning rate.')
         parser.add_argument('--miner.momentum', default=0.9, type=float, help='Training initial momentum for SGD.')
+        parser.add_argument('--miner.clip_gradients', default=0.8, type=float, help='Implement gradient clipping to avoid exploding loss on smaller architectures.')
         parser.add_argument('--miner.n_epochs', default=int(sys.maxsize), type=int, help='Number of training epochs.')
         parser.add_argument('--miner.epoch_length', default=int(sys.maxsize), type=int, help='Iterations of training per epoch (or dataset EOF)')
         parser.add_argument('--miner.batch_size_train', default=64, type=int, help='Training batch size.')
@@ -177,6 +179,7 @@ class Miner():
             # ---- Remote Backward pass ----
             loss = output.remote_target_loss + output.local_target_loss + output.distillation_loss
             loss.backward() # Accumulates gradients on the model.
+            clip_grad_norm_(self.model.parameters(), self.config.miner.clip_gradients) # clip model gradients
             self.optimizer.step() # Applies accumulated gradients.
             self.optimizer.zero_grad() # Zeros out gradients for next accummulation 
 

--- a/miners/TEXT/bert_mlm/bert_mlm.py
+++ b/miners/TEXT/bert_mlm/bert_mlm.py
@@ -34,6 +34,7 @@ from transformers import DataCollatorForLanguageModeling
 from pytorch_transformers import WarmupCosineWithHardRestartsSchedule
 from bittensor.utils.model_utils import ModelToolbox
 from synapses.bert import BertMLMSynapse
+from torch.nn.utils import clip_grad_norm_
 
 def mlm_batch(data, batch_size, tokenizer, collator):
     """ Returns a random batch from text dataset with 50 percent NSP.
@@ -118,6 +119,7 @@ class Miner():
     def add_args(parser: argparse.ArgumentParser):
         parser.add_argument('--miner.learning_rate', default=0.01, type=float, help='Training initial learning rate.')
         parser.add_argument('--miner.momentum', default=0.98, type=float, help='Training initial momentum for SGD.')
+        parser.add_argument('--miner.clip_gradients', default=0.8, type=float, help='Implement gradient clipping to avoid exploding loss on smaller architectures.')
         parser.add_argument('--miner.n_epochs', default=int(sys.maxsize), type=int, help='Number of training epochs.')
         parser.add_argument('--miner.epoch_length', default=500, type=int, help='Iterations of training per epoch')
         parser.add_argument('--miner.batch_size_train', default=1, type=int, help='Training batch size.')
@@ -216,6 +218,7 @@ class Miner():
             # ---- Backward pass ----
             loss = output.local_target_loss + output.distillation_loss + output.remote_target_loss
             loss.backward() # Accumulates gradients on the model.
+            clip_grad_norm_(self.model.parameters(), self.config.miner.clip_gradients) # clip model gradients
             self.optimizer.step() # Applies accumulated gradients.
             self.optimizer.zero_grad() # Zeros out gradients for next accummulation
 

--- a/miners/TEXT/bert_nsp/bert_nsp.py
+++ b/miners/TEXT/bert_nsp/bert_nsp.py
@@ -32,6 +32,8 @@ from torch.utils.tensorboard import SummaryWriter
 from bittensor.utils.model_utils import ModelToolbox
 from synapses.bert import BertNSPSynapse
 from pytorch_transformers import WarmupCosineWithHardRestartsSchedule
+from torch.nn.utils import clip_grad_norm_
+
 
 def nsp_batch(data, batch_size, tokenizer):
     """ Returns a random batch from text dataset with 50 percent NSP.
@@ -111,6 +113,7 @@ class Miner():
     def add_args(parser: argparse.ArgumentParser):
         parser.add_argument('--miner.learning_rate', default=0.01, type=float, help='Training initial learning rate.')
         parser.add_argument('--miner.momentum', default=0.98, type=float, help='Training initial momentum for SGD.')
+        parser.add_argument('--miner.clip_gradients', default=0.8, type=float, help='Implement gradient clipping to avoid exploding loss on smaller architectures.')
         parser.add_argument('--miner.n_epochs', default=int(sys.maxsize), type=int, help='Number of training epochs.')
         parser.add_argument('--miner.epoch_length', default=500, type=int, help='Iterations of training per epoch')
         parser.add_argument('--miner.batch_size_train', default=1, type=int, help='Training batch size.')
@@ -220,6 +223,7 @@ class Miner():
             # ---- Backward pass ----
             loss = output.local_target_loss + output.distillation_loss + output.remote_target_loss
             loss.backward() # Accumulates gradients on the model.
+            clip_grad_norm_(self.model.parameters(), self.config.miner.clip_gradients) # clip model gradients
             self.optimizer.step() # Applies accumulated gradients.
             self.optimizer.zero_grad() # Zeros out gradients for next accummulation
 

--- a/miners/TEXT/gpt2_wiki/gpt2_wiki.py
+++ b/miners/TEXT/gpt2_wiki/gpt2_wiki.py
@@ -30,6 +30,7 @@ from torch.utils.tensorboard import SummaryWriter
 from bittensor.utils.model_utils import ModelToolbox
 from synapses.gpt2 import GPT2LMSynapse, nextbatch
 from pytorch_transformers import WarmupCosineWithHardRestartsSchedule
+from torch.nn.utils import clip_grad_norm_
 
 class Miner():
     """
@@ -78,6 +79,7 @@ class Miner():
     def add_args(parser: argparse.ArgumentParser):
         parser.add_argument('--miner.learning_rate', default=0.01, type=float, help='Training initial learning rate.')
         parser.add_argument('--miner.momentum', default=0.98, type=float, help='Training initial momentum for SGD.')
+        parser.add_argument('--miner.clip_gradients', default=0.8, type=float, help='Implement gradient clipping to avoid exploding loss on smaller architectures.')
         parser.add_argument('--miner.n_epochs', default=int(sys.maxsize), type=int, help='Number of training epochs.')
         parser.add_argument('--miner.epoch_length', default=500, type=int, help='Iterations of training per epoch')
         parser.add_argument('--miner.batch_size_train', default=1, type=int, help='Training batch size.')
@@ -90,6 +92,7 @@ class Miner():
         parser.add_argument('--miner.trial_uid', default=str(time.time()).split('.')[0], type=str, help='Saved models go in miner.root_dir / miner.name / miner.uid')
         parser.add_argument('--miner.record_log', default=False, help='Record all logs when running this miner')
         parser.add_argument('--miner.config_file', type=str, help='config file to run this neuron, if not using cmd line arguments.')
+
         GPT2LMSynapse.add_args(parser)
         bittensor.neuron.Neuron.add_args(parser)
 
@@ -183,6 +186,7 @@ class Miner():
             # ---- Backward pass ----
             loss = output.local_target_loss + output.distillation_loss + output.remote_target_loss
             loss.backward() # Accumulates gradients on the model.
+            clip_grad_norm_(self.model.parameters(), self.config.miner.clip_gradients) # clip model gradients
             self.optimizer.step() # Applies accumulated gradients.
             self.optimizer.zero_grad() # Zeros out gradients for next accummulation
 


### PR DESCRIPTION
**Issue**:
On certain architectures, typically smaller ones, loss explodes after some arbitrary number of epochs. 
Goes from say, 6.282 to 298760397856.02222224555.

**Changes**:
This PR adds gradient clipping flag and implementation to miners to make sure miners don't hit the exploding loss. 

