### PR TITLE
dont override chain_endpoint if loaded in config

### DIFF
--- a/bittensor/_subtensor/__init__.py
+++ b/bittensor/_subtensor/__init__.py
@@ -84,15 +84,36 @@ class subtensor:
         """
         if config == None: config = subtensor.config()
         config = copy.deepcopy( config )
-        if chain_endpoint != None:
-            config.subtensor.network = chain_endpoint
-            config.subtensor.chain_endpoint = chain_endpoint
-        else:
-            config.subtensor.network = network if network != None else config.subtensor.network
-
-            if (config.subtensor.chain_endpoint == None):
-                config.subtensor.chain_endpoint = chain_endpoint if chain_endpoint != None else subtensor.determine_chain_endpoint(config.subtensor.network)
         
+        # Determine config.subtensor.chain_endpoint and config.subtensor.network config.
+        # If chain_endpoint is set, we override the network flag, otherwise, the chain_endpoint is assigned by the network.
+        # Argument importance: chain_endpoint > network > config.subtensor.chain_endpoint > config.subtensor.network
+       
+        # Select using chain_endpoint arg.
+        if chain_endpoint != None:
+            config.subtensor.chain_endpoint = chain_endpoint
+            config.subtensor.network = 'endpoint'
+            
+        # Select using network arg.
+        elif network != None:
+            config.subtensor.chain_endpoint = subtensor.determine_chain_endpoint(config.subtensor.network)
+            config.subtensor.network = network
+            
+        # Select using config.subtensor.chain_endpoint
+        elif config.subtensor.chain_endpoint != None:
+            config.subtensor.chain_endpoint = config.subtensor.chain_endpoint
+            config.subtensor.network = 'endpoint'
+         
+        # Select using config.subtensor.network
+        elif config.subtensor.network != None:
+            config.subtensor.chain_endpoint = subtensor.determine_chain_endpoint(config.subtensor.network)
+            config.subtensor.network = config.subtensor.network
+            
+        # Fallback to defaults.
+        else:
+            config.subtensor.chain_endpoint = subtensor.determine_chain_endpoint( bittensor.defaults.subtensor.network )
+            config.subtensor.network = bittensor.defaults.subtensor.network
+           
         substrate = SubstrateInterface(
             address_type = 42,
             type_registry_preset='substrate-node-template',
@@ -122,6 +143,7 @@ class subtensor:
                                         -- nobunaga (staging network)
                                         -- akatsuki (testing network)
                                         -- nakamoto (master network)
+                                        -- local (local running network)
                                     If this option is set it overloads subtensor.chain_endpoint with 
                                     an entry point node from that network.
                                     ''')
@@ -143,6 +165,8 @@ class subtensor:
     @staticmethod   
     def check_config( config: 'bittensor.Config' ):
         assert config.subtensor
+        assert config.subtensor.network != None
+        assert config.subtensor.chain_endpoint != None
 
     @staticmethod
     def determine_chain_endpoint(network: str):

--- a/bittensor/_subtensor/__init__.py
+++ b/bittensor/_subtensor/__init__.py
@@ -89,7 +89,9 @@ class subtensor:
             config.subtensor.chain_endpoint = chain_endpoint
         else:
             config.subtensor.network = network if network != None else config.subtensor.network
-            config.subtensor.chain_endpoint = chain_endpoint if chain_endpoint != None else subtensor.determine_chain_endpoint(config.subtensor.network)
+
+            if (config.subtensor.chain_endpoint == None):
+                config.subtensor.chain_endpoint = chain_endpoint if chain_endpoint != None else subtensor.determine_chain_endpoint(config.subtensor.network)
         
         substrate = SubstrateInterface(
             address_type = 42,


### PR DESCRIPTION
I was just debugging this
/bittensor/_subtensor/init.py:92
the command line argument gets stored into `config`, but the function argument `chain_endpoint == None` so we override `config.subtensor.chain_endpoint` on line 92 and set it to one of the endpoints on a network (local, nakamoto, etc.)

This makes it 127.0.0.1 on localhost, effectively ignoring the set chain_endpoint
`if (config.subtensor.chain_endpoint == None):` above line 92 would fix