### PR TITLE
Parallelize unit tests

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -59,9 +59,11 @@ __local_entrypoints__ = [
     '127.0.0.1:9944'
 ]
 
-# This port is fixed to 2**15 - 1 to avoid clashing with get_random_unused_port
+# Avoid collisions with other processes
+import os
+pid_port = 8192 + (os.getpid() % 8192)
 __mock_entrypoints__ = [
-    'localhost:16383'
+    f"localhost:{pid_port}"
 ]
 
 

--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -59,8 +59,9 @@ __local_entrypoints__ = [
     '127.0.0.1:9944'
 ]
 
+# This port is fixed to 2**15 - 1 to avoid clashing with get_random_unused_port
 __mock_entrypoints__ = [
-    'localhost:27212'
+    'localhost:16383'
 ]
 
 

--- a/bittensor/_subtensor/subtensor_mock.py
+++ b/bittensor/_subtensor/subtensor_mock.py
@@ -41,7 +41,7 @@ __type_registery__ = {
     }
 }
 
-GLOBAL_SUBTENSOR_MOCK_PROCESS_NAME = f"node-subtensor-{os.getpid()}"
+GLOBAL_SUBTENSOR_MOCK_PROCESS_NAME = "node-subtensor"
 print(GLOBAL_SUBTENSOR_MOCK_PROCESS_NAME)
 
 
@@ -86,7 +86,7 @@ class mock_subtensor():
         r""" If subtensor is running a mock process this kills the mock.
         """
         for p in psutil.process_iter():
-            if p.name() == GLOBAL_SUBTENSOR_MOCK_PROCESS_NAME and p.status() != psutil.STATUS_ZOMBIE and p.status() != psutil.STATUS_DEAD:
+            if p.name() == GLOBAL_SUBTENSOR_MOCK_PROCESS_NAME and p.parent().pid == os.getpid() and p.status() != psutil.STATUS_ZOMBIE and p.status() != psutil.STATUS_DEAD:
                return True
         return False
 
@@ -95,7 +95,7 @@ class mock_subtensor():
         r""" Kills the global mocked subtensor process even if not owned.
         """
         for p in psutil.process_iter():
-            if p.name() == GLOBAL_SUBTENSOR_MOCK_PROCESS_NAME:
+            if p.name() == GLOBAL_SUBTENSOR_MOCK_PROCESS_NAME and p.parent().pid == os.getpid() :
                 p.terminate()
                 p.kill()
 

--- a/bittensor/_subtensor/subtensor_mock.py
+++ b/bittensor/_subtensor/subtensor_mock.py
@@ -7,6 +7,7 @@ import time
 import os
 
 from . import subtensor_impl
+from tests.utils import get_random_unused_port
 
 __type_registery__ = {
     "runtime_id": 2,
@@ -40,7 +41,8 @@ __type_registery__ = {
     }
 }
 
-GLOBAL_SUBTENSOR_MOCK_PROCESS_NAME = 'node-subtensor'
+GLOBAL_SUBTENSOR_MOCK_PROCESS_NAME = f"node-subtensor-{os.getpid()}"
+print(GLOBAL_SUBTENSOR_MOCK_PROCESS_NAME)
 
 
 
@@ -104,10 +106,13 @@ class mock_subtensor():
         try:
             operating_system = "OSX" if platform == "darwin" else "Linux"
             path = "./bin/chain/{}/node-subtensor".format(operating_system)
-            port = int(bittensor.__mock_entrypoints__[0].split(':')[1])
-            print(port)
+            ws_port = int(bittensor.__mock_entrypoints__[0].split(':')[1])
+            print(ws_port)
+            print(os.getpid())
+            baseport = get_random_unused_port()
+            rpc = get_random_unused_port()
             subprocess.Popen([path, 'purge-chain', '--dev', '-y'], close_fds=True, shell=False)    
