### PR TITLE
Bug fix

### DIFF
--- a/bittensor/_metagraph/metagraph_impl.py
+++ b/bittensor/_metagraph/metagraph_impl.py
@@ -383,7 +383,7 @@ class Metagraph( torch.nn.Module ):
         if block == None:
             block = self.subtensor.get_current_block()
             n_total = self.subtensor.get_n( block = block )
-            neurons = self.subtensor.neurons( block = block )
+            neurons = self.subtensor.neurons()
         else:
             n_total = self.subtensor.get_n( block = block )
             neurons = self.subtensor.neurons( block = block )


### PR DESCRIPTION
Remove the block in `subtensor.neurons()` when syncing without block specified. This prevents the issue where the block is no longer available during the long syncing process