### PR TITLE
Change crypto version to fix syntax error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pandas
 psutil
 password_strength==0.0.3.post2
 protobuf==3.13.0
-pycryptodome==3.4.3
+pycryptodome==3.14.1
 py-sr25519-bindings==0.1.2
 py-ed25519-bindings~=0.1.2
 py-bip39-bindings>=0.1.6


### PR DESCRIPTION
Changed version of `pycryptodome` from 3.4.3 to 3.14.1