### PR TITLE
update requirements based on substrates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,15 +17,15 @@ psutil
 password_strength==0.0.3.post2
 protobuf==3.13.0
 pycryptodome==3.11.0
-py-sr25519-bindings
-py-ed25519-bindings
-py-bip39-bindings
+py-sr25519-bindings>=0.1.4,<1
+py-ed25519-bindings>=1.0,<2
+py-bip39-bindings>=0.1.9,<1
 pytest>=6.2.4
 pyyaml
 rich
 retry
 requests>=2.25.0
-scalecodec>=1.0.25
+scalecodec>=1.0.35
 termcolor
 torch==1.10
 transformers>=4.5.0
@@ -36,5 +36,5 @@ tqdm
 qqdm
 wandb>=0.11.1
 ansible_vault>=2.1
-substrate-interface
+substrate-interface==1.2.4
 markupsafe==2.0.1


### PR DESCRIPTION
- restrict substrate-interface to 1.2.4
- update the binding versions to the same as substrate-interface