### PR TITLE
BIT-283 validate template miner learning

### DIFF
--- a/bittensor/_neuron/text/template_miner/nucleus_impl.py
+++ b/bittensor/_neuron/text/template_miner/nucleus_impl.py
@@ -104,52 +104,78 @@ class Nucleus(nn.Module):
         validator_scores =  peer_weights_d2 * (self.peer_weights**2)/2  
         return validator_scores
 
-    def local_forward(self, inputs: torch.int64, training : bool = True) -> SimpleNamespace:
+    def local_forward(self, inputs: torch.LongTensor, training: bool = True) -> SimpleNamespace:
         """ Forward pass through GPT2 nucleus.
             Args:
-                inputs (:obj:`torch.int64` of shape :obj:`(batch_size, block_size)`, `required`):
-                    Batch_size length x list of text sentences.
+                inputs (:obj:`torch.LongTensor` of shape :obj:`(batch_size, block_size)`, `required`):
+                    Input batch of batch_size token sequences each of length block_size, where
+                    each token is :obj:`torch.int64` in range [0, bittensor.__vocab_size__ - 1]
                 training (:obj:`bool')`, `optional`, defaults to True):
                     Switch to True if this forward pass computes a CLM loss.
 
             Returns:
                 SimpleNamespace {
                     local_context (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_len, bittensor.__network_dim__)`, `required`):
-                        Hidden layer context.
+                        Transformer encoding produced using embedded inputs.
+                    local_hidden (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_len, bittensor.__vocab_size__)`, `optional`):
+                        Transformer encoding produced using local_context.
                     local_target (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, sequence_len, bittensor.__vocab_size__)`, `optional`):
-                        MLM Target predictions produced using local_context.
+                        Next token prediction logits produced using local_hidden.
                     local_target_loss (:obj:`torch.FloatTensor` of shape :obj:`(1)`, `optional`):
-                        MLM loss using local_context.
+                        Next token prediction loss using local_hidden.
+                    local_accuracy (:obj:`float`, `optional`):
+                        Next token prediction accuracy using local_hidden.
                 }
         """
         # To be filled.
         output = SimpleNamespace()
 
+        # embedding: retrieve learned representation vectors for input vocabulary tokens.
+        # inputs.shape = [batch_size, sequence_len]
+        # embedding.shape = [batch_size, sequence_len, bittensor.__network_dim__]
+        embedding = self.embedding(inputs)
+
+        # https://pytorch.org/docs/1.8.1/generated/torch.nn.Transformer.html#torch.nn.Transformer.forward
+        # src: (S, N, E) the sequence to the encoder (required).
+        # mask: (S, S) the mask for the src sequence (optional).
+        # where S is the source sequence length, N is the batch size, E is the feature number
+
+        # embedding.shape = [batch_size, sequence_len, bittensor.__network_dim__]
+        # local_encoder expects input shape = [sequence_len, batch_size, bittensor.__network_dim__]
+        embedding = embedding.transpose(0, 1)
+
         # local_context: hidden layer encoding of sequence with local_context.
-        # local_context.shape = [batch_size, sequence_len, bittensor.__network_dim__]
-        output.local_context = self.local_encoder( self.embedding( inputs ) )* math.sqrt(bittensor.__network_dim__)
+        # local_context.shape = [sequence_len, batch_size, bittensor.__network_dim__]
+        local_context = self.local_encoder(embedding) * math.sqrt(bittensor.__network_dim__)
 
         # local_context: adding positional encoding to local_context.
-        # local_context.shape = [batch_size, sequence_len, bittensor.__network_dim__]
-        output.local_context = self.local_pos_encoder(output.local_context)
+        # local_context.shape = [sequence_len, batch_size, bittensor.__network_dim__]
+        local_context = self.local_pos_encoder(local_context)
 
-        if training :
+        # external expects output.local_context shape = [batch_size, sequence_len, bittensor.__network_dim__]
+        output.local_context = local_context.transpose(0, 1)
+
+        if training:
             # local_hidden: local model which learns a new projection from the local_context
-            # local_hidden.shape = [batch_size, sequence_len, bittensor.__vocab_size__]
-            output.local_hidden = self.local_hidden( output.local_context.detach())
+            # local_hidden.shape = [sequence_len, batch_size, bittensor.__vocab_size__]
+            local_hidden = self.local_hidden(local_context.detach())
 
             # local_target: projection of local_hidden onto target dimension.
