### PR TITLE
Feature/dont ask if flag set

### DIFF
--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -698,8 +698,8 @@ class cli:
             config.wallet.name = str(wallet_name)
 
         if config.wallet.get('hotkey') is None and not config.no_prompt:
-            hotkey = Prompt.ask("Enter hotkey name (optional)", default = 'None')
-            config.wallet.hotkey = str(hotkey)
+            hotkey = Prompt.ask("Enter hotkey name (optional)", default = None)
+            config.wallet.hotkey = hotkey
 
     def check_stake_config( config: 'bittensor.Config' ):
         if config.subtensor.get('network') is None and not config.no_prompt:

--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -560,7 +560,7 @@ class cli:
         if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
+        if config.wallet.name is None and not config.no_prompt:
             if not Confirm.ask("Show all weights?"):
                 wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
                 config.wallet.name = str(wallet_name)
@@ -578,7 +578,7 @@ class cli:
         if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
+        if config.wallet.name is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -603,7 +603,7 @@ class cli:
         if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
+        if config.wallet.name is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -625,7 +625,7 @@ class cli:
                 config.unstake_all = True
 
     def check_query_config( config: 'bittensor.Config' ):
-        if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
+        if config.wallet.name is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -648,7 +648,7 @@ class cli:
         if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
+        if config.wallet.name is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -668,7 +668,7 @@ class cli:
         if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
+        if config.wallet.name is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -680,7 +680,7 @@ class cli:
         if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
+        if config.wallet.name is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -690,7 +690,7 @@ class cli:
                     
         # Get amount.
         if not config.amount and not config.stake_all:
-            if not Confirm.ask("Stake all Tao from account: [bold]'{}'[/bold]?".format(config.wallet.name)):
+            if not Confirm.ask("Stake all Tao from account: [bold]'{}'[/bold]?".format(config.wallet.get('name', bittensor.defaults.wallet.name))):
                 amount = Prompt.ask("Enter Tao amount to stake")
                 try:
                     config.amount = float(amount)
@@ -704,7 +704,7 @@ class cli:
         if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if config.wallet.name is None  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -712,7 +712,7 @@ class cli:
         if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
+        if config.wallet.name is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -721,12 +721,12 @@ class cli:
             config.wallet.hotkey = str(hotkey)
 
     def check_new_coldkey_config( config: 'bittensor.Config' ):
-        if config.wallet.name == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if config.wallet.name is None  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
     def check_new_hotkey_config( config: 'bittensor.Config' ):
-        if config.wallet.name == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if config.wallet.name is None  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -735,7 +735,7 @@ class cli:
             config.wallet.hotkey = str(hotkey)
 
     def check_regen_hotkey_config( config: 'bittensor.Config' ):
-        if config.wallet.name == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if config.wallet.name is None  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -747,7 +747,7 @@ class cli:
             config.mnemonic = Prompt.ask("Enter mnemonic")
 
     def check_regen_coldkey_config( config: 'bittensor.Config' ):
-        if config.wallet.name == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if config.wallet.name is None  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
         if config.mnemonic == None and config.seed == None:
@@ -764,7 +764,7 @@ class cli:
         if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if config.wallet.name is None  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 

--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -552,11 +552,12 @@ class cli:
             cli.check_update_config(config)
 
     def check_metagraph_config( config: 'bittensor.Config'):
-        if config.subtensor.network == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
+        
 
     def check_weights_config( config: 'bittensor.Config'):
-        if config.subtensor.network == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
@@ -574,7 +575,7 @@ class cli:
                 config.all_weights = True
 
     def check_transfer_config( config: 'bittensor.Config'):
-        if config.subtensor.network == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
@@ -599,7 +600,7 @@ class cli:
                 sys.exit()
 
     def check_unstake_config( config: 'bittensor.Config' ):
-        if config.subtensor.network == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
@@ -644,7 +645,7 @@ class cli:
                     sys.exit()
 
     def check_set_weights_config( config: 'bittensor.Config' ):
