### PR TITLE
Only support modern python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
             pytest -n2 --durations=0 --verbose --junitxml=test-results/unit_tests.xml \
             --splits $CIRCLE_NODE_TOTAL --group $((CIRCLE_NODE_INDEX + 1)) \
             --splitting-algorithm duration_based_chunks --store-durations --durations-path .test_durations \
+            --force-flaky --max-runs=3 --min-passes=1 \ # Ugly hack til all tests pass consistently.
             tests/unit_tests/
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
             pytest -n2 --durations=0 --verbose --junitxml=test-results/unit_tests.xml \
             --splits $CIRCLE_NODE_TOTAL --group $((CIRCLE_NODE_INDEX + 1)) \
             --splitting-algorithm duration_based_chunks --store-durations --durations-path .test_durations \
-            --force-flaky --max-runs=3 --min-passes=1 \ # Ugly hack til all tests pass consistently.
+            --force-flaky --max-runs=3 --min-passes=1 \ 
             tests/unit_tests/
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,26 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@1.5.0
+  python: circleci/python@2.0.3
 
 jobs:
   build-and-test:
-    docker:
-      - image: cimg/python:3.8
     resource_class: medium
     parallelism: 2
+    parameters:
+      python-version:
+        type: string
+    docker:
+      - image: cimg/python:<< parameters.python-version >>
 
     steps:
       - checkout
 
-      # TODO: Add Python version (matrix strategy)
       - restore_cache:
           name: Restore cached venv
           keys:
-            - v1-pypi-py3.8-{{ checksum "requirements.txt" }}
-            - v1-pypi-py3.8-
+            - v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements.txt" }}
+            - v1-pypi-py<< parameters.python-version >>
 
       - run:
           name: Update & Activate venv
@@ -31,7 +33,7 @@ jobs:
           name: Save cached venv
           paths:
             - "env/"
-          key: v1-pypi-py3.8-{{ checksum "requirements.txt" }}
+          key: v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements.txt" }}
 
       - run:
           name: Install Bittensor
@@ -74,4 +76,7 @@ jobs:
 workflows:
   pre-pr:
     jobs:
-      - build-and-test
+      - build-and-test:
+          matrix:
+            parameters:
+              python-version: ["3.7", "3.8", "3.9", "3.10"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,9 @@ jobs:
           command: |
             . env/bin/activate
             export PYTHONUNBUFFERED=1
-            pytest -n2 --durations=0 --verbose --junitxml=test-results/unit_tests.xml \
+            pytest -n2 --reruns 2 --durations=0 --verbose --junitxml=test-results/unit_tests.xml \
             --splits $CIRCLE_NODE_TOTAL --group $((CIRCLE_NODE_INDEX + 1)) \
             --splitting-algorithm duration_based_chunks --store-durations --durations-path .test_durations \
-            --reruns 2 \ 
             tests/unit_tests/
 
       - run:
@@ -64,10 +63,9 @@ jobs:
           command: |
             . env/bin/activate
             export PYTHONUNBUFFERED=1
-            pytest -n2 --durations=0 --verbose --junitxml=test-results/integration_tests.xml \
+            pytest -n2 --reruns 2 --durations=0 --verbose --junitxml=test-results/integration_tests.xml \
             --splits $CIRCLE_NODE_TOTAL --group $((CIRCLE_NODE_INDEX + 1)) \
             --splitting-algorithm duration_based_chunks --store-durations --durations-path .test_durations \
-            --reruns 2 \
             tests/integration_tests/
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
             pytest -n2 --durations=0 --verbose --junitxml=test-results/unit_tests.xml \
             --splits $CIRCLE_NODE_TOTAL --group $((CIRCLE_NODE_INDEX + 1)) \
             --splitting-algorithm duration_based_chunks --store-durations --durations-path .test_durations \
+            --reruns 2 \ 
             tests/unit_tests/
 
       - run:
@@ -66,7 +67,7 @@ jobs:
             pytest -n2 --durations=0 --verbose --junitxml=test-results/integration_tests.xml \
             --splits $CIRCLE_NODE_TOTAL --group $((CIRCLE_NODE_INDEX + 1)) \
             --splitting-algorithm duration_based_chunks --store-durations --durations-path .test_durations \
-            --force-flaky --max-runs=3 --min-passes=1 \ 
+            --reruns 2 \
             tests/integration_tests/
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,6 @@ jobs:
             pytest -n2 --durations=0 --verbose --junitxml=test-results/unit_tests.xml \
             --splits $CIRCLE_NODE_TOTAL --group $((CIRCLE_NODE_INDEX + 1)) \
             --splitting-algorithm duration_based_chunks --store-durations --durations-path .test_durations \
-            --force-flaky --max-runs=3 --min-passes=1 \ 
             tests/unit_tests/
 
       - run:
@@ -67,6 +66,7 @@ jobs:
             pytest -n2 --durations=0 --verbose --junitxml=test-results/integration_tests.xml \
             --splits $CIRCLE_NODE_TOTAL --group $((CIRCLE_NODE_INDEX + 1)) \
             --splitting-algorithm duration_based_chunks --store-durations --durations-path .test_durations \
+            --force-flaky --max-runs=3 --min-passes=1 \ 
             tests/integration_tests/
 
       - store_test_results:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ miniupnpc
 munch
 netaddr==0.8.0
 pandas
+flaky
 psutil
 password_strength==0.0.3.post2
 protobuf==3.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ google-api-python-client
 grpcio==1.42.0
 grpcio-tools==1.42.0
 loguru
-msgpack==1.0.2
+msgpack==1.0.4
 msgpack-numpy==0.4.7.1
 miniupnpc
 munch

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ retry
 requests>=2.25.0
 scalecodec>=1.0.35
 termcolor
-torch==1.10
+torch==1.11
 transformers>=4.5.0
 numpy
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ miniupnpc
 munch
 netaddr==0.8.0
 pandas
-flaky
 psutil
 password_strength==0.0.3.post2
 protobuf==3.13.0
@@ -26,6 +25,7 @@ py-bip39-bindings>=0.1.9,<1
 pytest>=6.2.4
 pytest-split
 pytest-xdist
+pytest-rerunfailures
 pyyaml
 rich
 retry

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,10 @@ setup(
 
         # Pick your license as you wish
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
@@ -67,5 +68,5 @@ setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    python_requires='>=3.5',
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
* Bumps various versions to support Python3.10 (and consequently Ubuntu 22.04, as that's the system-default).
* Removes support for EOL Python versions (we now only officially recognize >= 3.7).
* CircleCI now runs tests against all supported python versions in parallel.
    * We now try rerunning all tests twice, because 4/4 independent runs all need to pass and apparently saCRIfICiAL GOats aRe NoT A VAlID BUsineSS eXpeNSE