### PR TITLE
Padding added to received texts

### DIFF
--- a/bittensor/receptor.py
+++ b/bittensor/receptor.py
@@ -368,7 +368,7 @@ class _ReceptorCall(torch.autograd.Function):
             if  outputs.size(0) != inputs.size(0) \
                 or outputs.size(1) != inputs.size(1) \
                 or outputs.size(2) != bittensor.__network_dim__:
-                    logger.error('Forward request returned tensor with incorrect shape {}', list(outputs.shape))
+                    logger.error('Forward request returned tensor with incorrect shape {}, expected {}, from {}', list(outputs.shape), list(inputs.shape), ctx.caller.endpoint)
                     return zeros, torch.tensor(bittensor.proto.ReturnCode.ResponseShapeException)
 
             # ---- Safe catch NaNs and replace with 0.0 ----

--- a/notebooks/GPT_model_inference.ipynb
+++ b/notebooks/GPT_model_inference.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,14 +144,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "John is prouder of having gone than I believe\n"
+      "John is believed to have kissed Mary.John believes Bill\n"
      ]
     }
    ],
@@ -176,6 +176,13 @@
     "# Print what the model has predicted\n",
     "print(completion)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ termcolor
 tensorboard
 torch>=1.6.0
 torchvision
-transformers==4.5.1
+transformers>=4.5.0
 validators
 xxhash>=2.0.0
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ termcolor
 tensorboard
 torch>=1.6.0
 torchvision
-transformers
+transformers==4.5.1
 validators
 xxhash>=2.0.0
 pandas

--- a/synapses/gpt2.py
+++ b/synapses/gpt2.py
@@ -260,8 +260,16 @@ class GPT2Synapse(bittensor.synapse.Synapse):
                     Hidden layer representation produced using the local_context.
         """
         # Truncate seq length of incoming inputs if they are too long
-        inputs = inputs if inputs.size(1) <= self.block_size else inputs[:, -self.block_size:]
+        initial_length = inputs.size(1)
+        inputs = inputs if initial_length <= self.block_size else inputs[:, -self.block_size:]
         hidden = self.local_forward(inputs=inputs.to(self.device), training = False).local_hidden
+        
+        # Now pad the output tensor back to the original length
+        if initial_length > self.block_size:
+            diff = initial_length - self.block_size
+            padding = (0,0,diff,0)
+            hidden = torch.nn.functional.pad(hidden, padding, "constant", 0)
+            
         return hidden
 
 


### PR DESCRIPTION
Added padding to received texts. This avoids the error `Forward request returned tensor with incorrect shape [2, 5, 512], expected [2, 20]` 