-            _mock_subtensor_process = subprocess.Popen( [path, '--dev', '--port', str(port+1), '--ws-port', str(port), '--rpc-port', str(port + 2), '--tmp'], close_fds=True, shell=False, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+            _mock_subtensor_process = subprocess.Popen( [path, '--dev', '--port', str(baseport), '--ws-port', str(ws_port), '--rpc-port', str(rpc), '--tmp'], close_fds=True, shell=False, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
             print ('Starting subtensor process with pid {} and name {}'.format(_mock_subtensor_process.pid, GLOBAL_SUBTENSOR_MOCK_PROCESS_NAME))
             return _mock_subtensor_process
         except Exception as e:

--- a/tests/integration_tests/test_keyfile.py
+++ b/tests/integration_tests/test_keyfile.py
@@ -9,126 +9,151 @@
 # The above copyright notice and this permission notice shall be included in all copies or substantial portions of 
 # the Software.
 
+import os
+import shutil
+import time
 # THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
 # THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION 
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 # DEALINGS IN THE SOFTWARE.
-
-import bittensor
-from unittest.mock import MagicMock
-import os
-import shutil
+import unittest
 import unittest.mock as mock
+
 import pytest
 
-# Init dirs.
-if os.path.exists('/tmp/pytest'):
-    shutil.rmtree('/tmp/pytest')
+import bittensor
 
-def test_create():
-    keyfile = bittensor.keyfile (path = '/tmp/pytest/keyfile' )
-    
-    mnemonic = bittensor.Keypair.generate_mnemonic( 12 )
-    alice = bittensor.Keypair.create_from_mnemonic(mnemonic)
-    keyfile.set_keypair(alice, encrypt=True, overwrite=True, password = 'thisisafakepassword')
-    assert keyfile.is_readable()
-    assert keyfile.is_writable()
-    assert keyfile.is_encrypted()
-    keyfile.decrypt( password = 'thisisafakepassword' )
-    assert not keyfile.is_encrypted()
-    keyfile.encrypt( password = 'thisisafakepassword' )
-    assert keyfile.is_encrypted()
-    str(keyfile)
-    keyfile.decrypt( password = 'thisisafakepassword' )
-    assert not keyfile.is_encrypted()
-    str(keyfile)
 
-    assert keyfile.get_keypair( password = 'thisisafakepassword' ).ss58_address == alice.ss58_address
-    assert keyfile.get_keypair( password = 'thisisafakepassword' ).private_key == alice.private_key
-    assert keyfile.get_keypair( password = 'thisisafakepassword' ).public_key == alice.public_key
-    
-    bob = bittensor.Keypair.create_from_uri ('/Bob')
-    keyfile.set_keypair(bob, encrypt=True, overwrite=True, password = 'thisisafakepassword')
-    assert keyfile.get_keypair( password = 'thisisafakepassword' ).ss58_address == bob.ss58_address
-    assert keyfile.get_keypair( password = 'thisisafakepassword' ).public_key == bob.public_key
-    
-    repr(keyfile)
+class TestKeyFiles(unittest.TestCase):
 
-def test_legacy_coldkey():
-    keyfile = bittensor.keyfile (path = '/tmp/pytest/coldlegacy_keyfile' )
-    keyfile.make_dirs()
-    keyfile_data = b'0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f'
-    with open('/tmp/pytest/coldlegacy_keyfile', "wb") as keyfile_obj:
-        keyfile_obj.write( keyfile_data )
-    assert keyfile.keyfile_data == keyfile_data
-    keyfile.encrypt( password = 'this is the fake password' )
-    keyfile.decrypt( password = 'this is the fake password' )
-    keypair_bytes = b'{"accountId": "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f", "publicKey": "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f", "secretPhrase": null, "secretSeed": null, "ss58Address": "5DD26kC2kxajmwfbbZmVmxhrY9VeeyR1Gpzy9i8wxLUg6zxm"}'
-    assert keyfile.keyfile_data == keypair_bytes
-    assert keyfile.get_keypair().ss58_address == "5DD26kC2kxajmwfbbZmVmxhrY9VeeyR1Gpzy9i8wxLUg6zxm"
-    assert "0x" + keyfile.get_keypair().public_key.hex() == "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f"
+    def setUp(self) -> None:
+        self.root_path = f"/tmp/pytest{time.time()}"
+        os.makedirs(self.root_path)
 
-def test_validate_password():
-    from bittensor._keyfile.keyfile_impl import validate_password
-    assert validate_password(None) == False
-    assert validate_password('passw0rd') == False
-    assert validate_password('123456789') == False
-    with mock.patch('getpass.getpass',return_value='biTTensor'):
-        assert validate_password('biTTensor') == True
-    with mock.patch('getpass.getpass',return_value='biTTenso'):
-        assert validate_password('biTTensor') == False
+        self.create_keyfile()
 
-def test_decrypt_keyfile_data_legacy():
-    import base64
-    from bittensor._keyfile.keyfile_impl import decrypt_keyfile_data
-    from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-    from cryptography.fernet import Fernet
-    from cryptography.hazmat.primitives import hashes
-    from cryptography.hazmat.backends import default_backend
+    def tearDown(self) -> None:
+        shutil.rmtree(self.root_path)
 
-    __SALT = b"Iguesscyborgslikemyselfhaveatendencytobeparanoidaboutourorigins"
-    
-    def __generate_key(password):
-        kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), salt=__SALT, length=32, iterations=10000000, backend=default_backend())
-        key = base64.urlsafe_b64encode(kdf.derive(password.encode()))
-        return key
+    def create_keyfile(self):
+        keyfile = bittensor.keyfile(path=os.path.join(self.root_path, "keyfile"))
 
