### PR TITLE
Fix Docker Build and Docker-Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM nvidia/cuda:11.2.1-base
 
-
 LABEL bittensor.image.authors="bittensor.com" \
 	bittensor.image.vendor="Bittensor" \
 	bittensor.image.title="bittensor/bittensor" \
@@ -9,17 +8,19 @@ LABEL bittensor.image.authors="bittensor.com" \
 	bittensor.image.revision="${VCS_REF}" \
 	bittensor.image.created="${BUILD_DATE}" \
 	bittensor.image.documentation="https://app.gitbook.com/@opentensor/s/bittensor/"
-
 ARG DEBIAN_FRONTEND=noninteractive
+
+#nvidia key migration
+RUN apt-key del 7fa2af80
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub
+
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y apt-utils curl git cmake build-essential unzip python3-pip  wget iproute2 software-properties-common
 
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update
-RUN apt-get install python3.7 python3.7-dev -y
-RUN python3.7 -m pip install --upgrade pip
-
-RUN rm /usr/bin/python3
-RUN ln -s //usr/bin/python3.7 /usr/bin/python3
+RUN apt-get install python3 python3-dev -y
+RUN python3 -m pip install --upgrade pip
 
 # add Bittensor code to docker image
 RUN mkdir /bittensor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
       - ~/.bittensor:/root/.bittensor
 
     command: /bin/bash -c "
-      PYTHONPATH=/bittensor python3 /bittensor/miners/template_miner.py --subtensor.network akatsuki"
+      PYTHONPATH=/bittensor python3 /bittensor/miners/template_miner.py --subtensor.network nobunaga"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       - "8091:8091"
     volumes:
       - ~/.bittensor:/root/.bittensor
-    
+
     command: /bin/bash -c "
-      cd /bittensor
-      && python3.7 miners/text/template_miner.py --subtensor.network akatsuki"
+      PYTHONPATH=/bittensor python3 /bittensor/miners/template_miner.py --subtensor.network akatsuki"


### PR DESCRIPTION
This PR:

### **- Irons out the Python version inconsistency between the install scripts and the Dockerfile**

Right now, the Docker image builds with Python3.7, but the `install.sh` script per the install instructions installs Python3.8. This is because Python3 is installed in the install script, but we specifically point out 3.7 in the Dockerfile. This causes the docker container to not be compatible with the new keccak update, breaking it.

### **- Fixes the Docker Compose spec to have the command correctly route and find the Bittensor Python library**

Previously, we were not specifying the path to the Bittensor Python library. By specifying the `PYTHONPATH` environment variable, we are able to tell it where to go to find it.