### PR TITLE
bump because the pinned version was pulled

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cryptography>=3.1.1
 idna>=2.10
 jinja2>=3.0
 fuzzywuzzy==0.18.0
-python-levenshtein==0.12
+python-levenshtein==0.12.1
 google-api-python-client
 grpcio==1.42.0
 grpcio-tools==1.42.0


### PR DESCRIPTION
https://pypi.org/project/python-Levenshtein/#changelog 

> 0.12.1: Fixed handling of numerous possible wraparounds in calculating the size of memory allocations; incorrect handling of which could cause denial of service or even possible remote code execution in previous versions of the library.

Seems we should bump the versioning :|

Or maybe we can use a maintained fork https://github.com/maxbachmann/Levenshtein