### PR TITLE
Add pytest-xdist & split as dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,8 @@ py-sr25519-bindings>=0.1.4,<1
 py-ed25519-bindings>=1.0,<2
 py-bip39-bindings>=0.1.9,<1
 pytest>=6.2.4
+pytest-split
+pytest-xdist
 pyyaml
 rich
 retry


### PR DESCRIPTION
Hotfix to prevent failing builds from forked branches