### PR TITLE
Update Overview (caching, sorting, table width)

### DIFF
--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -73,6 +73,14 @@ class cli:
             help='''Set true to avoid using the cached overview from IPFS.''',
             default=False,
         )
+        overview_parser.add_argument(
+            '--width', 
+            dest='width', 
+            action='store',
+            type=int, 
+            help='''Set the output width of the overview. Defaults to automatic width from terminal.''',
+            default=None,
+        )
         bittensor.wallet.add_args( overview_parser )
         bittensor.subtensor.add_args( overview_parser )
         

--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -66,6 +66,13 @@ class cli:
             help='''Set true to protect the generated bittensor key with a password.''',
             default=False,
         )
+        overview_parser.add_argument(
+            '--no_cache', 
+            dest='no_cache', 
+            action='store_true', 
+            help='''Set true to avoid using the cached overview from IPFS.''',
+            default=False,
+        )
         bittensor.wallet.add_args( overview_parser )
         bittensor.subtensor.add_args( overview_parser )
         

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -21,6 +21,7 @@ from types import SimpleNamespace
 
 import bittensor
 from bittensor.utils.balance import Balance
+from fuzzywuzzy import fuzz
 from rich import print
 from rich.prompt import Confirm
 from rich.table import Table
@@ -511,6 +512,17 @@ class CLI:
         table.caption = "[white]Wallet balance: [green]\u03C4" + str(balance.tao)
 
         console.clear()
+
+        sort_by: str = self.config.wallet.sort_by
+        if sort_by is not None:
+            column_to_sort_by: int = 0
+            for index, column in zip(range(len(table.columns)), table.columns):
+                # Fuzzy match the column name. Default to the first column.
+                if fuzz.ratio(sort_by.lower(), column.header.lower().replace('[overline white]', '')) > 80:
+                    column_to_sort_by = index
+                    break
+            TABLE_DATA.sort(key=lambda row: row[column_to_sort_by])
+
         for row in TABLE_DATA:
             table.add_row(*row)
         table.box = None

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -514,7 +514,7 @@ class CLI:
         console.clear()
 
         sort_by: str = self.config.wallet.sort_by
-        if sort_by is not None:
+        if sort_by != "":
             column_to_sort_by: int = 0
             for index, column in zip(range(len(table.columns)), table.columns):
                 # Fuzzy match the column name. Default to the first column.

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -529,8 +529,8 @@ class CLI:
                     column_to_sort_by = index
                     break
             
-            if sort_order.lower() == 'desc' or sort_order.lower() == 'descending' or sort_order.lower() == 'reverse':
-                # Sort descending if the sort_order matches desc or descending
+            if sort_order.lower() in { 'desc', 'descending', 'reverse'}:
+                # Sort descending if the sort_order matches desc, descending, or reverse
                 sort_descending = True
                 
             TABLE_DATA.sort(key=lambda row: row[column_to_sort_by], reverse=sort_descending)

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -529,8 +529,8 @@ class CLI:
                     column_to_sort_by = index
                     break
             
-            if fuzz.ratio(sort_order.lower(), 'desc') > 80 or fuzz.ratio(sort_order.lower(), 'descending') > 80:
-                # Sort descending if the sort_order fuzzy-matches desc or descending
+            if sort_order.lower() == 'desc' or sort_order.lower() == 'descending' or sort_order.lower() == 'reverse':
+                # Sort descending if the sort_order matches desc or descending
                 sort_descending = True
                 
             TABLE_DATA.sort(key=lambda row: row[column_to_sort_by], reverse=sort_descending)

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -517,7 +517,7 @@ class CLI:
             TABLE_DATA.append(row)
             
         total_neurons = len(neurons)                
-        table = Table(show_footer=False)
+        table = Table(show_footer=False, width=self.config.get('width', None), pad_edge=False, box=None)
         table.title = (
             "[white]Wallet - {}:{}".format(self.config.wallet.name, wallet.coldkeypub.ss58_address)
         )