-    pw = 'fakepasssword238947239'
-    data = b'encrypt me!'
-    key = __generate_key(pw)
-    cipher_suite = Fernet(key)
-    encrypted_data = cipher_suite.encrypt(data)
+        mnemonic = bittensor.Keypair.generate_mnemonic(12)
+        alice = bittensor.Keypair.create_from_mnemonic(mnemonic)
+        keyfile.set_keypair(alice, encrypt=True, overwrite=True, password='thisisafakepassword')
 
-    decrypted_data = decrypt_keyfile_data( encrypted_data, pw)
-    assert decrypted_data == data
+        bob = bittensor.Keypair.create_from_uri('/Bob')
+        keyfile.set_keypair(bob, encrypt=True, overwrite=True, password='thisisafakepassword')
 
-def test_user_interface():
-    from bittensor._keyfile.keyfile_impl import ask_password_to_encrypt
+        return keyfile
 
-    with mock.patch('getpass.getpass', side_effect = ['pass', 'password', 'asdury3294y', 'asdury3294y']):
-        assert ask_password_to_encrypt() == 'asdury3294y'
+    def test_create(self):
+        keyfile = bittensor.keyfile(path=os.path.join(self.root_path, "keyfile"))
 
-def test_overwriting():    
-    from bittensor._keyfile.keyfile_impl import KeyFileError
-    
-    keyfile = bittensor.keyfile (path = '/tmp/pytest/keyfile' )
-    alice = bittensor.Keypair.create_from_uri ('/Alice')
-    keyfile.set_keypair(alice, encrypt=True, overwrite=True, password = 'thisisafakepassword')
-    bob = bittensor.Keypair.create_from_uri ('/Bob')
-    
-    with pytest.raises(KeyFileError) as pytest_wrapped_e:
-        with mock.patch('builtins.input', return_value = 'n'):
-            keyfile.set_keypair(bob, encrypt=True, overwrite=False, password = 'thisisafakepassword')
+        mnemonic = bittensor.Keypair.generate_mnemonic( 12 )
+        alice = bittensor.Keypair.create_from_mnemonic(mnemonic)
+        keyfile.set_keypair(alice, encrypt=True, overwrite=True, password = 'thisisafakepassword')
+        assert keyfile.is_readable()
+        assert keyfile.is_writable()
+        assert keyfile.is_encrypted()
+        keyfile.decrypt( password = 'thisisafakepassword' )
+        assert not keyfile.is_encrypted()
+        keyfile.encrypt( password = 'thisisafakepassword' )
+        assert keyfile.is_encrypted()
+        str(keyfile)
+        keyfile.decrypt( password = 'thisisafakepassword' )
+        assert not keyfile.is_encrypted()
+        str(keyfile)
 
-def test_keyfile_mock():
-    file = bittensor.keyfile( _mock = True )
-    assert file.exists_on_device()
-    assert not file.is_encrypted()
-    assert file.is_readable()
-    assert file.data
-    assert file.keypair
-    file.set_keypair( keypair = bittensor.Keypair.create_from_mnemonic( mnemonic = bittensor.Keypair.generate_mnemonic() ))
+        assert keyfile.get_keypair( password = 'thisisafakepassword' ).ss58_address == alice.ss58_address
+        assert keyfile.get_keypair( password = 'thisisafakepassword' ).private_key == alice.private_key
+        assert keyfile.get_keypair( password = 'thisisafakepassword' ).public_key == alice.public_key
 
