### PR TITLE
Read coldkey password from environment variables

### DIFF
--- a/bittensor/_keyfile/keyfile_impl.py
+++ b/bittensor/_keyfile/keyfile_impl.py
@@ -191,28 +191,11 @@ def encrypt_keyfile_data ( keyfile_data:bytes, password: str = None ) -> bytes:
 
 def get_coldkey_password_from_environment(coldkey_name: str) -> Optional[str]:
 
-    # hey bro i heard u like list comprehensions
-    try:
-        return str(
-            os.environ[
-                [
-                    x
-                    for x in list(
-                        map(
-                            lambda x: x if coldkey_name in x.lower() else None,
-                            {
-                                env_var
-                                for env_var in os.environ
-                                if "bittensor_cold_pw_" in env_var.lower()
-                            },
-                        )
-                    )
-                    if x is not None
-                ][0]
-            ]
-        )
-    except IndexError:
-        return None
+    candidate_pw_vars = set()
+    for env_var in os.environ:
+        if env_var.lower().startswith("bittensor_cold_pw_") and coldkey_name.lower() in env_var.lower():
+            return os.getenv(env_var)
+    return None
 
 
 def decrypt_keyfile_data(keyfile_data: bytes, password: str = None, coldkey_name: Optional[str] = None) -> bytes:

--- a/bittensor/_keyfile/keyfile_impl.py
+++ b/bittensor/_keyfile/keyfile_impl.py
@@ -21,6 +21,8 @@ import json
 import stat
 import getpass
 import bittensor
+from typing import Optional
+from pathlib import Path
 
 from ansible_vault import Vault
 from cryptography.exceptions import InvalidSignature, InvalidKey
@@ -186,7 +188,34 @@ def encrypt_keyfile_data ( keyfile_data:bytes, password: str = None ) -> bytes:
         vault = Vault( password )
     return vault.vault.encrypt ( keyfile_data )
 
-def decrypt_keyfile_data( keyfile_data: bytes, password: str = None) -> bytes:
+
+def get_coldkey_password_from_environment(coldkey_name: str) -> Optional[str]:
+
+    # hey bro i heard u like list comprehensions
+    try:
+        return str(
+            os.environ[
+                [
+                    x
+                    for x in list(
+                        map(
+                            lambda x: x if coldkey_name in x.lower() else None,
+                            {
+                                env_var
+                                for env_var in os.environ
+                                if "bittensor_cold_pw_" in env_var.lower()
+                            },
+                        )
+                    )
+                    if x is not None
+                ][0]
+            ]
+        )
+    except IndexError:
+        return None
+
+
+def decrypt_keyfile_data(keyfile_data: bytes, password: str = None, coldkey_name: Optional[str] = None) -> bytes:
     """ Decrypts passed keyfile data using ansible vault.
         Args:
             keyfile_data ( bytes, required ):
@@ -200,9 +229,11 @@ def decrypt_keyfile_data( keyfile_data: bytes, password: str = None) -> bytes:
             KeyFileError:
                 Raised if the file is corrupted or if the password is incorrect.
     """
-    password = getpass.getpass("Enter password to unlock key: ") if password == None else password
+    if coldkey_name is not None:
+        password = get_coldkey_password_from_environment(coldkey_name)
+
     try:
-        password = getpass.getpass("Enter password to unlock key: ") if password == None else password
+        password = getpass.getpass("Enter password to unlock key: ") if password is None else password
         console = bittensor.__console__;             
         with console.status(":key: Decrypting key..."):
             # Ansible decrypt.
@@ -232,6 +263,7 @@ class Keyfile( object ):
     """
     def __init__( self, path: str ):
         self.path = os.path.expanduser(path)
+        self.name = Path(self.path).parent.stem
 
     def __str__(self):
         if not self.exists_on_device():
@@ -320,7 +352,7 @@ class Keyfile( object ):
         """
         keyfile_data = self._read_keyfile_data_from_file()
         if keyfile_data_is_encrypted( keyfile_data ):
-            keyfile_data = decrypt_keyfile_data( keyfile_data, password)
+            keyfile_data = decrypt_keyfile_data(keyfile_data, password, coldkey_name=self.name)
         return deserialize_keypair_from_keyfile_data( keyfile_data )
 
     def make_dirs( self ):