-        if config.subtensor.network == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
@@ -664,7 +665,7 @@ class cli:
             config.weights = [float(val) for val in weights_str.split(',')]
 
     def check_inspect_config( config: 'bittensor.Config' ):
-        if config.subtensor.network == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
@@ -676,7 +677,7 @@ class cli:
             config.wallet.hotkey = str(hotkey)
 
     def check_stake_config( config: 'bittensor.Config' ):
-        if config.subtensor.network == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
@@ -700,7 +701,7 @@ class cli:
                 config.stake_all = True
 
     def check_overview_config( config: 'bittensor.Config' ):
-        if config.subtensor.network == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         if config.wallet.name == bittensor.defaults.wallet.name  and not config.no_prompt:
@@ -708,7 +709,7 @@ class cli:
             config.wallet.name = str(wallet_name)
 
     def check_register_config( config: 'bittensor.Config' ):
-        if config.subtensor.network == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         if config.wallet.name == bittensor.defaults.wallet.name and not config.no_prompt:
@@ -760,7 +761,7 @@ class cli:
     def check_run_config( config: 'bittensor.Config' ):
 
         # Check network.
-        if config.subtensor.network == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if config.subtensor.network is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         if config.wallet.name == bittensor.defaults.wallet.name  and not config.no_prompt:

--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -552,15 +552,15 @@ class cli:
             cli.check_update_config(config)
 
     def check_metagraph_config( config: 'bittensor.Config'):
-        if config.subtensor.network is None and not config.no_prompt:
+        if config.subtensor.get('network') is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
         
 
     def check_weights_config( config: 'bittensor.Config'):
-        if config.subtensor.network is None and not config.no_prompt:
+        if config.subtensor.get('network') is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name is None and not config.no_prompt:
+        if config.wallet.get('name') is None and not config.no_prompt:
             if not Confirm.ask("Show all weights?"):
                 wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
                 config.wallet.name = str(wallet_name)
@@ -575,10 +575,10 @@ class cli:
                 config.all_weights = True
 
     def check_transfer_config( config: 'bittensor.Config'):
-        if config.subtensor.network is None and not config.no_prompt:
+        if config.subtensor.get('network') is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name is None and not config.no_prompt:
+        if config.wallet.get('name') is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -600,20 +600,20 @@ class cli:
                 sys.exit()
 
     def check_unstake_config( config: 'bittensor.Config' ):
-        if config.subtensor.network is None and not config.no_prompt:
+        if config.subtensor.get('network') is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name is None and not config.no_prompt:
+        if config.wallet.get('name') is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.hotkey == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if config.wallet.get('hotkey') is None and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
                     
         # Get amount.
         if not config.amount and not config.unstake_all:
-            if not Confirm.ask("Unstake all Tao from: [bold]'{}'[/bold]?".format(config.wallet.hotkey)):
+            if not Confirm.ask("Unstake all Tao from: [bold]'{}'[/bold]?".format(config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey))):
                 amount = Prompt.ask("Enter Tao amount to unstake")
                 config.unstake_all = False
                 try:
@@ -625,11 +625,11 @@ class cli:
                 config.unstake_all = True
 
     def check_query_config( config: 'bittensor.Config' ):
-        if config.wallet.name is None and not config.no_prompt:
+        if config.wallet.get('name') is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.hotkey == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if config.wallet.get('hotkey') is None and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
                   
@@ -645,14 +645,14 @@ class cli:
                     sys.exit()
 
     def check_set_weights_config( config: 'bittensor.Config' ):
-        if config.subtensor.network is None and not config.no_prompt:
+        if config.subtensor.get('network') is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name is None and not config.no_prompt:
+        if config.wallet.get('name') is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.hotkey == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if config.wallet.get('hotkey') is None and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 
@@ -665,26 +665,26 @@ class cli:
             config.weights = [float(val) for val in weights_str.split(',')]
 
     def check_inspect_config( config: 'bittensor.Config' ):