-def test_keyfile_mock_func():
-    file = bittensor.keyfile.mock()
+        bob = bittensor.Keypair.create_from_uri ('/Bob')
+        keyfile.set_keypair(bob, encrypt=True, overwrite=True, password = 'thisisafakepassword')
+        assert keyfile.get_keypair( password = 'thisisafakepassword' ).ss58_address == bob.ss58_address
+        assert keyfile.get_keypair( password = 'thisisafakepassword' ).public_key == bob.public_key
+
+        repr(keyfile)
+
+    def test_legacy_coldkey(self):
+        legacy_filename = os.path.join(self.root_path, "coldlegacy_keyfile")
+        keyfile = bittensor.keyfile (path = legacy_filename)
+        keyfile.make_dirs()
+        keyfile_data = b'0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f'
+        with open(legacy_filename, "wb") as keyfile_obj:
+            keyfile_obj.write( keyfile_data )
+        assert keyfile.keyfile_data == keyfile_data
+        keyfile.encrypt( password = 'this is the fake password' )
+        keyfile.decrypt( password = 'this is the fake password' )
+        keypair_bytes = b'{"accountId": "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f", "publicKey": "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f", "secretPhrase": null, "secretSeed": null, "ss58Address": "5DD26kC2kxajmwfbbZmVmxhrY9VeeyR1Gpzy9i8wxLUg6zxm"}'
+        assert keyfile.keyfile_data == keypair_bytes
+        assert keyfile.get_keypair().ss58_address == "5DD26kC2kxajmwfbbZmVmxhrY9VeeyR1Gpzy9i8wxLUg6zxm"
+        assert "0x" + keyfile.get_keypair().public_key.hex() == "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f"
+
+    def test_validate_password(self):
+        from bittensor._keyfile.keyfile_impl import validate_password
+        assert validate_password(None) == False
+        assert validate_password('passw0rd') == False
+        assert validate_password('123456789') == False
+        with mock.patch('getpass.getpass',return_value='biTTensor'):
+            assert validate_password('biTTensor') == True
+        with mock.patch('getpass.getpass',return_value='biTTenso'):
+            assert validate_password('biTTensor') == False
+
+    def test_decrypt_keyfile_data_legacy(self):
+        import base64
+
+        from cryptography.fernet import Fernet
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+        from bittensor._keyfile.keyfile_impl import decrypt_keyfile_data
+
+        __SALT = b"Iguesscyborgslikemyselfhaveatendencytobeparanoidaboutourorigins"
+
+        def __generate_key(password):
+            kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), salt=__SALT, length=32, iterations=10000000, backend=default_backend())
+            key = base64.urlsafe_b64encode(kdf.derive(password.encode()))
+            return key
+
+        pw = 'fakepasssword238947239'
+        data = b'encrypt me!'
+        key = __generate_key(pw)
+        cipher_suite = Fernet(key)
+        encrypted_data = cipher_suite.encrypt(data)
+
+        decrypted_data = decrypt_keyfile_data( encrypted_data, pw)
+        assert decrypted_data == data
+
+    def test_user_interface(self):
+        from bittensor._keyfile.keyfile_impl import ask_password_to_encrypt
+
+        with mock.patch('getpass.getpass', side_effect = ['pass', 'password', 'asdury3294y', 'asdury3294y']):
+            assert ask_password_to_encrypt() == 'asdury3294y'
+
+    def test_overwriting(self):
+        from bittensor._keyfile.keyfile_impl import KeyFileError
+
+        keyfile = bittensor.keyfile (path = os.path.join(self.root_path, "keyfile"))
+        alice = bittensor.Keypair.create_from_uri ('/Alice')
+        keyfile.set_keypair(alice, encrypt=True, overwrite=True, password = 'thisisafakepassword')
+        bob = bittensor.Keypair.create_from_uri ('/Bob')
+
+        with pytest.raises(KeyFileError) as pytest_wrapped_e:
+            with mock.patch('builtins.input', return_value = 'n'):
+                keyfile.set_keypair(bob, encrypt=True, overwrite=False, password = 'thisisafakepassword')
+
+    def test_keyfile_mock(self):
+        file = bittensor.keyfile( _mock = True )
+        assert file.exists_on_device()
+        assert not file.is_encrypted()
+        assert file.is_readable()
+        assert file.data
+        assert file.keypair
+        file.set_keypair( keypair = bittensor.Keypair.create_from_mnemonic( mnemonic = bittensor.Keypair.generate_mnemonic() ))
+
+    def test_keyfile_mock_func(self):
+        file = bittensor.keyfile.mock()

