### PR TITLE
Fix balance formatting issue

### DIFF
--- a/bittensor/utils/balance.py
+++ b/bittensor/utils/balance.py
@@ -49,7 +49,7 @@ class Balance:
         return self.tao
 
     def __str__(self):
-        return f"{self.unit}{float(self.tao):,.9f}".replace(".", ",")
+        return f"{self.unit}{float(self.tao):,.9f}"
 
     def __rich__(self):
         return "[green]{}[/green][green]{}[/green][green].[/green][dim green]{}[/dim green]".format(


### PR DESCRIPTION
Fixes an issue where balances were formatted entirely with commas,

e.g.
```
τ1,497,49
```
is now displayed correctly as:
```
τ1,497.49
```