-        if config.subtensor.network is None and not config.no_prompt:
+        if config.subtensor.get('network') is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name is None and not config.no_prompt:
+        if config.wallet.get('name') is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.hotkey == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if config.wallet.get('hotkey') is None and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name (optional)", default = 'None')
             config.wallet.hotkey = str(hotkey)
 
     def check_stake_config( config: 'bittensor.Config' ):
-        if config.subtensor.network is None and not config.no_prompt:
+        if config.subtensor.get('network') is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name is None and not config.no_prompt:
+        if config.wallet.get('name') is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.hotkey == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if config.wallet.get('hotkey') is None and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
                     
@@ -701,45 +701,45 @@ class cli:
                 config.stake_all = True
 
     def check_overview_config( config: 'bittensor.Config' ):
-        if config.subtensor.network is None and not config.no_prompt:
+        if config.subtensor.get('network') is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name is None  and not config.no_prompt:
+        if config.wallet.get('name') is None  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
     def check_register_config( config: 'bittensor.Config' ):
-        if config.subtensor.network is None and not config.no_prompt:
+        if config.subtensor.get('network') is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name is None and not config.no_prompt:
+        if config.wallet.get('name') is None and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.hotkey == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if config.wallet.get('hotkey') is None and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 
     def check_new_coldkey_config( config: 'bittensor.Config' ):
-        if config.wallet.name is None  and not config.no_prompt:
+        if config.wallet.get('name') is None  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
     def check_new_hotkey_config( config: 'bittensor.Config' ):
-        if config.wallet.name is None  and not config.no_prompt:
+        if config.wallet.get('name') is None  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.hotkey == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if config.wallet.get('hotkey') is None and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 
     def check_regen_hotkey_config( config: 'bittensor.Config' ):
-        if config.wallet.name is None  and not config.no_prompt:
+        if config.wallet.get('name') is None  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.hotkey == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if config.wallet.get('hotkey') is None and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
         
@@ -747,7 +747,7 @@ class cli:
             config.mnemonic = Prompt.ask("Enter mnemonic")
 
     def check_regen_coldkey_config( config: 'bittensor.Config' ):
-        if config.wallet.name is None  and not config.no_prompt:
+        if config.wallet.get('name') is None  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
         if config.mnemonic == None and config.seed == None:
@@ -761,15 +761,15 @@ class cli:
     def check_run_config( config: 'bittensor.Config' ):
 
         # Check network.
-        if config.subtensor.network is None and not config.no_prompt:
+        if config.subtensor.get('network') is None and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.name is None  and not config.no_prompt:
+        if config.wallet.get('name') is None  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
         # Check hotkey.
-        if config.wallet.hotkey == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if config.wallet.get('hotkey') is None and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -163,7 +163,7 @@ class CLI:
         # Check coldkey.
         wallet = bittensor.wallet( config = self.config )
         if not wallet.coldkeypub_file.exists_on_device():
-            if Confirm.ask("Coldkey: [bold]'{}'[/bold] does not exist, do you want to create it".format(self.config.wallet.name)):
+            if Confirm.ask("Coldkey: [bold]'{}'[/bold] does not exist, do you want to create it".format(self.config.wallet.get('name', bittensor.defaults.wallet.name))):
                 wallet.create_new_coldkey()
             else:
                 sys.exit()
@@ -262,6 +262,7 @@ class CLI:
             prompt = not self.config.no_prompt 
         )
 
+    @staticmethod
     def _get_hotkey_wallets_for_wallet( wallet ):
         hotkey_wallets = []
         hotkeys_path = wallet.path + '/' + wallet.name + '/hotkeys'
@@ -272,6 +273,14 @@ class CLI:
         for hotkey_file_name in hotkey_files:
             hotkey_wallets.append( bittensor.wallet( path = wallet.path, name = wallet.name, hotkey = hotkey_file_name ))
         return hotkey_wallets
