### PR TITLE
[Fix] google api reqs incompatible with our protobuf req

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@ idna>=2.10
 fuzzywuzzy==0.18.0
 python-levenshtein==0.12
 google-api-python-client
-googleapis-common-protos<=1.56.0
-google-api-core<=2.8.0
 grpcio==1.42.0
 grpcio-tools==1.42.0
 loguru
@@ -19,7 +17,7 @@ netaddr==0.8.0
 pandas
 psutil
 password_strength==0.0.3.post2
-protobuf==3.13.0
+protobuf>=3.15.0
 pycryptodome==3.11.0
 py-sr25519-bindings>=0.1.4,<1
 py-ed25519-bindings>=1.0,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ fuzzywuzzy==0.18.0
 python-levenshtein==0.12
 google-api-python-client
 googleapis-common-protos<=1.56.0
-google-api-core>=2.7.3,<2.8.0
+google-api-core<=2.8.0
 grpcio==1.42.0
 grpcio-tools==1.42.0
 loguru

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ idna>=2.10
 fuzzywuzzy==0.18.0
 python-levenshtein==0.12
 google-api-python-client
+googleapis-common-protos<=1.56.0
+google-api-core>=2.7.3,<2.8.0
 grpcio==1.42.0
 grpcio-tools==1.42.0
 loguru


### PR DESCRIPTION
Installing the newest version of bittensor can cause an issue for some users.  

     Traceback (most recent call last):
     File "/home/<>/.local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 581, in _build_master
         ws.require(__requires__)
     File "/home/<>/.local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 909, in require
         needed = self.resolve(parse_requirements(requirements))
     File "/home/<>/.local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 800, in resolve
         raise VersionConflict(dist, req).with_context(dependent_req)
     pkg_resources.ContextualVersionConflict: (protobuf 3.13.0 (/home/<>/.local/lib/python3.8/site-packages), Requirement.parse('protobuf>=3.15.0'), {'googleapis-common-protos'})  

https://github.com/googleapis/python-api-common-protos/commit/f04ed64b233e1ff95370ef412ad5ecb92cb5780e [ups the `porotobuf` requirement from `>= 3.12.0` to `>=3.15.0`](https://github.com/googleapis/python-api-common-protos/blob/f04ed64b233e1ff95370ef412ad5ecb92cb5780e/setup.py#L25)

keeping `googleapis-common-protos<=1.56.0` fixes this

*and*

https://github.com/googleapis/python-api-core/commit/d84d66c2a4107f5f9a20c53e870a27fb1250ea3d [ups the `protobuf` requirement the same](https://github.com/googleapis/python-api-core/blob/d84d66c2a4107f5f9a20c53e870a27fb1250ea3d/setup.py#L33)

keeping `google-api-core<=2.8.0` fixes this.  