### PR TITLE
Adds explorer link to block after transfer complete

### DIFF
--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -808,6 +808,10 @@ To run a local node (See: docs/running_a_validator.md) \n
                 response.process_events()
                 if response.is_success:
                     bittensor.__console__.print(":white_heavy_check_mark: [green]Finalized[/green]")
+                    block_hash = response.block_hash
+                    bittensor.__console__.print("[green]Block Hash: {}[/green]".format( block_hash ))
+                    explorer_url = "https://explorer.nakamoto.opentensor.ai/#/explorer/query/{block_hash}".format( block_hash = block_hash )
+                    bittensor.__console__.print("[green]Explorer Link: {}[/green]".format( explorer_url ))
                 else:
                     bittensor.__console__.print(":cross_mark: [red]Failed[/red]: error:{}".format(response.error_message))
 

--- a/tests/integration_tests/test_subtensor.py
+++ b/tests/integration_tests/test_subtensor.py
@@ -230,6 +230,7 @@ class TestSubtensor(unittest.TestCase):
                 self.is_success = True
             def process_events(self):
                 return True
+            block_hash: str = '0x'
 
         neuron = self.neurons[ 1 ]
         self.subtensor.substrate.submit_extrinsic = MagicMock(return_value = success()) 
@@ -248,6 +249,7 @@ class TestSubtensor(unittest.TestCase):
                 self.is_success = True
             def process_events(self):
                 return True
+            block_hash: str = '0x'
 
         neuron = self.neurons[ 1 ]
         self.subtensor.substrate.submit_extrinsic = MagicMock(return_value = success()) 


### PR DESCRIPTION
This change adds a print out of the explorer link to Bittensor Oracle after a transfer is completed

See
<img width="791" alt="unknown" src="https://user-images.githubusercontent.com/24501463/159598058-ed698b2e-4c2b-4dca-b725-37adabeca001.png">