@@ -560,10 +560,8 @@ class CLI:
 
         for row in TABLE_DATA:
             table.add_row(*row)
-        table.box = None
-        table.pad_edge = False
-        table.width = None
-        console.print(table)
+        
+        console.print(table, width=self.config.get('width', None))
 
 class CacheException(Exception):
     """

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -1,5 +1,4 @@
 # The MIT License (MIT)
-# The MIT License (MIT)
 # Copyright © 2021 Yuma Rao
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
@@ -16,17 +15,18 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 # DEALINGS IN THE SOFTWARE.
 
-import bittensor
-
 import os
 import sys
-from rich.tree import Tree
-from rich import print
-from tqdm import tqdm
-from rich.table import Table
-from rich.prompt import Confirm
+from types import SimpleNamespace
 
+import bittensor
 from bittensor.utils.balance import Balance
+from rich import print
+from rich.prompt import Confirm
+from rich.table import Table
+from rich.tree import Tree
+from tqdm import tqdm
+
 
 class CLI:
     """
@@ -413,10 +413,31 @@ class CLI:
         neurons = []
         block = subtensor.block
         with console.status(":satellite: Syncing with chain: [white]{}[/white] ...".format(self.config.subtensor.network)):
-            for wallet in tqdm(all_hotkeys):
-                nn = subtensor.neuron_for_pubkey( wallet.hotkey.ss58_address )
-                if not nn.is_null:
-                    neurons.append( (nn, wallet) )
+            try:
+                if self.config.subtensor.network not in ('local', 'nakamoto'):
+                    # We only cache neurons for local/nakamoto.
+                    raise Exception("This network is not cached, defaulting to regular overview.")
+            
+                if self.config.no_cache:
+                    raise Exception("Flag was set to not use cache, defaulting to regular overview.")
+
+                metagraph: bittensor.Metagraph = bittensor.metagraph( subtensor = subtensor )
+                # Grab cached neurons from IPFS
+                all_neurons = metagraph.retrieve_cached_neurons()
+                # Map the hotkeys to uids
+                hotkey_to_neurons = {n.hotkey: n.uid for n in all_neurons}
+                for wallet in tqdm(all_hotkeys):
+                    uid = hotkey_to_neurons.get(wallet.hotkey.ss58_address)
+                    if uid is not None:
+                        nn = all_neurons[uid]
+                        neurons.append( (nn, wallet) )
+            except Exception as e:
+                for wallet in tqdm(all_hotkeys):
+                    # Get overview without cache
+                    nn = subtensor.neuron_for_pubkey( wallet.hotkey.ss58_address )
+                    if not nn.is_null:
+                      neurons.append( (nn, wallet) )
+                      
             balance = subtensor.get_balance( wallet.coldkeypub.ss58_address )
 
         TABLE_DATA = []  
@@ -426,7 +447,8 @@ class CLI:
         total_consensus = 0.0
         total_incentive = 0.0
         total_dividends = 0.0
-        total_emission = 0     
+        total_emission = 0   
+
         for nn, hotwallet in tqdm(neurons):
             uid = nn.uid
             active = nn.active

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -410,6 +410,11 @@ class CLI:
         wallet = bittensor.wallet( config = self.config )
         subtensor = bittensor.subtensor( config = self.config )
         all_hotkeys = CLI._get_hotkey_wallets_for_wallet( wallet )
+        
+        if self.config.wallet.hotkeys:
+            # Only show hotkeys for wallets in the list
+            all_hotkeys = [hotkey for hotkey in all_hotkeys if hotkey.hotkey_str in self.config.wallet.hotkeys]
+            
         neurons = []
         block = subtensor.block
         with console.status(":satellite: Syncing with chain: [white]{}[/white] ...".format(self.config.subtensor.network)):

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -514,14 +514,23 @@ class CLI:
         console.clear()
 
         sort_by: str = self.config.wallet.sort_by
