### PR TITLE
Bugfix circleci python version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,18 @@ jobs:
 
     steps:
       - checkout
+      -
+      - run:
+          name: Check Python Minor Version
+          command: |
+            export PYTHON_VERSION=$(python -V)
+            echo $PYTHON_VERSION
 
       - restore_cache:
           name: Restore cached venv
           keys:
-            - v1-pypi-py{{ checksum "~/.pyenv/versions/*/bin/python" }}-{{ checksum "requirements.txt" }}
-            - v1-pypi-py{{ checksum "~/.pyenv/versions/*/bin/python" }}
+            - v1-pypi-py{{ .Environment.PYTHON_VERSION }}-{{ checksum "requirements.txt" }}
+            - v1-pypi-py{{ .Environment.PYTHON_VERSION }}
 
       - run:
           name: Update & Activate venv
@@ -34,7 +40,7 @@ jobs:
           name: Save cached venv
           paths:
             - "env/"
-          key: v1-pypi-py{{ checksum "~/.pyenv/versions/*/bin/python" }}-{{ checksum "requirements.txt" }}
+          key: v1-pypi-py{{ .Environment.PYTHON_VERSION }}-{{ checksum "requirements.txt" }}
 
       - run:
           name: Install Bittensor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
           name: Combine Coverage
           command: |
             pip3 install --upgrade coveralls
-            coveralls --finish --rcfile .coveragerc
+            coveralls --finish --rcfile .coveragerc || echo "Failed to upload coverage"
 
 workflows:
   pre-pr:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Check Python Minor Version
           command: |
-            echp 'export PYTHON_VERSION=$(python -V)' >> $BASH_ENV
+            echo 'export PYTHON_VERSION=$(python -V)' >> $BASH_ENV
             python -V
 
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ jobs:
           name: Check Python Minor Version
           command: |
             echo 'test'
-            echo $(python -V)
-            echo 'export PYTHON_VERSION=$(python -V)' >> $BASH_ENV
+            #echo $(python -V)
+            #echo 'export PYTHON_VERSION=$(python -V)' >> $BASH_ENV
 
       - restore_cache:
           name: Restore cached venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,9 @@ jobs:
       - run:
           name: Check Python Minor Version
           command: |
-            echo 'export PYTHON_VERSION=$(python -V)' >> $BASH_ENV
+            echo 'test'
             echo $(python -V)
+            echo 'export PYTHON_VERSION=$(python -V)' >> $BASH_ENV
 
       - restore_cache:
           name: Restore cached venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
       - restore_cache:
           name: Restore cached venv
           keys:
-            - v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements.txt" }}
-            - v1-pypi-py<< parameters.python-version >>
+            - v1-pypi-py{{ checksum "~/.pyenv/versions/*/bin/python" }}-{{ checksum "requirements.txt" }}
+            - v1-pypi-py{{ checksum "~/.pyenv/versions/*/bin/python" }}
 
       - run:
           name: Update & Activate venv
@@ -34,7 +34,7 @@ jobs:
           name: Save cached venv
           paths:
             - "env/"
-          key: v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements.txt" }}
+          key: v1-pypi-py{{ checksum "~/.pyenv/versions/*/bin/python" }}-{{ checksum "requirements.txt" }}
 
       - run:
           name: Install Bittensor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,13 @@ jobs:
             CI_JOB_ID: $CIRCLE_NODE_INDEX
             COVERALLS_PARALLEL: true
 
+  test-all-versions:
+    docker:
+      - image: cimg/python:3.10
+    steps:
+      - run:
+          echo "Success"
+
   coveralls:
     docker:
       - image: cimg/python:3.10
@@ -105,6 +112,9 @@ workflows:
           matrix:
             parameters:
               python-version: ["3.7", "3.8", "3.9", "3.10.5"]
+      - test-all-versions:
+          - requires:
+              - build-and-test
       - coveralls:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,12 +88,13 @@ jobs:
             CI_JOB_ID: $CIRCLE_NODE_INDEX
             COVERALLS_PARALLEL: true
 
-  test-all-versions:
+  unit-tests-all-python-versions:
     docker:
       - image: cimg/python:3.10
     steps:
       - run:
-          echo "Success"
+          name: Placeholder command
+          command: echo "Success, only runs if all python versions ran"
 
   coveralls:
     docker:
@@ -112,9 +113,9 @@ workflows:
           matrix:
             parameters:
               python-version: ["3.7", "3.8", "3.9", "3.10.5"]
-      - test-all-versions:
-          - requires:
-              - build-and-test
+      - unit-tests-all-python-versions:
+          requires:
+            - build-and-test
       - coveralls:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
       - run:
           name: Check Python Minor Version
           command: |
-            export PYTHON_VERSION=$(python -V)
-            echo $PYTHON_VERSION
+            echp 'export PYTHON_VERSION=$(python -V)' >> $BASH_ENV
+            python -V
 
       - restore_cache:
           name: Restore cached venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: Check Python Minor Version
           command: |
             echo 'export PYTHON_VERSION=$(python -V)' >> $BASH_ENV
-            python -V
+            echo $(python -V)
 
       - restore_cache:
           name: Restore cached venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,18 +17,11 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Check Python Minor Version
-          command: |
-            echo 'test'
-            #echo $(python -V)
-            #echo 'export PYTHON_VERSION=$(python -V)' >> $BASH_ENV
-
       - restore_cache:
           name: Restore cached venv
           keys:
-            - v1-pypi-py{{ .Environment.PYTHON_VERSION }}-{{ checksum "requirements.txt" }}
-            - v1-pypi-py{{ .Environment.PYTHON_VERSION }}
+            - v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements.txt" }}
+            - v1-pypi-py<< parameters.python-version >>
 
       - run:
           name: Update & Activate venv
@@ -41,7 +34,7 @@ jobs:
           name: Save cached venv
           paths:
             - "env/"
-          key: v1-pypi-py{{ .Environment.PYTHON_VERSION }}-{{ checksum "requirements.txt" }}
+          key: v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements.txt" }}
 
       - run:
           name: Install Bittensor
@@ -111,7 +104,7 @@ workflows:
       - build-and-test:
           matrix:
             parameters:
-              python-version: ["3.7", "3.8", "3.9", "3.10"]
+              python-version: ["3.7", "3.8", "3.9", "3.10.5"]
       - coveralls:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - checkout
-      -
+
       - run:
           name: Check Python Minor Version
           command: |


### PR DESCRIPTION
Fixes an issue in circleCI where builds will fail when the minor version of python gets bumped on circleCI. The cached `venv` would point to the old minor version and fail to execute any tests.

Also snuck in a fix for when people fork our repo, they can't run coverage because the token is secret so we don't pass it. So far external pulls have been documentation / minor enough that they wouldn't affect coverage.