+
+    def _get_coldkey_wallets(self):
+        try:
+            wallets = next(os.walk(os.path.expanduser(self.config.wallet.path)))[1]
+        except StopIteration:
+            # No wallet files found.
+            wallets = []
+        return wallets
 
     def list(self):
         r""" Lists wallets.
@@ -394,7 +403,7 @@ class CLI:
         subtensor = bittensor.subtensor( config = self.config )
         metagraph = bittensor.metagraph( subtensor = subtensor )
         wallet = bittensor.wallet( config = self.config )
-        with console.status(":satellite: Syncing with chain: [white]{}[/white] ...".format(self.config.subtensor.network)):
+        with console.status(":satellite: Syncing with chain: [white]{}[/white] ...".format(self.config.subtensor.get('network', bittensor.defaults.subtensor.network))):
             metagraph.load()
             metagraph.sync()
             metagraph.save()
@@ -441,9 +450,9 @@ class CLI:
             
         neurons = []
         block = subtensor.block
-        with console.status(":satellite: Syncing with chain: [white]{}[/white] ...".format(self.config.subtensor.network)):
+        with console.status(":satellite: Syncing with chain: [white]{}[/white] ...".format(self.config.subtensor.get('network', bittensor.defaults.subtensor.network))):
             try:
-                if self.config.subtensor.network not in ('local', 'nakamoto'):
+                if self.config.subtensor.get('network', bittensor.defaults.subtensor.network) not in ('local', 'nakamoto'):
                     # We only cache neurons for local/nakamoto.
                     raise CacheException("This network is not cached, defaulting to regular overview.")
             

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -132,7 +132,8 @@ class CLI:
         
         with bittensor.__console__.status(":satellite: Looking up account on: [white]{}[/white] ...".format(self.config.subtensor.get('network', bittensor.defaults.subtensor.network))):
             
-            if self.config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey) == 'None':
+            if self.config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey) is None:
+                # If no hotkey is provided, inspect just the coldkey
                 wallet.coldkeypub
                 cold_balance = wallet.get_balance( subtensor = subtensor )
                 bittensor.__console__.print("\n[bold white]{}[/bold white]:\n  {}[bold white]{}[/bold white]\n {} {}\n".format( wallet, "coldkey:".ljust(15), wallet.coldkeypub.ss58_address, " balance:".ljust(15), cold_balance.__rich__()), highlight=True)

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -130,7 +130,7 @@ class CLI:
         dendrite = bittensor.dendrite( wallet = wallet )
 
         
-        with bittensor.__console__.status(":satellite: Looking up account on: [white]{}[/white] ...".format(self.config.subtensor.network)):
+        with bittensor.__console__.status(":satellite: Looking up account on: [white]{}[/white] ...".format(self.config.subtensor.get('network', bittensor.defaults.subtensor.network))):
             
             if self.config.wallet.hotkey == 'None':
                 wallet.coldkeypub

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -132,7 +132,7 @@ class CLI:
         
         with bittensor.__console__.status(":satellite: Looking up account on: [white]{}[/white] ...".format(self.config.subtensor.get('network', bittensor.defaults.subtensor.network))):
             
-            if self.config.wallet.hotkey == 'None':
+            if self.config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey) == 'None':
                 wallet.coldkeypub
                 cold_balance = wallet.get_balance( subtensor = subtensor )
                 bittensor.__console__.print("\n[bold white]{}[/bold white]:\n  {}[bold white]{}[/bold white]\n {} {}\n".format( wallet, "coldkey:".ljust(15), wallet.coldkeypub.ss58_address, " balance:".ljust(15), cold_balance.__rich__()), highlight=True)

--- a/bittensor/_neuron/text/advanced_server/__init__.py
+++ b/bittensor/_neuron/text/advanced_server/__init__.py
@@ -106,7 +106,7 @@ class neuron:
         bittensor.dataset.check_config( config )
         bittensor.axon.check_config( config )
         bittensor.wandb.check_config( config )
-        full_path = os.path.expanduser('{}/{}/{}/{}'.format( config.logging.logging_dir, config.wallet.name, config.wallet.hotkey, config.neuron.name ))
+        full_path = os.path.expanduser('{}/{}/{}/{}'.format( config.logging.logging_dir, config.wallet.get('name', bittensor.defaults.wallet.name), config.wallet.hotkey, config.neuron.name ))
         config.neuron.full_path = os.path.expanduser(full_path)
         if not os.path.exists(config.neuron.full_path):
             os.makedirs(config.neuron.full_path)

--- a/bittensor/_neuron/text/advanced_server/__init__.py
+++ b/bittensor/_neuron/text/advanced_server/__init__.py
@@ -106,7 +106,7 @@ class neuron:
         bittensor.dataset.check_config( config )
         bittensor.axon.check_config( config )
         bittensor.wandb.check_config( config )
-        full_path = os.path.expanduser('{}/{}/{}/{}'.format( config.logging.logging_dir, config.wallet.get('name', bittensor.defaults.wallet.name), config.wallet.hotkey, config.neuron.name ))
+        full_path = os.path.expanduser('{}/{}/{}/{}'.format( config.logging.logging_dir, config.wallet.get('name', bittensor.defaults.wallet.name), config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), config.neuron.name ))
         config.neuron.full_path = os.path.expanduser(full_path)
         if not os.path.exists(config.neuron.full_path):
             os.makedirs(config.neuron.full_path)

--- a/bittensor/_neuron/text/multitron_server/__init__.py
+++ b/bittensor/_neuron/text/multitron_server/__init__.py
@@ -62,7 +62,7 @@ class neuron:
         bittensor.dataset.check_config( config )
         bittensor.axon.check_config( config )
         bittensor.wandb.check_config( config )
-        full_path = os.path.expanduser('{}/{}/{}/{}'.format( config.logging.logging_dir, config.wallet.get('name', bittensor.defaults.wallet.name), config.wallet.hotkey, config.neuron.name ))
+        full_path = os.path.expanduser('{}/{}/{}/{}'.format( config.logging.logging_dir, config.wallet.get('name', bittensor.defaults.wallet.name), config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), config.neuron.name ))
         config.neuron.full_path = os.path.expanduser(full_path)
         assert config.neuron.device != 'cpu', "multitron_server must be ran on cuda device. Please consider mining with template_server or advanced_server instead."
         if not os.path.exists(config.neuron.full_path):

--- a/bittensor/_neuron/text/multitron_server/__init__.py
+++ b/bittensor/_neuron/text/multitron_server/__init__.py
@@ -62,7 +62,7 @@ class neuron:
         bittensor.dataset.check_config( config )
         bittensor.axon.check_config( config )
         bittensor.wandb.check_config( config )
-        full_path = os.path.expanduser('{}/{}/{}/{}'.format( config.logging.logging_dir, config.wallet.name, config.wallet.hotkey, config.neuron.name ))
+        full_path = os.path.expanduser('{}/{}/{}/{}'.format( config.logging.logging_dir, config.wallet.get('name', bittensor.defaults.wallet.name), config.wallet.hotkey, config.neuron.name ))
         config.neuron.full_path = os.path.expanduser(full_path)
         assert config.neuron.device != 'cpu', "multitron_server must be ran on cuda device. Please consider mining with template_server or advanced_server instead."
         if not os.path.exists(config.neuron.full_path):

--- a/bittensor/_neuron/text/template_server/__init__.py
+++ b/bittensor/_neuron/text/template_server/__init__.py
@@ -102,7 +102,7 @@ class neuron:
         bittensor.dataset.check_config( config )
         bittensor.axon.check_config( config )
         bittensor.wandb.check_config( config )
-        full_path = os.path.expanduser('{}/{}/{}/{}'.format( config.logging.logging_dir, config.wallet.name, config.wallet.hotkey, config.neuron.name ))
+        full_path = os.path.expanduser('{}/{}/{}/{}'.format( config.logging.logging_dir, config.wallet.get('name', bittensor.defaults.wallet.name), config.wallet.hotkey, config.neuron.name ))
         config.neuron.full_path = os.path.expanduser(full_path)
         if not os.path.exists(config.neuron.full_path):
             os.makedirs(config.neuron.full_path)

--- a/bittensor/_neuron/text/template_server/__init__.py
+++ b/bittensor/_neuron/text/template_server/__init__.py
@@ -102,7 +102,7 @@ class neuron:
         bittensor.dataset.check_config( config )
         bittensor.axon.check_config( config )
         bittensor.wandb.check_config( config )
-        full_path = os.path.expanduser('{}/{}/{}/{}'.format( config.logging.logging_dir, config.wallet.get('name', bittensor.defaults.wallet.name), config.wallet.hotkey, config.neuron.name ))
+        full_path = os.path.expanduser('{}/{}/{}/{}'.format( config.logging.logging_dir, config.wallet.get('name', bittensor.defaults.wallet.name), config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), config.neuron.name ))
         config.neuron.full_path = os.path.expanduser(full_path)
         if not os.path.exists(config.neuron.full_path):
             os.makedirs(config.neuron.full_path)

--- a/bittensor/_subtensor/__init__.py
+++ b/bittensor/_subtensor/__init__.py
@@ -104,7 +104,7 @@ class subtensor:
 
         # Returns a mocked connection with a background chain connection.
         config.subtensor._mock = _mock if _mock != None else config.subtensor._mock
-        if config.subtensor._mock == True or network == 'mock' or config.subtensor.network == 'mock':
+        if config.subtensor._mock == True or network == 'mock' or config.subtensor.get('network', bittensor.defaults.subtensor.network) == 'mock':
             config.subtensor._mock = True
             return subtensor_mock.mock_subtensor.mock()
         
@@ -125,12 +125,12 @@ class subtensor:
         # Select using config.subtensor.chain_endpoint
         elif config.subtensor.chain_endpoint != None:
             config.subtensor.chain_endpoint = config.subtensor.chain_endpoint
-            config.subtensor.network = config.subtensor.network
+            config.subtensor.network = config.subtensor.get('network', bittensor.defaults.subtensor.network)
          
         # Select using config.subtensor.network
         elif config.subtensor.network != None:
             config.subtensor.chain_endpoint = subtensor.determine_chain_endpoint( config.subtensor.network )
-            config.subtensor.network = config.subtensor.network
+            config.subtensor.network = config.subtensor.get('network', bittensor.defaults.subtensor.network)
             
         # Fallback to defaults.
         else:
@@ -148,7 +148,7 @@ class subtensor:
         subtensor.check_config( config )
         return subtensor_impl.Subtensor( 
             substrate = substrate,
-            network = config.subtensor.network,
+            network = config.subtensor.get('network', bittensor.defaults.subtensor.network),
             chain_endpoint = config.subtensor.chain_endpoint,
         )
 
@@ -170,7 +170,7 @@ class subtensor:
     @classmethod
     def add_args(cls, parser: argparse.ArgumentParser ):
         try:
-            parser.add_argument('--subtensor.network', default = bittensor.defaults.subtensor.network, type=str, 
+            parser.add_argument('--subtensor.network', default = None, type=str, 
                                 help='''The subtensor network flag. The likely choices are:
                                         -- nobunaga (staging network)
                                         -- nakamoto (master network)

--- a/bittensor/_subtensor/__init__.py
+++ b/bittensor/_subtensor/__init__.py
@@ -170,7 +170,7 @@ class subtensor:
     @classmethod
     def add_args(cls, parser: argparse.ArgumentParser ):
         try:
-            parser.add_argument('--subtensor.network', default = None, type=str, 
+            parser.add_argument('--subtensor.network', default = argparse.SUPPRESS, type=str, 
                                 help='''The subtensor network flag. The likely choices are:
                                         -- nobunaga (staging network)
                                         -- nakamoto (master network)

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -56,25 +56,25 @@ class wallet:
         if config == None: 
             config = wallet.config()
         config = copy.deepcopy( config )
-        config.wallet.name = name if name != None else config.wallet.name
+        config.wallet.name = name if name != None else config.wallet.get('name', bittensor.defaults.wallet.name)
         config.wallet.hotkey = hotkey if hotkey != None else config.wallet.hotkey
         config.wallet.path = path if path != None else config.wallet.path
         config.wallet._mock = _mock if _mock != None else config.wallet._mock
         wallet.check_config( config )
         # Allows mocking from the command line.
-        if config.wallet.name == 'mock' or config.wallet._mock:
+        if config.wallet.get('name', bittensor.defaults.wallet.name) == 'mock' or config.wallet._mock:
             config.wallet._mock = True
             _mock = True
 
             return wallet_mock.Wallet_mock(
-                name = config.wallet.name, 
+                name = config.wallet.get('name', bittensor.defaults.wallet.name), 
                 hotkey = config.wallet.hotkey, 
                 path = config.wallet.path,
                 _mock = True,
             )
 
         return wallet_impl.Wallet(
-            name = config.wallet.name, 
+            name = config.wallet.get('name', bittensor.defaults.wallet.name), 
             hotkey = config.wallet.hotkey, 
             path = config.wallet.path,
         )
@@ -102,7 +102,7 @@ class wallet:
         """ Accept specific arguments from parser
         """
         try:
-            parser.add_argument('--wallet.name',required=False, default=bittensor.defaults.wallet.name, help='''The name of the wallet to unlock for running bittensor (name mock is reserved for mocking this wallet)''')
+            parser.add_argument('--wallet.name',required=False, default=None, help='''The name of the wallet to unlock for running bittensor (name mock is reserved for mocking this wallet)''')
             parser.add_argument('--wallet.hotkey', required=False, default=bittensor.defaults.wallet.hotkey, help='''The name of wallet's hotkey.''')
             parser.add_argument('--wallet.path',required=False, default=bittensor.defaults.wallet.path, help='''The path to your bittensor wallets''')
             parser.add_argument('--wallet._mock', action='store_true', default=bittensor.defaults.wallet._mock, help='To turn on wallet mocking for testing purposes.')
@@ -133,7 +133,7 @@ class wallet:
         """ Check config for wallet name/hotkey/path/hotkeys/sort_by
         """
         assert 'wallet' in config
-        assert isinstance(config.wallet.name, str)
+        assert isinstance(config.wallet.get('name', bittensor.defaults.wallet.name), str)
         assert isinstance(config.wallet.hotkey, str)
         assert isinstance(config.wallet.path, str)
         assert isinstance(config.wallet.hotkeys, list)

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -20,10 +20,13 @@
 import argparse
 import copy
 import os
+from typing import Optional
 
 import bittensor
-from . import wallet_impl
-from . import wallet_mock
+
+from . import wallet_impl, wallet_mock
+
+
 class wallet:
     """ Create and init wallet that stores hot and coldkey
     """
@@ -136,7 +139,7 @@ class wallet:
         """
         assert 'wallet' in config
         assert isinstance(config.wallet.get('name', bittensor.defaults.wallet.name), str)