+        sort_order: str = self.config.wallet.sort_order
+
         if sort_by != "":
             column_to_sort_by: int = 0
+            sort_descending: bool = False # Default sort_order to ascending
+
             for index, column in zip(range(len(table.columns)), table.columns):
                 # Fuzzy match the column name. Default to the first column.
                 if fuzz.ratio(sort_by.lower(), column.header.lower().replace('[overline white]', '')) > 80:
                     column_to_sort_by = index
                     break
-            TABLE_DATA.sort(key=lambda row: row[column_to_sort_by])
+            
+            if fuzz.ratio(sort_order.lower(), 'desc') > 80 or fuzz.ratio(sort_order.lower(), 'descending') > 80:
+                # Sort descending if the sort_order fuzzy-matches desc or descending
+                sort_descending = True
+                
+            TABLE_DATA.sort(key=lambda row: row[column_to_sort_by], reverse=sort_descending)
 
         for row in TABLE_DATA:
             table.add_row(*row)

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -128,9 +128,11 @@ class wallet:
 
     @classmethod   
     def check_config(cls, config: 'bittensor.Config' ):
-        """ Check config for wallet name/hotkey/path
+        """ Check config for wallet name/hotkey/path/hotkeys/sort_by
         """
         assert 'wallet' in config
         assert isinstance(config.wallet.name, str)
         assert isinstance(config.wallet.hotkey, str)
         assert isinstance(config.wallet.path, str)
+        assert isinstance(config.wallet.hotkeys, list)
+        assert isinstance(config.wallet.sort_by, str)

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -108,6 +108,7 @@ class wallet:
             parser.add_argument('--wallet._mock', action='store_true', default=bittensor.defaults.wallet._mock, help='To turn on wallet mocking for testing purposes.')
             parser.add_argument('--wallet.hotkeys', required=False, action='store', default=bittensor.defaults.wallet.hotkeys, type=str, nargs='*', help='''Specify the hotkeys by name.''')
             parser.add_argument('--wallet.sort_by', required=False, action='store', default=bittensor.defaults.wallet.sort_by, type=str, help='''Sort the hotkeys by the specified criteria.''')
+            parser.add_argument('--wallet.sort_order', required=False, action='store', default=bittensor.defaults.wallet.sort_order, type=str, help='''Sort the hotkeys in the specified ordering.''')
 
         except argparse.ArgumentError:
             # re-parsing arguments.
@@ -125,6 +126,7 @@ class wallet:
         # CLI defaults for Overview
         defaults.wallet.hotkeys = []
         defaults.wallet.sort_by = ""
+        defaults.wallet.sort_order = "ascending"
 
     @classmethod   
     def check_config(cls, config: 'bittensor.Config' ):
@@ -136,3 +138,4 @@ class wallet:
         assert isinstance(config.wallet.path, str)
         assert isinstance(config.wallet.hotkeys, list)
         assert isinstance(config.wallet.sort_by, str)
+        assert isinstance(config.wallet.sort_order, str)

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -106,6 +106,7 @@ class wallet:
             parser.add_argument('--wallet.hotkey', required=False, default=bittensor.defaults.wallet.hotkey, help='''The name of wallet's hotkey.''')
             parser.add_argument('--wallet.path',required=False, default=bittensor.defaults.wallet.path, help='''The path to your bittensor wallets''')
             parser.add_argument('--wallet._mock', action='store_true', default=bittensor.defaults.wallet._mock, help='To turn on wallet mocking for testing purposes.')
+            parser.add_argument('--wallet.hotkeys', required=False, action='store', default=bittensor.defaults.wallet.hotkeys, type=str, nargs='*', help='''Specify the hotkeys by name.''')
         except argparse.ArgumentError:
             # re-parsing arguments.
             pass
@@ -119,6 +120,8 @@ class wallet:
         defaults.wallet.hotkey = os.getenv('BT_WALLET_HOTKEY') if os.getenv('BT_WALLET_HOTKEY') != None else 'default'
         defaults.wallet.path = os.getenv('BT_WALLET_PATH') if os.getenv('BT_WALLET_PATH') != None else '~/.bittensor/wallets/'
         defaults.wallet._mock = os.getenv('BT_WALLET_MOCK') if os.getenv('BT_WALLET_MOCK') != None else False
+        # CLI defaults for Overview
+        defaults.wallet.hotkeys = []
 
     @classmethod   
     def check_config(cls, config: 'bittensor.Config' ):

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -107,6 +107,8 @@ class wallet:
             parser.add_argument('--wallet.path',required=False, default=bittensor.defaults.wallet.path, help='''The path to your bittensor wallets''')
             parser.add_argument('--wallet._mock', action='store_true', default=bittensor.defaults.wallet._mock, help='To turn on wallet mocking for testing purposes.')
             parser.add_argument('--wallet.hotkeys', required=False, action='store', default=bittensor.defaults.wallet.hotkeys, type=str, nargs='*', help='''Specify the hotkeys by name.''')
+            parser.add_argument('--wallet.sort_by', required=False, action='store', default=bittensor.defaults.wallet.sort_by, type=str, help='''Sort the hotkeys by the specified criteria.''')
+
         except argparse.ArgumentError:
             # re-parsing arguments.
             pass
@@ -122,6 +124,7 @@ class wallet:
         defaults.wallet._mock = os.getenv('BT_WALLET_MOCK') if os.getenv('BT_WALLET_MOCK') != None else False
         # CLI defaults for Overview
         defaults.wallet.hotkeys = []
+        defaults.wallet.sort_by = None
 
     @classmethod   
     def check_config(cls, config: 'bittensor.Config' ):

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -106,9 +106,9 @@ class wallet:
             parser.add_argument('--wallet.hotkey', required=False, default=bittensor.defaults.wallet.hotkey, help='''The name of wallet's hotkey.''')
             parser.add_argument('--wallet.path',required=False, default=bittensor.defaults.wallet.path, help='''The path to your bittensor wallets''')
             parser.add_argument('--wallet._mock', action='store_true', default=bittensor.defaults.wallet._mock, help='To turn on wallet mocking for testing purposes.')
-            parser.add_argument('--wallet.hotkeys', required=False, action='store', default=bittensor.defaults.wallet.hotkeys, type=str, nargs='*', help='''Specify the hotkeys by name.''')
-            parser.add_argument('--wallet.sort_by', required=False, action='store', default=bittensor.defaults.wallet.sort_by, type=str, help='''Sort the hotkeys by the specified criteria.''')
-            parser.add_argument('--wallet.sort_order', required=False, action='store', default=bittensor.defaults.wallet.sort_order, type=str, help='''Sort the hotkeys in the specified ordering.''')
+            parser.add_argument('--wallet.hotkeys', required=False, action='store', default=bittensor.defaults.wallet.hotkeys, type=str, nargs='*', help='''Specify the hotkeys by name. (e.g. hk1 hk2 hk3)''')
+            parser.add_argument('--wallet.sort_by', required=False, action='store', default=bittensor.defaults.wallet.sort_by, type=str, help='''Sort the hotkeys by the specified column title (e.g. name, uid, axon).''')
+            parser.add_argument('--wallet.sort_order', required=False, action='store', default=bittensor.defaults.wallet.sort_order, type=str, help='''Sort the hotkeys in the specified ordering. (ascending/asc or descending/desc/reverse)''')
 
         except argparse.ArgumentError:
             # re-parsing arguments.

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -124,7 +124,7 @@ class wallet:
         defaults.wallet._mock = os.getenv('BT_WALLET_MOCK') if os.getenv('BT_WALLET_MOCK') != None else False
         # CLI defaults for Overview
         defaults.wallet.hotkeys = []
-        defaults.wallet.sort_by = None
+        defaults.wallet.sort_by = ""
 
     @classmethod   
     def check_config(cls, config: 'bittensor.Config' ):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ base58>=2.0.1
 certifi>=2020.11.8
 cryptography>=3.1.1
 idna>=2.10
+fuzzywuzzy==0.18.0
+python-levenshtein==0.12
 google-api-python-client
 grpcio==1.42.0
 grpcio-tools==1.42.0

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -303,6 +303,33 @@ class TestCli(unittest.TestCase):
         cli = bittensor.cli(config)
         cli.run()
 
+
+    def test_overview_with_width_config( self ):
+        bittensor.subtensor.register = MagicMock(return_value = True)  
+        
+        config = self.config
+        config.command = "overview"
+        config.subtensor._mock = True
+        config.width = 100
+        config.subtensor.network = "mock"
+        config.no_prompt = True
+
+        cli = bittensor.cli(config)
+        cli.run()
+
+    def test_overview_without_width_config( self ):
+        bittensor.subtensor.register = MagicMock(return_value = True)  
+        
+        config = self.config
+        config.command = "overview"
+        config.subtensor._mock = True
+        # Don't specify width in config
+        config.subtensor.network = "mock"
+        config.no_prompt = True
+
+        cli = bittensor.cli(config)
+        cli.run()
+
     def test_register( self ):
 
         config = self.config

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -225,6 +225,45 @@ class TestCli(unittest.TestCase):
         cli = bittensor.cli(config)
         cli.run()
 
+    def test_overview_with_sort_order_config( self ):
+        bittensor.subtensor.register = MagicMock(return_value = True)  
+        
+        config = self.config
+        config.command = "overview"
+        config.subtensor._mock = True
+        config.wallet.sort_order = "desc" # Set descending sort order
+        config.subtensor.network = "mock"
+        config.no_prompt = True
+
+        cli = bittensor.cli(config)
+        cli.run()
+
+    def test_overview_with_sort_order_config_bad_sort_type( self ):
+        bittensor.subtensor.register = MagicMock(return_value = True)  
+        
+        config = self.config
+        config.command = "overview"
+        config.subtensor._mock = True
+        config.wallet.sort_order = "nowaythisshouldmatchanyorderingchoice" 
+        config.subtensor.network = "mock"
+        config.no_prompt = True
+
+        cli = bittensor.cli(config)
+        cli.run()
+
+    def test_overview_without_sort_order_config( self ):
+        bittensor.subtensor.register = MagicMock(return_value = True)  
+        
+        config = self.config
+        config.command = "overview"
+        config.subtensor._mock = True
+        # Don't specify sort_order in config
+        config.subtensor.network = "mock"
+        config.no_prompt = True
+
+        cli = bittensor.cli(config)
+        cli.run()
+
     def test_register( self ):
 
         config = self.config

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -110,12 +110,44 @@ class TestCli(unittest.TestCase):
         
         config = self.config
         config.command = "overview"
+        config.no_cache = True  # Don't use neuron cache
         config.subtensor._mock = True
         config.subtensor.network = "mock"
         config.no_prompt = True
 
         cli = bittensor.cli(config)
         cli.run()
+
+    def test_overview_with_cache( self ):
+        bittensor.subtensor.register = MagicMock(return_value = True)  
+        
+        config = self.config
+        config.command = "overview"
+        config.no_cache = False # Use neuron cache
+        config.subtensor._mock = True
+        config.subtensor.network = "mock"
+        config.no_prompt = True
+
+        cli = bittensor.cli(config)
+        cli.run()
+
+    def test_overview_with_cache_cache_fails( self ):
+        bittensor.subtensor.register = MagicMock(return_value = True)  
+        
+        config = self.config
+        config.command = "overview"
+        config.no_cache = False # Use neuron cache
+        config.subtensor._mock = True
+        config.subtensor.network = "mock"
+        config.no_prompt = True
+
+        with patch('bittensor.Metagraph.retrieve_cached_neurons') as mock_retrieve_cached_neurons:
+            # Mock the cache retrieval to fail
+            mock_retrieve_cached_neurons.side_effect = Exception("Cache failed")
+
+            # Should not raise an exception
+            cli = bittensor.cli(config)
+            cli.run()
 
     def test_register( self ):
 

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -149,6 +149,31 @@ class TestCli(unittest.TestCase):
             cli = bittensor.cli(config)
             cli.run()
 
+    def test_overview_with_hotkeys_config( self ):
+        bittensor.subtensor.register = MagicMock(return_value = True)  
+        
+        config = self.config
+        config.command = "overview"
+        config.subtensor._mock = True
+        config.subtensor.network = "mock"
+        config.no_prompt = True
+        config.wallet.hotkeys = ['some_hotkey']
+
+        cli = bittensor.cli(config)
+        cli.run()
+
+    def test_overview_without_hotkeys_config( self ):
+        bittensor.subtensor.register = MagicMock(return_value = True)  
+        
+        config = self.config
+        config.command = "overview"
+        config.subtensor._mock = True
+        config.subtensor.network = "mock"
+        config.no_prompt = True
+
+        cli = bittensor.cli(config)
+        cli.run()
+
     def test_register( self ):
 
         config = self.config

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -187,6 +187,44 @@ class TestCli(unittest.TestCase):
         cli = bittensor.cli(config)
         cli.run()
 
+    def test_overview_with_sort_by_config( self ):
+        bittensor.subtensor.register = MagicMock(return_value = True)  
+        
+        config = self.config
+        config.command = "overview"
+        config.subtensor._mock = True
+        config.subtensor.network = "mock"
+        config.no_prompt = True
+        config.wallet.sort_by = "rank"
+
+        cli = bittensor.cli(config)
+        cli.run()
+
+    def test_overview_with_sort_by_bad_column_name( self ):
+        bittensor.subtensor.register = MagicMock(return_value = True)  
+        
+        config = self.config
+        config.command = "overview"
+        config.subtensor._mock = True
+        config.subtensor.network = "mock"
+        config.no_prompt = True
+        config.wallet.sort_by = "totallynotmatchingcolumnname"
+
+        cli = bittensor.cli(config)
+        cli.run()
+
+    def test_overview_without_sort_by_config( self ):
+        bittensor.subtensor.register = MagicMock(return_value = True)  
+        
+        config = self.config
+        config.command = "overview"
+        config.subtensor._mock = True
+        config.subtensor.network = "mock"
+        config.no_prompt = True
+
+        cli = bittensor.cli(config)
+        cli.run()
+
     def test_register( self ):
 
         config = self.config

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -149,6 +149,19 @@ class TestCli(unittest.TestCase):
             cli = bittensor.cli(config)
             cli.run()
 
+    def test_overview_without_no_cache_confg( self ):
+        bittensor.subtensor.register = MagicMock(return_value = True)  
+        
+        config = self.config
+        config.command = "overview"
+        # Don't specify no_cache in config
+        config.subtensor._mock = True
+        config.subtensor.network = "mock"
+        config.no_prompt = True
+
+        cli = bittensor.cli(config)
+        cli.run()
+
     def test_overview_with_hotkeys_config( self ):
         bittensor.subtensor.register = MagicMock(return_value = True)  
         


### PR DESCRIPTION
**Re-submit of #771 because of CI**

This PR adds a cached overview (from IPFS) by default, with the flag `--no_cache` to opt-out
- This significantly speeds up the overview command 
     - Assuming IPFS is fairly up-to-date, the accuracy issues for most people are likely less significant than the time overview would take

Edit:
This PR also adds:
- Hotkey sorting in overview via fuzzy-matching a column title `--wallet.sort_by <column_title>`
- Hotkey sort_order in overview via specifying `--wallet.sort_order <ascending|descending|reverse>`
- Hotkey specifying for overview `--wallet.hotkeys <hk0> <hk1> <hk2> ...`
- Optional width argument for the overview output `--width <int>`