### PR TITLE
Adds multiprocessing to registration solving

### DIFF
--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -502,7 +502,7 @@ To run a local node (See: docs/running_a_validator.md) \n
         while True:
             
             # Solve latest POW.
-            pow_result = bittensor.utils.create_pow( self )
+            pow_result = bittensor.utils.create_pow( self, wallet )
             with bittensor.__console__.status(":satellite: Registering...({}/10)".format(attempts)) as status:
                 with self.substrate as substrate:
                     try:

--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -504,8 +504,17 @@ To run a local node (See: docs/running_a_validator.md) \n
             # Solve latest POW.
             pow_result = bittensor.utils.create_pow( self, wallet )
             with bittensor.__console__.status(":satellite: Registering...({}/10)".format(attempts)) as status:
+                # verify wallet not already registered
+                if (wallet.is_registered( self )):
+                    bittensor.__console__.print(":white_heavy_check_mark: [green]Registered[/green]")
+                    return True
+                    
                 with self.substrate as substrate:
                     try:
+                        if pow_result is None:
+                            # might be registered already
+                            raise "Failed registration attempt"
+                        
                         call = substrate.compose_call( 
                             call_module='SubtensorModule',  
                             call_function='register', 

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -10,8 +10,7 @@ import time
 import torch
 import numbers
 import pandas
-import sys
-from typing import Tuple, List, Union, Optional
+from typing import Any, Tuple, List, Union, Optional
 
 
 def indexed_values_to_dataframe ( 
@@ -98,12 +97,14 @@ def solve_for_difficulty( block_hash, difficulty ):
             break
     return nonce, seal
 
-def solve_for_difficulty_fast( subtensor, num_processes: int = 5, update_interval: int = 100000 ) -> None:
+def solve_for_difficulty_fast( subtensor, wallet, num_processes: int = 5, update_interval: int = 100000 ) -> Tuple[int, int, Any, int, Any]:
     """
     Solves the POW for registration using multiprocessing.
     Args:
         subtensor
             Subtensor to connect to for block information and to submit.
+        wallet:
+            Wallet to use for registration.
         num_processes: int
             Number of processes to use.
         update_interval: int

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -1,4 +1,6 @@
 import binascii
+import multiprocessing
+import ctypes
 import struct
 import hashlib
 import math
@@ -8,6 +10,7 @@ import time
 import torch
 import numbers
 import pandas
+import sys
 from typing import Tuple, List, Union, Optional
 
 
@@ -95,8 +98,22 @@ def solve_for_difficulty( block_hash, difficulty ):
             break
     return nonce, seal
 
-
-def solve_for_difficulty_fast( subtensor ):
+def solve_for_difficulty_fast( subtensor, num_processes: int = 5, update_interval: int = 100000 ) -> None:
+    """
+    Solves the POW for registration using multiprocessing.
+    Args:
+        subtensor
+            Subtensor to connect to for block information and to submit.
+        num_processes: int
+            Number of processes to use.
+        update_interval: int
+            Number of nonces to solve before updating block information.
+    Note: 
+    - We should modify the number of processes based on user input.
+    - We can also modify the update interval to do smaller blocks of work,
+        while still updating the block information after a different number of nonces,
+        to increase the transparency of the process while still keeping the speed.
+    """
     block_number = subtensor.get_current_block()
     difficulty = subtensor.difficulty
     block_hash = subtensor.substrate.get_block_hash( block_number )
@@ -104,33 +121,20 @@ def solve_for_difficulty_fast( subtensor ):
         block_hash = subtensor.substrate.get_block_hash( block_number )
     block_bytes = block_hash.encode('utf-8')[2:]
     
-    meets = False
     nonce = -1
     limit = int(math.pow(2,256) - 1)
-    best = math.inf
-    update_interval = 100000
     start_time = time.time()
 
     console = bittensor.__console__
-    with console.status("Solving") as status:
-        while not meets:
-            nonce += 1 
-
-            # Create seal.
-            nonce_bytes = binascii.hexlify(nonce.to_bytes(8, 'little'))
-            pre_seal = nonce_bytes + block_bytes
-            seal = hashlib.sha256( bytearray(hex_bytes_to_u8_list(pre_seal)) ).digest()
-
-            seal_number = int.from_bytes(seal, "big")
-            product = seal_number * difficulty
-            if product - limit < best:
-                best = product - limit
-                best_seal = seal
-
-            if product < limit:
-                return nonce, block_number, block_hash, difficulty, seal
-
-            if nonce % update_interval == 0:
+    with console.status("Solving") as status:        
+        found_solution = multiprocessing.Value('q', -1, lock=False) # int
+        best = multiprocessing.Value(ctypes.c_char_p, lock=True) # byte array to get around int size of ctypes
+        best.raw = struct.pack("d", float('inf'))
+        best_seal = multiprocessing.Array('h', 32, lock=True) # short array should hold bytes (0, 256)
+        with multiprocessing.Pool(processes=num_processes, initializer=initProcess_, initargs=(solve_, found_solution, best, best_seal)) as pool:
+            while found_solution.value == -1: # no solution found
+                result = pool.starmap(solve_, iterable=[(nonce, block_bytes, difficulty, block_hash, block_number, limit) for nonce in range(update_interval)])
+                nonce += update_interval
                 itrs_per_sec = update_interval / (time.time() - start_time)
                 start_time = time.time()
                 difficulty = subtensor.difficulty
@@ -139,8 +143,38 @@ def solve_for_difficulty_fast( subtensor ):
                 while block_hash == None:
                     block_hash = subtensor.substrate.get_block_hash( block_number)
                 block_bytes = block_hash.encode('utf-8')[2:]
-                status.update("Solving\n  Nonce: [bold white]{}[/bold white]\n  Difficulty: [bold white]{}[/bold white]\n  Iters: [bold white]{}/s[/bold white]\n  Block: [bold white]{}[/bold white]\n  Best: [bold white]{}[/bold white]".format( nonce, int(itrs_per_sec), difficulty, block_hash.encode('utf-8'), binascii.hexlify(best_seal) ))
-      
+                with best_seal.get_lock():
+                    status.update("Solving\n  Nonce: [bold white]{}[/bold white]\n  Difficulty: [bold white]{}[/bold white]\n  Iters: [bold white]{}/s[/bold white]\n  Block: [bold white]{}[/bold white]\n  Best: [bold white]{}[/bold white]".format( nonce, difficulty, int(itrs_per_sec), block_hash.encode('utf-8'), binascii.hexlify(bytes(best_seal) or bytes(0)) ))
+            # exited while, found_solution contains the nonce
+            nonce, block_number, block_hash, difficulty, seal = result[found_solution.value]
+            return nonce, block_number, block_hash, difficulty, seal
+
+def initProcess_(f, found_solution, best, best_seal):
+    f.found = found_solution
+    f.best = best
+    f.best_seal = best_seal
+
+def solve_(nonce, block_bytes, difficulty, block_hash, block_number, limit):
+    # Create seal.
+    nonce_bytes = binascii.hexlify(nonce.to_bytes(8, 'little'))
+    pre_seal = nonce_bytes + block_bytes
+    seal = hashlib.sha256( bytearray(hex_bytes_to_u8_list(pre_seal)) ).digest()
+  
+    seal_number = int.from_bytes(seal, "big")
+    product = seal_number * difficulty
+
+    if product < limit:
+        solve_.found.value = nonce
+        return (nonce, block_number, block_hash, difficulty, seal)
+    with solve_.best.get_lock():
+        best_value_as_d = struct.unpack('d', solve_.best.raw)[0]
+        if (product - limit) < best_value_as_d:
+            
+            with solve_.best_seal.get_lock():
+                solve_.best.raw = struct.pack('d', product - limit)
+                for i in range(32):
+                    solve_.best_seal[i] = seal[i]
+    return None
 
 def create_pow( subtensor ):
     nonce, block_number, block_hash, difficulty, seal = solve_for_difficulty_fast( subtensor )

--- a/tests/unit_tests/bittensor_tests/utils/test_utils.py
+++ b/tests/unit_tests/bittensor_tests/utils/test_utils.py
@@ -162,8 +162,8 @@ def test_solve_for_difficulty_fast_registered_already():
     # tests if the registration stops after the first block of nonces
     for _ in range(10):
         workblocks_before_is_registered = random.randint(2, 10)
-        # return True each work block but return False after a random number of blocks
-        is_registered_return_values = [True for _ in range(workblocks_before_is_registered)] + [False] + [True, True]
+        # return False each work block but return True after a random number of blocks
+        is_registered_return_values = [False for _ in range(workblocks_before_is_registered)] + [True] + [False, False]
 
         block_hash = '0xba7ea4eb0b16dee271dbef5911838c3f359fcf598c74da65a54b919b68b67279'
         subtensor = MagicMock()
@@ -173,6 +173,7 @@ def test_solve_for_difficulty_fast_registered_already():
         subtensor.substrate.get_block_hash = MagicMock( return_value=block_hash )
         wallet = MagicMock()
         wallet.is_registered = MagicMock( side_effect=is_registered_return_values )
+        assert wallet.is_registered.call_count == workblocks_before_is_registered + 1
 
         # all arugments should return None to indicate an early return
         a, b, c, d, e = bittensor.utils.solve_for_difficulty_fast( subtensor, wallet )

--- a/tests/unit_tests/bittensor_tests/utils/test_utils.py
+++ b/tests/unit_tests/bittensor_tests/utils/test_utils.py
@@ -14,6 +14,8 @@ from substrateinterface.base import Keypair
 from _pytest.fixtures import fixture
 from loguru import logger
 
+from unittest.mock import MagicMock
+
 
 
 @fixture(scope="function")
@@ -137,3 +139,45 @@ def test_solve_for_difficulty():
     nonce, seal = bittensor.utils.solve_for_difficulty(block_hash, 10)
     assert nonce == 2
     assert seal == b'\x8a\xa5\x0fA\xb1\n\xd0\xdea\x7f\x86rWq1\xa5|\x18\xd0\xc7\x81\xf4\x81\x03\xf9P\xc8\x19\xb9\x1f-\xcf'
+
+def test_solve_for_difficulty_fast():
+    block_hash = '0xba7ea4eb0b16dee271dbef5911838c3f359fcf598c74da65a54b919b68b67279'
+    subtensor = MagicMock()
+    subtensor.get_current_block = MagicMock( return_value=1 )
+    subtensor.difficulty = 1
+    subtensor.substrate = MagicMock()
+    subtensor.substrate.get_block_hash = MagicMock( return_value=block_hash )
+    wallet = MagicMock()
+    wallet.is_registered = MagicMock( return_value=False )
+
+    _, _, _, _, seal = bittensor.utils.solve_for_difficulty_fast( subtensor, wallet )
+
+    assert bittensor.utils.seal_meets_difficulty(seal, 1)
+    
+    subtensor.difficulty = 10
+    _, _, _, _, seal = bittensor.utils.solve_for_difficulty_fast( subtensor, wallet )
+    assert bittensor.utils.seal_meets_difficulty(seal, 10)
+    
+def test_solve_for_difficulty_fast_registered_already():
+    # tests if the registration stops after the first block of nonces
+    for _ in range(10):
+        workblocks_before_is_registered = random.randint(2, 10)
+        # return True each work block but return False after a random number of blocks
+        is_registered_return_values = [True for _ in range(workblocks_before_is_registered)] + [False] + [True, True]
+
+        block_hash = '0xba7ea4eb0b16dee271dbef5911838c3f359fcf598c74da65a54b919b68b67279'
+        subtensor = MagicMock()
+        subtensor.get_current_block = MagicMock( return_value=1 )
+        subtensor.difficulty = 2560000000 # set high to make solving take a long time
+        subtensor.substrate = MagicMock()
+        subtensor.substrate.get_block_hash = MagicMock( return_value=block_hash )
+        wallet = MagicMock()
+        wallet.is_registered = MagicMock( side_effect=is_registered_return_values )
+
+        # all arugments should return None to indicate an early return
+        a, b, c, d, e = bittensor.utils.solve_for_difficulty_fast( subtensor, wallet )
+        assert a is None
+        assert b is None
+        assert c is None
+        assert d is None
+        assert e is None

--- a/tests/unit_tests/bittensor_tests/utils/test_utils.py
+++ b/tests/unit_tests/bittensor_tests/utils/test_utils.py
@@ -173,7 +173,6 @@ def test_solve_for_difficulty_fast_registered_already():
         subtensor.substrate.get_block_hash = MagicMock( return_value=block_hash )
         wallet = MagicMock()
         wallet.is_registered = MagicMock( side_effect=is_registered_return_values )
-        assert wallet.is_registered.call_count == workblocks_before_is_registered + 1
 
         # all arugments should return None to indicate an early return
         a, b, c, d, e = bittensor.utils.solve_for_difficulty_fast( subtensor, wallet )
@@ -182,3 +181,5 @@ def test_solve_for_difficulty_fast_registered_already():
         assert c is None
         assert d is None
         assert e is None
+        # called every time until True
+        assert wallet.is_registered.call_count == workblocks_before_is_registered + 1


### PR DESCRIPTION
Adds multiprocessing to the registration solver. 
Note: 
    - We should modify the number of processes based on user input.
    - We can also modify the update interval to do smaller blocks of work,
        while still updating the block information after a different number of nonces,
        to increase the transparency of the process while still keeping the speed.
        
  Would be good if we had some flags for user configuration. Current default is 5 processes and update interval of 100,000 nonces before block information is re-polled