@@ -418,7 +450,7 @@ class Keyfile( object ):
             raise KeyFileError( "No write access for {}".format( self.path ) ) 
         keyfile_data = self._read_keyfile_data_from_file()
         if keyfile_data_is_encrypted( keyfile_data ):
-            keyfile_data = decrypt_keyfile_data( keyfile_data, password )
+            keyfile_data = decrypt_keyfile_data(keyfile_data, password, coldkey_name=self.name)
         as_keypair = deserialize_keypair_from_keyfile_data( keyfile_data )
         keyfile_data = serialized_keypair_to_keyfile_data( as_keypair )
         self._write_keyfile_data_to_file( keyfile_data, overwrite = True )

--- a/bittensor/_keyfile/keyfile_impl.py
+++ b/bittensor/_keyfile/keyfile_impl.py
@@ -229,7 +229,7 @@ def decrypt_keyfile_data(keyfile_data: bytes, password: str = None, coldkey_name
             KeyFileError:
                 Raised if the file is corrupted or if the password is incorrect.
     """
-    if coldkey_name is not None:
+    if coldkey_name is not None and password is not None:
         password = get_coldkey_password_from_environment(coldkey_name)
 
     try:

--- a/bittensor/_keyfile/keyfile_impl.py
+++ b/bittensor/_keyfile/keyfile_impl.py
@@ -188,12 +188,13 @@ def encrypt_keyfile_data ( keyfile_data:bytes, password: str = None ) -> bytes:
         vault = Vault( password )
     return vault.vault.encrypt ( keyfile_data )
 
-
 def get_coldkey_password_from_environment(coldkey_name: str) -> Optional[str]:
 
-    candidate_pw_vars = set()
     for env_var in os.environ:
-        if env_var.lower().startswith("bittensor_cold_pw_") and coldkey_name.lower() in env_var.lower():
+        if (
+            env_var.lower().startswith("bittensor_cold_pw_")
+            and coldkey_name.lower() in env_var.lower()
+        ):
             return os.getenv(env_var)
     return None
 

--- a/bittensor/_keyfile/keyfile_impl.py
+++ b/bittensor/_keyfile/keyfile_impl.py
@@ -188,14 +188,16 @@ def encrypt_keyfile_data ( keyfile_data:bytes, password: str = None ) -> bytes:
         vault = Vault( password )
     return vault.vault.encrypt ( keyfile_data )
 
+
 def get_coldkey_password_from_environment(coldkey_name: str) -> Optional[str]:
 
     for env_var in os.environ:
         if (
-            env_var.lower().startswith("bittensor_cold_pw_")
-            and coldkey_name.lower() in env_var.lower()
+            env_var.upper().startswith("BT_COLD_PW_")
+            and env_var.upper().endswith(coldkey_name.upper())
         ):
             return os.getenv(env_var)
+
     return None
 
 

--- a/bittensor/_keyfile/keyfile_impl.py
+++ b/bittensor/_keyfile/keyfile_impl.py
@@ -229,7 +229,7 @@ def decrypt_keyfile_data(keyfile_data: bytes, password: str = None, coldkey_name
             KeyFileError:
                 Raised if the file is corrupted or if the password is incorrect.
     """
-    if coldkey_name is not None and password is not None:
+    if coldkey_name is not None and password is None:
         password = get_coldkey_password_from_environment(coldkey_name)
 
     try:


### PR DESCRIPTION
Allows reading in the password for btcli operations from an environment variable rather than explicitly from the commandline. If you don't pass the `--no_prompt` flag, you will still be prompted before performing a stake/unstake/transfer etc. as a safeguard.

This will search your current environment variables for something formatted as `BT_COLD_PW_XXXX` where `XXXX` is the name of your coldkey (in order to enable automatic staking for those with multiple cold keys on the same machine).

Note that coldkey names are *not* case sensitive. What kind of monster has keys with the same name with different capitalization to differentiate them?? why would we even support that in the first place?

example usage:
```
btcli stake --amount 10  --subtensor.network nobunaga --wallet.name my_test_wallet --wallet.hotkey default --no_prompt 
```