### PR TITLE
Fix for dataloader

### DIFF
--- a/bittensor/_dataloader/dataloader_impl.py
+++ b/bittensor/_dataloader/dataloader_impl.py
@@ -164,7 +164,7 @@ class GenesisTextDataloader( Dataloader ):
                 # Let's construct a dataset!
                 random_dataset_file = random.choice(directory['links'])
                 filename = random_dataset_file['Name']
-                total_dataset_size = int(random_dataset_file['Size'])
+                total_dataset_size = 0
 
                 # Make sure the file we chose satisfies our maximum file size requirement
                 while total_dataset_size <= self.max_corpus_size:


### PR DESCRIPTION
Simple fix for dataloader; total_dataset_size was initialized with the size of the dataset before being retrieved. Now it should remove the bug where the dataloader has no data. Sometimes, the first file loaded in is greater than the max_corpus_size which results in no files being loaded in.