-        assert isinstance(config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), str | None)
+        assert isinstance(config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), Optional[str])
         assert isinstance(config.wallet.path, str)
         assert isinstance(config.wallet.hotkeys, list)
         assert isinstance(config.wallet.sort_by, str)

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -136,7 +136,7 @@ class wallet:
         """
         assert 'wallet' in config
         assert isinstance(config.wallet.get('name', bittensor.defaults.wallet.name), str)
-        assert isinstance(config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), str)
+        assert isinstance(config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), str | None)
         assert isinstance(config.wallet.path, str)
         assert isinstance(config.wallet.hotkeys, list)
         assert isinstance(config.wallet.sort_by, str)

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -20,7 +20,6 @@
 import argparse
 import copy
 import os
-from typing import Optional
 
 import bittensor
 
@@ -139,7 +138,7 @@ class wallet:
         """
         assert 'wallet' in config
         assert isinstance(config.wallet.get('name', bittensor.defaults.wallet.name), str)
-        assert isinstance(config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), Optional[str])
+        assert isinstance(config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), (str, None))
         assert isinstance(config.wallet.path, str)
         assert isinstance(config.wallet.hotkeys, list)
         assert isinstance(config.wallet.sort_by, str)

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -57,7 +57,7 @@ class wallet:
             config = wallet.config()
         config = copy.deepcopy( config )
         config.wallet.name = name if name != None else config.wallet.get('name', bittensor.defaults.wallet.name)
