### PR TITLE
break infinite loop in registration

### DIFF
--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -484,6 +484,9 @@ To run a local node (See: docs/running_a_validator.md) \n
             success (bool):
                 flag is true if extrinsic was finalized or uncluded in the block. 
                 If we did not wait for finalization / inclusion, the response is true.
+
+            message (str):
+                The error message or 'Success'.
         """
 
         with bittensor.__console__.status(":satellite: Checking Account..."):

--- a/bittensor/_wallet/wallet_impl.py
+++ b/bittensor/_wallet/wallet_impl.py
@@ -26,6 +26,7 @@ from types import SimpleNamespace
 from typing import Union
 from substrateinterface import Keypair
 from termcolor import colored
+from rich.prompt import Prompt
 import bittensor
 
 def display_mnemonic_msg( keypair : Keypair, key_type : str ):
@@ -243,8 +244,14 @@ class Wallet():
         """
         # Get chain connection.
         if subtensor == None: subtensor = bittensor.subtensor()
-        subtensor.register( wallet = self, wait_for_inclusion = wait_for_inclusion, wait_for_finalization = wait_for_finalization, prompt=prompt )
-        
+
+        success = False
+        while success == False:
+            success, message = subtensor.register( wallet = self, wait_for_inclusion = wait_for_inclusion, wait_for_finalization = wait_for_finalization, prompt=prompt )
+            if success == False and message == 'AlreadyRegistered':
+                self.hotkey_str = Prompt.ask("Enter new hotkey name: ")
+                self.create()
+
         return self
 
     def add_stake( self, 

--- a/bittensor/_wallet/wallet_impl.py
+++ b/bittensor/_wallet/wallet_impl.py
@@ -247,7 +247,7 @@ class Wallet():
 
         success, message = subtensor.register( wallet = self, wait_for_inclusion = wait_for_inclusion, wait_for_finalization = wait_for_finalization, prompt=prompt )
 
-        # If the registration is unsuccessful because of the key already exist in the network,
+        # If the registration is unsuccessful because the key already exist in the network,
         # Create and register the wallet again with a new hotkey name.  
         if success == False and message == 'AlreadyRegistered':
             self.hotkey_str = Prompt.ask("Enter new hotkey name: ")

--- a/bittensor/_wallet/wallet_impl.py
+++ b/bittensor/_wallet/wallet_impl.py
@@ -245,12 +245,14 @@ class Wallet():
         # Get chain connection.
         if subtensor == None: subtensor = bittensor.subtensor()
 
-        success = False
-        while success == False:
-            success, message = subtensor.register( wallet = self, wait_for_inclusion = wait_for_inclusion, wait_for_finalization = wait_for_finalization, prompt=prompt )
-            if success == False and message == 'AlreadyRegistered':
-                self.hotkey_str = Prompt.ask("Enter new hotkey name: ")
-                self.create()
+        success, message = subtensor.register( wallet = self, wait_for_inclusion = wait_for_inclusion, wait_for_finalization = wait_for_finalization, prompt=prompt )
+
+        # If the registration is unsuccessful because of the key already exist in the network,
+        # Create and register the wallet again with a new hotkey name.  
+        if success == False and message == 'AlreadyRegistered':
+            self.hotkey_str = Prompt.ask("Enter new hotkey name: ")
+            self.create()
+            self.register()
 
         return self
 


### PR DESCRIPTION
- If a wallet is already registered on the network ie. registration message coming back with response.error_message == 'AlreadyRegistered', then force the user to create a new hotkey.