--- a/tests/integration_tests/test_wallet.py
+++ b/tests/integration_tests/test_wallet.py
@@ -18,6 +18,7 @@
 import bittensor
 from unittest.mock import MagicMock
 import os
+import time
 import shutil
 from bittensor.utils.balance import Balance
 
@@ -25,11 +26,12 @@ from bittensor.utils.balance import Balance
 subtensor = bittensor.subtensor(network = 'nobunaga')
 
 def init_wallet():
-    if os.path.exists('/tmp/pytest'):
-        shutil.rmtree('/tmp/pytest')
+    wallet_path = f"/tmp/pytest/{time.time()}"
+    if os.path.exists(wallet_path):
+        shutil.rmtree(wallet_path)
     
     the_wallet = bittensor.wallet (
-        path = '/tmp/pytest',
+        path = wallet_path,
         name = 'pytest',
         hotkey = 'pytest',
     )

--- a/tests/unit_tests/benchmarking/test_dendrite_multiprocess.py
+++ b/tests/unit_tests/benchmarking/test_dendrite_multiprocess.py
@@ -4,8 +4,10 @@ import time
 from multiprocessing import Pool
 from qqdm import qqdm
 
+from tests.utils import get_random_unused_port
+
 wallet =  bittensor.wallet (
-    path = '/tmp/pytest',
+    path = f"/tmp/pytest{time.time()}",
     name = 'pytest',
     hotkey = 'pytest',
 ) 
