### PR TITLE
Bit 490 synapse one fail drag all down

### DIFF
--- a/bittensor/_axon/axon_impl.py
+++ b/bittensor/_axon/axon_impl.py
@@ -179,7 +179,7 @@ class Axon( bittensor.grpc.BittensorServicer ):
         synapse_messages = [ "Success" for _ in synapses ]
         synapse_codes = [ bittensor.proto.ReturnCode.Success for _ in synapses ]
         synapse_inputs = [ None for _ in synapses ]
-        synapse_responses = [ None for _ in synapses ] # We fill nones for non success.
+        synapse_responses = [ synapse.empty() for synapse in synapses ] # We fill nones for non success.
         synapse_is_response = [ False for _ in synapses ]
         synapse_call_times = [ 0 for _ in synapses ]
         start_time = clock.time()
@@ -286,7 +286,7 @@ class Axon( bittensor.grpc.BittensorServicer ):
                     inputs_x = deserialized_forward_tensors,
                     synapses = synapses,
                 )
-            
+
             synapse_is_response = [ True for _ in synapses ]
             # ========================================
             # ==== Fill codes from forward calls ====
@@ -331,7 +331,6 @@ class Axon( bittensor.grpc.BittensorServicer ):
                     synapse_responses [ index ] = synapse.serialize_forward_response_tensor( deserialized_forward_tensors[ index ], forward_response_tensors [ index ] )
                 else:
                     synapse_responses [ index ] = synapse.empty()
-                response_synapses.append(synapse.serialize_to_wire_proto(code = synapse_codes[index], message= synapse_messages[index] ))
 
             except ValueError as e:
                 if str(e) == 'Empty Response':
@@ -341,11 +340,15 @@ class Axon( bittensor.grpc.BittensorServicer ):
 
                 synapse_call_times [ index ] = clock.time() - start_time
                 synapse_messages [index] = "Synapse response shape exception with error: {}".format( str( e ) )
+                synapse_responses [ index ] = synapse.empty()
 
             except Exception as e:
                 synapse_codes [ index ]= bittensor.proto.ReturnCode.ResponseSerializationException
                 synapse_call_times [ index ] = clock.time() - start_time
                 synapse_messages [index] = "Synapse response serialization exception with error: {}".format( str( e ) )
+                synapse_responses [ index ] = synapse.empty()
+            
+            response_synapses.append(synapse.serialize_to_wire_proto(code = synapse_codes[index], message= synapse_messages[index] ))
         # Check if the call can stop here.
         if check_if_should_return():
             finalize_codes_stats_and_logs()

--- a/bittensor/_neuron/text/core_server/run.py
+++ b/bittensor/_neuron/text/core_server/run.py
@@ -284,6 +284,12 @@ def serve(
             
             if iteration != 0:
                 (losses/iteration).backward()
+        
+        else:
+            while end_block >= current_block:
+                time.sleep(12)
+                current_block = subtensor.get_current_block()
+
 
         # --- Update parameters
         if (config.neuron.local_train and iteration > 0) or (config.neuron.remote_train and model.backward_gradients_count > 0):
@@ -300,6 +306,10 @@ def serve(
             model.backward_gradients = 0
             logger.info('Backpropagation Successful: Model updated')
             local_data = {'local/loss': losses.detach().item() / iteration}
+
+            if local_data['local/loss'] < model.best_loss:
+                model.best_loss = local_data['local/loss']
+                model.save(config.neuron.full_path)
 
         wandb_data = {            
             'stake': nn.stake,
@@ -321,9 +331,6 @@ def serve(
             wandb.log( { **wandb_data, **wandb_info_axon, **local_data }, step = current_block )
             wandb.log( { 'stats': wandb.Table( dataframe = df ) }, step = current_block )
 
-        if local_data['local/loss'] < model.best_loss:
-            model.best_loss = local_data['local/loss']
-            model.save(config.neuron.full_path)
 
         if current_block - last_set_block > config.neuron.blocks_per_set_weights:
             try: 

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -790,7 +790,7 @@ class nucleus( torch.nn.Module ):
                           'routing_score': routing_score[_uid]}
                 
                 _stats.update({'logits': query_responses[index][index_s],
-                               'logits_val': torch.cat([ res[idx-1].reshape() for res, idx in zip (query_responses[index][index_s], non_eos_indices)])})
+                               'logits_val': torch.cat([ res[idx-1] for res, idx in zip (query_responses[index][index_s], non_eos_indices)])})
 
                 for target, ext in [(inputs_seq, ''), (inputs_val, '_val')]:
                     _loss = self.get_target_loss_casuallm(_stats['logits' + ext], target, eval_type = ext)  # CausalLM loss


### PR DESCRIPTION
Some bug fixes
- axon side: synapse response default to be synapse.empty()
- axon side: even if one of the synapse failed, the running result should always be added to response_synapses.
- if core server is not training locally or remotely, then it should sleep through the block time
- update model only if we do local train or remote train
- remove empty reshape in core validator