-            # local_target.shape = [batch_size, sequence_len, bittensor.__vocab_size__]
-            output.local_target = self.local_decoder( output.local_hidden )
+            # local_target.shape = [sequence_len, batch_size, bittensor.__vocab_size__]
+            local_target = self.local_decoder(local_hidden)
+
+            # external expects output shape = [batch_size, sequence_len, bittensor.__network_dim__]
+            output.local_hidden = local_hidden.transpose(0, 1)
+            output.local_target = local_target.transpose(0, 1)
 
             # local_target_loss: MLM loss between local_target and passed targets.
             # local_target_loss.shape = [1]
             shift_logits = output.local_target[..., :-1, :].contiguous()
             shift_labels = inputs[..., 1:].contiguous()
-            output.local_target_loss = self.loss_fct( shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1) )
+            output.local_target_loss = self.loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
 
-            predictions=shift_logits.detach().max(2).indices
-            output.local_accuracy = (predictions==shift_labels).sum().item()/predictions.nelement()
+            predictions = shift_logits.detach().max(2).indices
+            output.local_accuracy = (predictions == shift_labels).sum().item() / predictions.nelement()
         return output
 
     def remote_forward(self, inputs: torch.int64, training: bool) -> SimpleNamespace:

--- a/bittensor/_neuron/text/template_miner/nucleus_impl.py
+++ b/bittensor/_neuron/text/template_miner/nucleus_impl.py
@@ -105,7 +105,7 @@ class Nucleus(nn.Module):
         return validator_scores
 
     def local_forward(self, inputs: torch.LongTensor, training: bool = True) -> SimpleNamespace:
-        """ Forward pass through GPT2 nucleus.
+        """ Forward pass through local transformer model of nucleus.
             Args:
                 inputs (:obj:`torch.LongTensor` of shape :obj:`(batch_size, block_size)`, `required`):
                     Input batch of batch_size token sequences each of length block_size, where

--- a/bittensor/_neuron/text/template_miner/nucleus_impl.py
+++ b/bittensor/_neuron/text/template_miner/nucleus_impl.py
@@ -142,7 +142,7 @@ class Nucleus(nn.Module):
         #           predicting each token in the sequence.
         # src_mask.shape = [sequence_len, sequence_len]
         src_mask = torch.triu(torch.ones(sequence_len, sequence_len) * float('-inf'), diagonal=1)
-        src_mask.to(self.config.neuron.device)
+        src_mask = src_mask.to(self.config.neuron.device)
 
         # embedding: retrieve learned representation vectors for input vocabulary tokens.
         # inputs.shape = [batch_size, sequence_len]

--- a/bittensor/_neuron/text/template_miner/nucleus_impl.py
+++ b/bittensor/_neuron/text/template_miner/nucleus_impl.py
@@ -142,6 +142,7 @@ class Nucleus(nn.Module):
         #           predicting each token in the sequence.
         # src_mask.shape = [sequence_len, sequence_len]
         src_mask = torch.triu(torch.ones(sequence_len, sequence_len) * float('-inf'), diagonal=1)
+        src_mask.to(self.config.neuron.device)
 
         # embedding: retrieve learned representation vectors for input vocabulary tokens.
         # inputs.shape = [batch_size, sequence_len]


### PR DESCRIPTION
### Fix local_forward to use seq-first and attention mask

torch <= 1.8.1 only supports sequence-first transformer inputs, so this fix transposes `[batch_size, sequence_len, ...]` to `[sequence_len, batch_size, ...]` for all TransformerEncoder inputs.

Separate transpose statements are used, instead of integrating into existing statements, in anticipation of Pytorch upgrade where `batch_first=True` can be specified and these transpose statements can then be removed.

Also fixed the type and docstring specification for `local_forward`.

### Add attention mask to local_forward

TransformerEncoder mask is specified for the task of next token prediction, preventing forward-looking.

The mask is an upper-triangular -inf matrix of `[sequence_len, sequence_len]`, which is standard and added to the attention matrix before SoftMax effectively removing values contributed by the token to be predicted and all tokens that come after it in the sequence.

### template-miner nakamoto test

Ran template-miner for a day on nakamoto with fixes to `local_forward` without any errors or visible problems.

### wandb report

https://wandb.ai/opentaco/neuron-tests/reports/Neuron-tests-template_miner_local--VmlldzoxMjY2Nzg4?accessToken=w6fs3zm43dwnz18zl4vdl30kjhyez8u57sde80bvkii8utsr7ra27112sxqk74gk

### Neuron-tests

(withholding until bittensor.dataset used instead of HF datasets) 

https://github.com/opentensor/bittensor/blob/2b84f43ac617d8decc88cc1b87f3dadfde663af3/tests/neuron_tests/template_miner_local.py