@@ -13,7 +15,7 @@ wallet =  bittensor.wallet (
 wallet.create_new_coldkey( use_password=False, overwrite = True)
 wallet.create_new_hotkey( use_password=False, overwrite = True)
 logging =bittensor.logging(debug=True)
-ports = [8081, 8082,8083,8084,8085]
+ports = [get_random_unused_port() for _ in range(5)]
 
 inputs="""in my palm is a clear stone , and inside it is a
     small ivory statuette . a guardian angel .

--- a/tests/unit_tests/bittensor_tests/test_axon.py
+++ b/tests/unit_tests/bittensor_tests/test_axon.py
@@ -15,13 +15,16 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 # DEALINGS IN THE SOFTWARE.
 
-import torch
-import grpc
-import bittensor
 import time
-import pytest
-import uuid
 import unittest.mock as mock
+import uuid
+
+import grpc
+import pytest
+import torch
+
+import bittensor
+from tests.utils import get_random_unused_port
 
 wallet = bittensor.wallet.mock()
 axon = bittensor.axon(wallet = wallet)
@@ -777,7 +780,7 @@ def is_port_in_use(port):
             return False
 
 def test_axon_is_destroyed():
-    port = 8081
+    port = get_random_unused_port()
     assert is_port_in_use( port ) == False
     axon = bittensor.axon ( port = port )
     assert is_port_in_use( port ) == True
@@ -788,7 +791,7 @@ def test_axon_is_destroyed():
     axon.__del__()
     assert is_port_in_use( port ) == False
 
-    port = 8082
+    port = get_random_unused_port()
     assert is_port_in_use( port ) == False
     axon2 = bittensor.axon ( port = port )
     assert is_port_in_use( port ) == True
@@ -797,7 +800,7 @@ def test_axon_is_destroyed():
     axon2.__del__()
     assert is_port_in_use( port ) == False
 
-    port_3 = 8086
+    port_3 = get_random_unused_port()
     assert is_port_in_use( port_3 ) == False
     axonA = bittensor.axon ( port = port_3 )
     assert is_port_in_use( port_3 ) == True

--- a/tests/unit_tests/bittensor_tests/test_config.py
+++ b/tests/unit_tests/bittensor_tests/test_config.py
@@ -26,7 +26,12 @@ def test_loaded_config():
 
 def test_strict():
     parser = argparse.ArgumentParser()
-    parser.add_argument("arg", help="Dummy Args")
+
+    # Positional/mandatory arguments don't play nice with multiprocessing.
+    # When the CLI is used, the argument is just the 0th element or the filepath.
+    # However with multiprocessing this function call actually comes from a subprocess, and so there
+    # is no positional argument and this raises an exception when we try to parse the args later.
+    # parser.add_argument("arg", help="Dummy Args")
     parser.add_argument("--cov", help="Dummy Args")
     parser.add_argument("--cov-append", action='store_true', help="Dummy Args")
     parser.add_argument("--cov-config",  help="Dummy Args")

--- a/tests/unit_tests/bittensor_tests/test_endpoint.py
+++ b/tests/unit_tests/bittensor_tests/test_endpoint.py
@@ -15,16 +15,17 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 # DEALINGS IN THE SOFTWARE.
 
-import bittensor 
-import torch
 import random
+
 import pytest
+import torch
+
+import bittensor
+from tests.utils import get_random_unused_port
 
 test_wallet = bittensor.wallet.mock()
-endpoint = None
 
 def test_create_endpoint():
-    global endpoint
     endpoint = bittensor.endpoint(
         version = bittensor.__version_as_int__,
         uid = 0,
@@ -129,6 +130,16 @@ def test_endpoint_fails_checks():
 
 
 def test_endpoint_to_tensor():
+    endpoint = bittensor.endpoint(
+        version = bittensor.__version_as_int__,
+        uid = 0,
+        ip = '0.0.0.0',
+        ip_type = 4,
+        port = get_random_unused_port(),
+        hotkey = test_wallet.hotkey.ss58_address,
+        coldkey = test_wallet.coldkey.ss58_address,
+        modality = 0
+    )
     tensor_endpoint = endpoint.to_tensor()
     assert list(tensor_endpoint.shape) == [250]
     converted_endpoint = bittensor.endpoint.from_tensor( tensor_endpoint )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,20 @@
+import socket
+from random import randint
+
+max_tries = 10
+
+
+def get_random_unused_port():
+    def port_in_use(port: int) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            return s.connect_ex(("localhost", port)) == 0
+
+    tries = 0
+    while tries < max_tries:
+        tries += 1
+        port = randint(2**14, 2**16 - 1)
+
+        if not port_in_use(port):
+            return port
+
+    raise RuntimeError(f"Tried {max_tries} random ports and could not find an open one")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,11 @@
 import socket
 from random import randint
+from typing import Set
 
 max_tries = 10
 
 
-def get_random_unused_port():
+def get_random_unused_port(allocated_ports: Set = {}):
     def port_in_use(port: int) -> bool:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             return s.connect_ex(("localhost", port)) == 0
@@ -14,7 +15,8 @@ def get_random_unused_port():
         tries += 1
         port = randint(2**14, 2**16 - 1)
 
-        if not port_in_use(port):
+        if port not in allocated_ports and not port_in_use(port):
+            allocated_ports.add(port)
             return port
 
     raise RuntimeError(f"Tried {max_tries} random ports and could not find an open one")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ from typing import Set
 max_tries = 10
 
 
-def get_random_unused_port(allocated_ports: Set = {}):
+def get_random_unused_port(allocated_ports: Set = set()):
     def port_in_use(port: int) -> bool:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             return s.connect_ex(("localhost", port)) == 0


### PR DESCRIPTION
Makes some changes that allow unit tests to run in parallel. This is imperfect and has some hacks, but the main changes are:

* Choosing random unused ports when instantiating instances of axons, subtensors, etc.
* Using unittest's `setUp` method to ensure objects that need to exist for tests are created within those tests.
* Basing any paths that are generated on the current timestamp (i.e. any wallet).
* Fun one: some of the tests need to spawn/kill mock subtensor subprocesses. These subprocesses are now identified by their parent's PID and the port that it uses is chosen using this as well. pretty cool, right?

One side effect of this PR is that I run `isort` on save in my IDE. This rearranges some of the imports and removes unused ones so any import code was likely just resorted.