### PR TITLE
Dataset close logic

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,4 @@ omit =
   ./tests/*
   ./bittensor/_neuron/*
   ./bittensor/_cli/__init__.py
+  ./bittensor/_cli/cli_impl.py

--- a/bittensor/_dataset/thread_queue.py
+++ b/bittensor/_dataset/thread_queue.py
@@ -18,6 +18,7 @@
 import threading
 import time
 import queue
+from loguru import logger
 
 class ProducerThread(threading.Thread):
     r""" This producer thread runs in backgraound to fill the queue with the result of the target function.
@@ -88,3 +89,4 @@ class ThreadQueue():
     def close(self):
         self.producer.stop()
         self.producer.join()
+        logger.success('Dataset thread Closed')

--- a/bittensor/_dataset/thread_queue.py
+++ b/bittensor/_dataset/thread_queue.py
@@ -82,6 +82,9 @@ class ThreadQueue():
         self.producer = ProducerThread(name='producer', queue = self.queue, target = producer_target, arg = producer_arg)
         self.producer.start()
 
+    def __del__(self):
+        self.close()
+
     def close(self):
         self.producer.stop()
         self.producer.join()

--- a/bittensor/_dataset/thread_queue.py
+++ b/bittensor/_dataset/thread_queue.py
@@ -89,4 +89,4 @@ class ThreadQueue():
     def close(self):
         self.producer.stop()
         self.producer.join()
-        logger.success('Dataset thread Closed')
+        logger.success('Dataset Thread Queue Closed')

--- a/bittensor/_dendrite/__init__.py
+++ b/bittensor/_dendrite/__init__.py
@@ -41,7 +41,7 @@ class dendrite:
             max_worker_threads: int = None,
             max_active_receptors: int = None,
             receptor_pool: 'bittensor.ReceptorPool' = None,
-            multiprocess: bool = False,
+            multiprocess: bool = None,
             compression: str = None,
         ) -> 'bittensor.Dendrite':
         r""" Creates a new Dendrite object from passed arguments.
@@ -86,6 +86,7 @@ class dendrite:
                 max_active_receptors = config.dendrite.max_active_receptors,
                 compression = config.dendrite.compression,
             )
+
         if config.dendrite.multiprocessing:
             try:
                 manager_client = dendrite.manager_connect()

--- a/bittensor/_dendrite/dendrite_impl.py
+++ b/bittensor/_dendrite/dendrite_impl.py
@@ -96,6 +96,7 @@ class Dendrite(torch.autograd.Function):
     def __del__(self):
         if self.manager:
             self.manager.deduct_connection_count()
+        bittensor.logging.success('Dendrite Deleted', sufix = '')
 
     @staticmethod
     def forward(

--- a/bittensor/_dendrite/manager_server.py
+++ b/bittensor/_dendrite/manager_server.py
@@ -49,6 +49,7 @@ class ManagerServer(BaseManager):
             self.server.stop_event.set()
             self.manager_thread.stop()
             self.manager_thread.join()
+        logger.success('Manager Server Closed')
     
     def add_connection_count(self):
         self.connected_count += 1

--- a/bittensor/_metagraph/metagraph_impl.py
+++ b/bittensor/_metagraph/metagraph_impl.py
@@ -580,6 +580,7 @@ class Metagraph( torch.nn.Module ):
                 }
                 dataframe.loc[uid] = pandas.Series( v )
             dataframe['uid'] = dataframe.index
+            return dataframe
         except Exception as e:
             bittensor.logging.error('failed metagraph.to_dataframe()', str(e))
             return pandas.DataFrame()

--- a/bittensor/_neuron/text/advanced_server/run.py
+++ b/bittensor/_neuron/text/advanced_server/run.py
@@ -323,6 +323,8 @@ def serve( config, gp_server):
     except KeyboardInterrupt:
         # --- User ended session ----
         axon.stop()
+        dataset.close()
+        
     except Exception as e:
         # --- Unknown error ----
         logger.exception('Unknown exception: {} with traceback {}', e, traceback.format_exc())

--- a/bittensor/_neuron/text/sgmoe_validator/__init__.py
+++ b/bittensor/_neuron/text/sgmoe_validator/__init__.py
@@ -72,15 +72,20 @@ class neuron:
         return self.metagraph
 
     def run(self):
-        run(self.config,
-            validator = self.nucleus,
-            subtensor = self.subtensor,
-            wallet = self.wallet,
-            metagraph = self.metagraph,
-            dataset = self.dataset,
-            device = self.device,
-            uid = self.uid,
-            dendrite = self.nucleus.dendrite)
+        try:
+            run(self.config,
+                validator = self.nucleus,
+                subtensor = self.subtensor,
+                wallet = self.wallet,
+                metagraph = self.metagraph,
+                dataset = self.dataset,
+                device = self.device,
+                uid = self.uid,
+                dendrite = self.nucleus.dendrite)
+
+        except KeyboardInterrupt:
+            self.dataset.close()
+            self.dendrite.__del__()
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):

--- a/bittensor/_neuron/text/template_miner/neuron_impl.py
+++ b/bittensor/_neuron/text/template_miner/neuron_impl.py
@@ -102,6 +102,7 @@ class Neuron:
 
     def __exit__ ( self, exc_type, exc_value, exc_traceback ):
         self.axon.stop()
+        self.dataset.close()
         del self.dendrite
         print(exc_type, exc_value, exc_traceback)
     

--- a/bittensor/_neuron/text/template_miner/neuron_impl.py
+++ b/bittensor/_neuron/text/template_miner/neuron_impl.py
@@ -103,7 +103,7 @@ class Neuron:
     def __exit__ ( self, exc_type, exc_value, exc_traceback ):
         self.axon.stop()
         self.dataset.close()
-        del self.dendrite
+        self.dendrite.__del__()
         print(exc_type, exc_value, exc_traceback)
     
     def run( self ):

--- a/bittensor/_neuron/text/template_miner/neuron_impl.py
+++ b/bittensor/_neuron/text/template_miner/neuron_impl.py
@@ -103,7 +103,6 @@ class Neuron:
     def __exit__ ( self, exc_type, exc_value, exc_traceback ):
         self.axon.stop()
         self.dataset.close()
-        self.dendrite.__del__()
         print(exc_type, exc_value, exc_traceback)
     
     def run( self ):

--- a/bittensor/_neuron/text/template_validator/__init__.py
+++ b/bittensor/_neuron/text/template_validator/__init__.py
@@ -72,15 +72,19 @@ class neuron:
         return self.metagraph
 
     def run(self):
-        run(self.config,
-            validator = self.nucleus,
-            subtensor = self.subtensor,
-            wallet = self.wallet,
-            metagraph = self.metagraph,
-            dataset = self.dataset,
-            device = self.device,
-            uid = self.uid,
-            dendrite = self.nucleus.dendrite)
+        try:
+            run(self.config,
+                validator = self.nucleus,
+                subtensor = self.subtensor,
+                wallet = self.wallet,
+                metagraph = self.metagraph,
+                dataset = self.dataset,
+                device = self.device,
+                uid = self.uid,
+                dendrite = self.nucleus.dendrite)
+        except KeyboardInterrupt:
+            self.dataset.close()
+            self.dendrite.__del__()
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):

--- a/tests/unit_tests/bittensor_tests/test_dendrite.py
+++ b/tests/unit_tests/bittensor_tests/test_dendrite.py
@@ -255,6 +255,10 @@ def test_dendrite_backoff():
     assert list(out[0].shape) == [3, 3, bittensor.__network_dim__]
     del _dendrite
 
+def test_dendrite_to_dataframe():
+    df = dendrite.to_dataframe(bittensor.metagraph().sync())
+    assert not df.empty
+    
 def test_dendrite_multiple():
     endpoint_obj = bittensor.endpoint(
         version = bittensor.__version_as_int__,

--- a/tests/unit_tests/bittensor_tests/test_dendrite.py
+++ b/tests/unit_tests/bittensor_tests/test_dendrite.py
@@ -255,10 +255,6 @@ def test_dendrite_backoff():
     assert list(out[0].shape) == [3, 3, bittensor.__network_dim__]
     del _dendrite
 
-def test_dendrite_to_dataframe():
-    df = dendrite.to_dataframe(bittensor.metagraph().sync())
-    assert not df.empty
-    
 def test_dendrite_multiple():
     endpoint_obj = bittensor.endpoint(
         version = bittensor.__version_as_int__,

--- a/tests/unit_tests/bittensor_tests/test_metagraph.py
+++ b/tests/unit_tests/bittensor_tests/test_metagraph.py
@@ -57,9 +57,6 @@ def test_retrieve_cached_neurons():
     n = metagraph.retrieve_cached_neurons()
     assert len(n) >= 2000
     
-    n = metagraph.retrieve_cached_neurons(600000)
-    assert len(n) >= 2000
-
 def test_to_dataframe():
     df = metagraph.to_dataframe()
-    assert not df.empty()
+    assert not df.empty

--- a/tests/unit_tests/bittensor_tests/test_metagraph.py
+++ b/tests/unit_tests/bittensor_tests/test_metagraph.py
@@ -12,6 +12,7 @@ def test_print_empty():
 
 def test_sync():
     metagraph.sync()
+    metagraph.sync(600000)
 
 def test_load_sync_save():
     metagraph.sync()
@@ -51,3 +52,14 @@ def test_properties():
     metagraph.S
     metagraph.D
     metagraph.C
+
+def test_retrieve_cached_neurons():
+    n = metagraph.retrieve_cached_neurons()
+    assert len(n) >= 2000
+    
+    n = metagraph.retrieve_cached_neurons(600000)
+    assert len(n) >= 2000
+
+def test_to_dataframe():
+    df = metagraph.to_dataframe()
+    assert not df.empty()


### PR DESCRIPTION
Reviewed all the closing logic
- Make sure dataset thread queue / dendrite manager would be closed upon garbage collection or upon keyboard interrupt for miners and validators.