-        config.wallet.hotkey = hotkey if hotkey != None else config.wallet.hotkey
+        config.wallet.hotkey = hotkey if hotkey != None else config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey)
         config.wallet.path = path if path != None else config.wallet.path
         config.wallet._mock = _mock if _mock != None else config.wallet._mock
         wallet.check_config( config )
@@ -68,14 +68,14 @@ class wallet:
 
             return wallet_mock.Wallet_mock(
                 name = config.wallet.get('name', bittensor.defaults.wallet.name), 
-                hotkey = config.wallet.hotkey, 
+                hotkey = config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), 
                 path = config.wallet.path,
                 _mock = True,
             )
 
         return wallet_impl.Wallet(
             name = config.wallet.get('name', bittensor.defaults.wallet.name), 
-            hotkey = config.wallet.hotkey, 
+            hotkey = config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), 
             path = config.wallet.path,
         )
 
@@ -102,8 +102,8 @@ class wallet:
         """ Accept specific arguments from parser
         """
         try:
-            parser.add_argument('--wallet.name',required=False, default=None, help='''The name of the wallet to unlock for running bittensor (name mock is reserved for mocking this wallet)''')
-            parser.add_argument('--wallet.hotkey', required=False, default=bittensor.defaults.wallet.hotkey, help='''The name of wallet's hotkey.''')
+            parser.add_argument('--wallet.name',required=False, default=argparse.SUPPRESS, help='''The name of the wallet to unlock for running bittensor (name mock is reserved for mocking this wallet)''')
+            parser.add_argument('--wallet.hotkey', required=False, default=argparse.SUPPRESS, help='''The name of wallet's hotkey.''')
             parser.add_argument('--wallet.path',required=False, default=bittensor.defaults.wallet.path, help='''The path to your bittensor wallets''')
             parser.add_argument('--wallet._mock', action='store_true', default=bittensor.defaults.wallet._mock, help='To turn on wallet mocking for testing purposes.')
             parser.add_argument('--wallet.hotkeys', required=False, action='store', default=bittensor.defaults.wallet.hotkeys, type=str, nargs='*', help='''Specify the hotkeys by name. (e.g. hk1 hk2 hk3)''')
@@ -134,7 +134,7 @@ class wallet:
         """
         assert 'wallet' in config
         assert isinstance(config.wallet.get('name', bittensor.defaults.wallet.name), str)
-        assert isinstance(config.wallet.hotkey, str)
+        assert isinstance(config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), str)
         assert isinstance(config.wallet.path, str)
         assert isinstance(config.wallet.hotkeys, list)
         assert isinstance(config.wallet.sort_by, str)


### PR DESCRIPTION
Previously, unset flags for `subtensor.network`, `wallet.name`, and `wallet.hotkey` had a default value that was not `None`
We would check the config to see if the defaults are set, in order to determine if we should prompt for a new value.
This is an issue because if a user wanted the default as the value, and set it with a flag, the user would still be prompted.

This PR changes the default flag value to `argparse.SUPPRESS`, which removes the value from the config namespace, and allows us to check if the flag was set at all.

To accommodate this, we also now check those values with `config.<parent>.get('<child>', <bittensor.default.<parent>.<child>)` to have the same effect as keeping the default