```python
# The MIT License (MIT)
# Copyright © 2021 Yuma Rao

# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
# the Software.

# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
# DEALINGS IN THE SOFTWARE.

""" Model learning test for template_miner local_forward stage.
"""

import wandb
import torch
import argparse
import bittensor
import transformers

from datasets import load_dataset
from torch.utils.data import DataLoader
from bittensor._neuron.text.template_miner.nucleus_impl import Nucleus


def modify_args(parser: argparse.ArgumentParser):
    r""" Modify custom params in the parser for this test.
    """
    parser.add_argument('--wandb.name', type=str, help='''Optionally pass wandb run name for use_wandb''', default='template_miner_local')
    parser.add_argument('--wandb.project', type=str, help='''Optionally pass wandb project name for use_wandb''', default='neuron-tests')
    parser.add_argument('--wandb.tags', type=str, help='''Optionally pass wandb tags for use_wandb''', default='neuron, test, template_miner_local')
    parser.add_argument('--wandb.run_group', type=str, help='''Optionally pass wandb group name for use_wandb''', default='template_miner_local')

    parser.add_argument('--dataset.batch_size', type=int, help='Batch size.', default=64)
    parser.add_argument('--dataset.block_size', type=int, help='Number of text items to pull for each example..', default=50)
    parser.add_argument('--dataset.num_workers',  type=int, help='Number of workers for data loader.', default=16)
    parser.add_argument('--dataset.name', type=str, help='Which dataset to use.', default='bookcorpusopen')
    parser.add_argument('--dataset.split', type=str, help='Which split to use (train/test/validation).', default='train')

    parser.add_argument('--nucleus.nhid', type=int, help='the dimension of the feedforward network model in nn.TransformerEncoder', default=768)
    parser.add_argument('--nucleus.nhead', type=int, help='the number of heads in the multihead attention models', default=8)
    parser.add_argument('--nucleus.nlayers', type=int, help='the number of nn.TransformerEncoderLayer in nn.TransformerEncoder', default=8)
    parser.add_argument('--nucleus.dropout', type=float, help='the dropout value', default=0.1)

    parser.add_argument('--neuron.learning_rate', type=float, help='Training initial learning rate.', default=1e-4)
    parser.add_argument('--neuron.weight_decay', type=float, help='nucleus parameter weight decay.', default=0.25)
    parser.add_argument('--neuron.momentum', type=float, help='optimizer momentum.', default=0.8)
    parser.add_argument('--neuron.clip_gradients', type=float, help='Implement gradient clipping to avoid exploding loss on smaller architectures.', default=1.0)
    parser.add_argument('--neuron.batch_size_train', type=int, help='Training batch size.', default=32)
    parser.add_argument('--neuron.device', type=str, help='Torch device for training.', default='cuda:0')
    parser.add_argument('--neuron.use_wandb', action='store_true', help='''neuron activates its weights and biases powers''', default=False)
    parser.add_argument('--neuron.n_epochs', type=int, help='Number of training epochs.', default=300000)
    parser.add_argument('--neuron.lr_scheduler', type=str, help='Learning rate scheduler name.', default='get_cosine_with_hard_restarts_schedule_with_warmup')
    parser.add_argument('--neuron.num_warmup_steps', type=int, help='Learning rate scheduler number of warmup steps.', default=60000)
    parser.add_argument('--neuron.num_cycles', type=int, help='Learning rate scheduler number of cycles for hard restart.', default=5)


def main_config() -> 'bittensor.Config':
    r""" Fills a config namespace object with defaults or information from the command line.
    """
    parser = argparse.ArgumentParser(conflict_handler='resolve')
    parser.add_argument('--config', type=str, help='If set, defaults are overridden by passed file.')

    bittensor.logging.add_args(parser)
    bittensor.wandb.add_args(parser)
    bittensor.dataset.add_args(parser)
    bittensor._neuron.text.template_miner.nucleus.add_args(parser)

    modify_args(parser)

    return bittensor.config(parser)


def chunk(batch, block_size: int):
    r"""
    Concatenates and chunks a batch of token sequences into batches of length block_size.
    Args:
        batch: Input batch of tokenized sequences.
        block_size: Length of each token sequence in the batch.

    Returns:
        A new modified batch of shape [new_batch_size, block_size].
    """
    concatenated = {key: sum(batch[key], []) for key in batch.keys()}
    total_length = len(concatenated['input_ids'])
    trunc_length = (total_length // block_size) * block_size
    new_batch = {
        key: [val[i:i+block_size] for i in range(0, trunc_length, block_size)] for key, val in concatenated.items()
    }
    return new_batch


def main(config: 'bittensor.Config'):
    r"""
    Trains template_miner nucleus local transformer model on a large dataset, with a next token prediction objective.
    Use as test to evaluate next token prediction accuracy by comparing against pretrained model baseline.
    Use as validation check with expectation of similar train/validation accuracy, to ensure no label leak
    in the training process which would produce much larger train accuracy than validation accuracy.
    Args:
        config (:obj:`bittensor.Config`, `required`): bittensor config

    Returns:

    """
    batch_size = config.dataset.batch_size
    block_size = config.dataset.block_size

    # Load a named dataset split from HuggingFace datasets.
    dataset = load_dataset(config.dataset.name, split=config.dataset.split)

    # Tokenize the dataset text sequences.
    tokenizer = bittensor.tokenizer()
    dataset = dataset.map(lambda batch: tokenizer(batch['text']), remove_columns=['text', 'title'],
                          batched=True, num_proc=config.dataset.num_workers)

    # Chunk the token sequences into fixed block_size length.
    dataset = dataset.map(lambda batch: chunk(batch, block_size),
                          batched=True, batch_size=2, num_proc=config.dataset.num_workers)  #

    # Format our dataset to outputs torch.Tensor to train a pytorch model.
    columns = ['input_ids', 'attention_mask']
    dataset.set_format(type='torch', columns=columns)

    # Define pytorch dataloader with shuffled batches of batch_size token sequences of block_size length.
    dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=True)

    device = config.neuron.device

    # Initialize nucleus pytorch model and move to specified device
    model = Nucleus(config).to(device)

    # Define optimizer over all model parameters at specified learning rate
    optimizer = torch.optim.AdamW(model.parameters(), lr=config.neuron.learning_rate)

    # Define learning rate scheduler (multiplier) for optimizer
    scheduler = None
    if config.neuron.lr_scheduler == 'get_cosine_schedule_with_warmup':
        scheduler = transformers.get_cosine_schedule_with_warmup(optimizer=optimizer,
                                                                 num_warmup_steps=config.neuron.num_warmup_steps,
                                                                 num_training_steps=config.neuron.n_epochs)
    elif config.neuron.lr_scheduler == 'get_cosine_with_hard_restarts_schedule_with_warmup':
        scheduler = transformers.get_cosine_with_hard_restarts_schedule_with_warmup(optimizer=optimizer,
                                                                                    num_warmup_steps=config.neuron.num_warmup_steps,
                                                                                    num_training_steps=config.neuron.n_epochs,
                                                                                    num_cycles=config.neuron.num_cycles)

    if config.neuron.use_wandb:
        bittensor.wandb(config)  # Initialize wandb logging
        wandb.watch(model)  # Track model parameters and gradients
        wandb_table_data = []

    for epoch, batch in enumerate(dataloader):
        input_ids = batch['input_ids'].to(device)
        target = input_ids[:, -1]  # held out target of last token
        input_ids = input_ids[:, :-1]  # entire sequence except last token

        output = model.local_forward(input_ids, training=True)  # forward pass in local transformer model
        acc = output.local_accuracy  # training accuracy on next token prediction in train sequence with masking
        loss = output.local_target_loss
        lr = optimizer.param_groups[0]['lr']  # record actual learning rate

        prediction = output.local_target[:, -1, :].argmax(-1)  # predict unseen last token
        target_acc = (prediction == target).sum().item() / len(target)  # validation accuracy on predicting unseen token

        if epoch % 100 == 0:
            print('%d: %.1f (%.2f, %.2f, %f)' % (epoch, loss.item(), acc, target_acc, lr), end=' ')

        optimizer.zero_grad()  # remove previously accumulated gradients
        loss.backward()  # accumulate gradients wrt training loss
        torch.nn.utils.clip_grad_norm_(model.parameters(), 0.5)
        optimizer.step()  # update model parameters to reduce loss
        if scheduler:
            scheduler.step()  # update learning rate multiplier

        if epoch % 1000 == 0:
            predictions = output.local_target.argmax(-1)  # predict next token in sequence
            if config.neuron.use_wandb:
                wandb_table_data += [[epoch, loss, acc, target_acc, lr,
                                      tokenizer.decode(predictions[0]), tokenizer.decode(input_ids[0])]]

            print('\n.\n', tokenizer.decode(input_ids[0]), '\n...\n')
            print(list(zip([tokenizer.decode(_) for _ in input_ids[0]],
                           [tokenizer.decode(_) for _ in predictions[0]])), '\n.\n')

        if config.neuron.use_wandb:
            wandb.log({'loss': loss,
                       'acc': acc,
                       'target_acc': target_acc,
                       'lr': lr})

            if epoch % 10000 == 0:
                wandb_table = wandb.Table(columns=['epoch', 'loss', 'acc', 'target_acc', 'lr', 'predict', 'input'])
                for row in wandb_table_data:
                    wandb_table.add_data(*row)
                wandb.log({'training_samples': wandb_table})


if __name__ == '__main__':
    use_config = main_config()
    main(use_config)
```