### PR TITLE
pin protobuf to 3.15.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ netaddr==0.8.0
 pandas
 psutil
 password_strength==0.0.3.post2
-protobuf>=3.15.0
+protobuf==3.15.0
 pycryptodome==3.11.0
 py-sr25519-bindings>=0.1.4,<1
 py-ed25519-bindings>=1.0,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ base58>=2.0.1
 certifi>=2020.11.8
 cryptography>=3.1.1
 idna>=2.10
+jinja2>=3.0
 fuzzywuzzy==0.18.0
 python-levenshtein==0.12
 google-api-python-client


### PR DESCRIPTION
Currently, we have requirements.txt at `protobuf>=3.15.0` but this leads to a protobuf error during fresh installs of bittensor/protobuf. This PR pins to `protobuf==3.15.0`  

        Traceback (most recent call last):
          File "<string>", line 1, in <module>
          File "/root/.bittensor/bittensor/bittensor/__init__.py", line 83, in <module>
            import bittensor._proto.bittensor_pb2 as proto
          File "/root/.bittensor/bittensor/bittensor/_proto/bittensor_pb2.py", line 33, in <module>
            _descriptor.EnumValueDescriptor(
          File "/usr/local/lib/python3.8/dist-packages/google/protobuf/descriptor.py", line 755, in __new__
            _message.Message._CheckCalledFromGeneratedFile()
        TypeError: Descriptors cannot not be created directly.
        If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
        If you cannot immediately regenerate your protos, some other possible workarounds are:
         1. Downgrade the protobuf package to 3.20.x or lower.
         2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).