### PR TITLE
Adds flag --wallet.reregister <bool>

### DIFF
--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -483,6 +483,7 @@ class server(torch.nn.Module):
         parser.add_argument('--neuron.finetune.all', action='store_true', help='Finetune your whole model instead of only on the last (few) layers', default=False)
         parser.add_argument('--neuron.finetune.num_layers', type=int, help='The number of layers to finetune on your model.', default=1)
         parser.add_argument('--neuron.finetune.layer_name', type=str, help='Specify since which layer to finetune. eg. encoder.layer.11', default=None)
+        parser.add_argument('--neuron.reregister', type=bool, help='If set, reregister the neuron if it is de-registered.', default=True)
 
 
 

--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -483,7 +483,6 @@ class server(torch.nn.Module):
         parser.add_argument('--neuron.finetune.all', action='store_true', help='Finetune your whole model instead of only on the last (few) layers', default=False)
         parser.add_argument('--neuron.finetune.num_layers', type=int, help='The number of layers to finetune on your model.', default=1)
         parser.add_argument('--neuron.finetune.layer_name', type=str, help='Specify since which layer to finetune. eg. encoder.layer.11', default=None)
-        parser.add_argument('--neuron.reregister', type=bool, help='If set, reregister the neuron if it is de-registered.', default=True)
 
 
 

--- a/bittensor/_neuron/text/core_server/run.py
+++ b/bittensor/_neuron/text/core_server/run.py
@@ -51,18 +51,9 @@ def serve(
 
     # Load/Create our bittensor wallet.
     if wallet == None:
-        wallet = bittensor.wallet( config = config ).create()
-    
-    # Check if wallet is registered. 
-    ## Optionally, register the wallet.
-    if not wallet.is_registered(subtensor=subtensor):
-        logger.info(f'Wallet is not registered on {str(subtensor.network)}.')
-        if config.neuron.reregister:
-            wallet.register(subtensor=subtensor)
-        else:
-            # Exit if we are not registered and we do not want to reregister.
-            logger.info('The --neuron.reregister flag is set to False. Exiting.')
-            return None
+        wallet = bittensor.wallet( config = config ).create().register(subtensor=subtensor) 
+    else:
+        wallet.register(subtensor=subtensor)
 
 
     # Load/Sync/Save our metagraph.

--- a/bittensor/_neuron/text/core_server/run.py
+++ b/bittensor/_neuron/text/core_server/run.py
@@ -51,9 +51,18 @@ def serve(
 
     # Load/Create our bittensor wallet.
     if wallet == None:
-        wallet = bittensor.wallet( config = config ).create().register(subtensor=subtensor) 
-    else:
-        wallet.register(subtensor=subtensor)
+        wallet = bittensor.wallet( config = config ).create()
+    
+    # Check if wallet is registered. 
+    ## Optionally, register the wallet.
+    if not wallet.is_registered(subtensor=subtensor):
+        logger.info(f'Wallet is not registered on {str(subtensor.network)}.')
+        if config.neuron.reregister:
+            wallet.register(subtensor=subtensor)
+        else:
+            # Exit if we are not registered and we do not want to reregister.
+            logger.info('The --neuron.reregister flag is set to False. Exiting.')
+            return None
 
 
     # Load/Sync/Save our metagraph.

--- a/bittensor/_neuron/text/core_server/run.py
+++ b/bittensor/_neuron/text/core_server/run.py
@@ -51,9 +51,9 @@ def serve(
 
     # Load/Create our bittensor wallet.
     if wallet == None:
-        wallet = bittensor.wallet( config = config ).create().register(subtensor=subtensor) 
+        wallet = bittensor.wallet( config = config ).create().reregister(subtensor=subtensor) 
     else:
-        wallet.register(subtensor=subtensor)
+        wallet.reregister(subtensor=subtensor)
 
 
     # Load/Sync/Save our metagraph.

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -206,9 +206,11 @@ class neuron:
         r""" Sanity checks and begin validator.
         """
         # === Wallet ===
-        # Connects wallett to network. 
+        # Connects wallet to network. 
+        self.wallet.create()
         # NOTE: This registration step should likely be solved offline first.
-        self.wallet.create().register( subtensor = self.subtensor )
+        self.wallet.reregister( subtensor = self.subtensor )
+
 
         # === UID ===
         # Get our uid from the chain. 

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -175,7 +175,6 @@ class neuron:
         parser.add_argument('--neuron._mock', action='store_true', help='To turn on neuron mocking for testing purposes.', default=False )
         parser.add_argument('--neuron.wait_for_finalization', action='store_true', help='''when setting weights the miner waits for trnasaction finalization.''', default=False)
         parser.add_argument('--neuron.forward_num', type=int, help='''How much forward request before a backward call.''', default=3)
-        parser.add_argument('--neuron.reregister', type=bool, help='If set, reregister the neuron if it is de-registered.', default=True)
 
     @classmethod
     def config ( cls ):
@@ -207,18 +206,9 @@ class neuron:
         r""" Sanity checks and begin validator.
         """
         # === Wallet ===
-        # Connects wallet to network. 
-        self.wallet.create()
-        # Check if wallet is registered and optionally reregister if not.
+        # Connects wallett to network. 
         # NOTE: This registration step should likely be solved offline first.
-        if not self.wallet.is_registered( subtensor = self.subtensor ):
-            logger.info(f'Wallet is not registered on {str(self.subtensor.network)}.')
-            if self.config.neuron.reregister:
-                self.wallet.register( subtensor = self.subtensor )
-            else:
-                # Exit if we are not registered and we do not want to reregister.
-                logger.info('The --neuron.reregister flag is set to False. Exiting.')
-                return None
+        self.wallet.create().register( subtensor = self.subtensor )
 
         # === UID ===
         # Get our uid from the chain. 

--- a/bittensor/_neuron/text/template_miner/__init__.py
+++ b/bittensor/_neuron/text/template_miner/__init__.py
@@ -228,9 +228,9 @@ class neuron:
         r""" Sanity checks and begin miner-validator.
         """
         # === Wallet ===
-        # Connects wallett to network. 
+        # Connects wallet to network. 
         # NOTE: This registration step should likely be solved offline first.
-        self.wallet.register( subtensor = self.subtensor )
+        self.wallet.reregister( subtensor = self.subtensor )
 
         # === UID ===
         # Get our uid from the chain. 

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -73,12 +73,14 @@ class wallet:
                 hotkey = config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), 
                 path = config.wallet.path,
                 _mock = True,
+                config = config
             )
 
         return wallet_impl.Wallet(
             name = config.wallet.get('name', bittensor.defaults.wallet.name), 
             hotkey = config.wallet.get('hotkey', bittensor.defaults.wallet.hotkey), 
             path = config.wallet.path,
+            config = config
         )
 
     @classmethod   
@@ -113,6 +115,7 @@ class wallet:
             parser.add_argument('--' + prefix_str + 'wallet.all_hotkeys', required=False, action='store_true', default=bittensor.defaults.wallet.all_hotkeys, help='''To specify all hotkeys. Specifying hotkeys will exclude them from this all.''')
             parser.add_argument('--' + prefix_str + 'wallet.sort_by', required=False, action='store', default=bittensor.defaults.wallet.sort_by, type=str, help='''Sort the hotkeys by the specified column title (e.g. name, uid, axon).''')
             parser.add_argument('--' + prefix_str + 'wallet.sort_order', required=False, action='store', default=bittensor.defaults.wallet.sort_order, type=str, help='''Sort the hotkeys in the specified ordering. (ascending/asc or descending/desc/reverse)''')
+            parser.add_argument('--' + prefix_str + 'wallet.reregister', required=False, action='store', default=bittensor.defaults.wallet.reregister, type=bool, help='''Whether to reregister the wallet if it is not already registered.''')
         except argparse.ArgumentError as e:
             import pdb
             #pdb.set_trace()
@@ -133,6 +136,8 @@ class wallet:
         defaults.wallet.all_hotkeys = False
         defaults.wallet.sort_by = ""
         defaults.wallet.sort_order = "ascending"
+        # Defaults for registration
+        defaults.wallet.reregister = True
 
     @classmethod   
     def check_config(cls, config: 'bittensor.Config' ):
@@ -145,3 +150,4 @@ class wallet:
         assert isinstance(config.wallet.hotkeys, list)
         assert isinstance(config.wallet.sort_by, str)
         assert isinstance(config.wallet.sort_order, str)
+        assert isinstance(config.wallet.reregister, bool)

--- a/tests/unit_tests/bittensor_tests/test_neuron.py
+++ b/tests/unit_tests/bittensor_tests/test_neuron.py
@@ -1,6 +1,13 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 import bittensor
-import torch 
+import torch
 import torch.nn as nn
+from bittensor._subtensor import subtensor
+from bittensor._subtensor.subtensor_mock import mock_subtensor
 from torch.nn import TransformerEncoder, TransformerEncoderLayer
 
 
@@ -54,6 +61,231 @@ def test_set_fine_tuning_params():
     core_server.pre_model = Model()
     core_server.config.neuron.finetune.layer_name = None
     assert core_server.set_fine_tuning_params() == (False, None) 
+
+def test_coreserver_reregister_flag_false_exit():
+    config = bittensor.Config()
+    config.neuron = bittensor.Config()
+    config.neuron.reregister = False
+
+    mock_wallet = MagicMock(
+        is_registered=MagicMock(return_value=False), # mock the wallet as not registered
+    )
+    mock_subtensor = MagicMock()
+    mock_model = MagicMock(
+        to=MagicMock(return_value=None),
+        device=None
+    )
+
+    with patch('bittensor.metagraph') as mock_metagraph:
+        class MockException(Exception):
+            pass
+
+        def exit_early():
+            raise MockException('exit_early')
+
+        mock_metagraph.return_value = MagicMock(
+            load=exit_early
+        )
+
+        # Should not raise MockException
+        bittensor.neurons.core_server.run.serve(
+                config=config,
+                model=mock_model,
+                subtensor=mock_subtensor,
+                wallet=mock_wallet,
+                axon=None,
+                metagraph=None,
+        )
+
+        # Should have exited before creating a metagraph object
+        mock_metagraph.assert_not_called()
+
+def test_coreserver_reregister_flag_true():
+    config = bittensor.Config()
+    config.neuron = bittensor.Config()
+    config.neuron.reregister = True
+
+    mock_wallet = MagicMock(
+        is_registered=MagicMock(return_value=False), # mock the wallet as not registered
+    )
+    mock_subtensor = MagicMock()
+    mock_model = MagicMock(
+        to=MagicMock(return_value=None),
+        device=None
+    )
+
+    with patch('bittensor.metagraph') as mock_metagraph:
+        class MockException(Exception):
+            pass
+
+        def exit_early():
+            raise MockException('exit_early')
+
+        mock_metagraph.return_value = MagicMock(
+            load=exit_early
+        )
+
+        with pytest.raises(MockException):
+            # Should raise MockException
+            bittensor.neurons.core_server.run.serve(
+                    config=config,
+                    model=mock_model,
+                    subtensor=mock_subtensor,
+                    wallet=mock_wallet,
+                    axon=None,
+                    metagraph=None,
+            )
+
+        # Should have continued to creating a metagraph object
+        mock_metagraph.assert_called_once()
+
+def test_corevalidator_reregister_flag_false_exit():
+    config = bittensor.Config()
+    config.neuron = bittensor.Config()
+    config.neuron.reregister = False
+
+    mock_register_func = MagicMock()
+
+    class MockException(Exception):
+        pass
+
+    def exit_early(*args, **kwargs):
+        raise MockException('exit_early')
+
+    mock_wallet = MagicMock(
+        is_registered=MagicMock(return_value=False), # mock the wallet as not registered
+        create=MagicMock(return_value=None),
+        register=mock_register_func,
+        get_uid=exit_early
+    )
+
+    mock_self_neuron=MagicMock(
+        wallet=mock_wallet,
+        spec=bittensor.neurons.core_validator.neuron,
+        subtensor=MagicMock(
+            network="mock"
+        ),
+        config=config,
+    )
+
+    # Should not raise MockException
+    bittensor.neurons.core_validator.neuron.__enter__(
+        self=mock_self_neuron
+    )
+
+    # Should not try to register the neuron
+    mock_register_func.assert_not_called()
+
+def test_corevalidator_reregister_flag_true():
+    config = bittensor.Config()
+    config.neuron = bittensor.Config()
+    config.neuron.reregister = True
+
+    mock_register_func = MagicMock()
+
+    class MockException(Exception):
+        pass
+
+    def exit_early(*args, **kwargs):
+        raise MockException('exit_early')
+
+    mock_wallet = MagicMock(
+        is_registered=MagicMock(return_value=False), # mock the wallet as not registered
+        create=MagicMock(return_value=None),
+        register=mock_register_func,
+        get_uid=exit_early
+    )
+
+    mock_self_neuron=MagicMock(
+        wallet=mock_wallet,
+        spec=bittensor.neurons.core_validator.neuron,
+        subtensor=MagicMock(
+            network="mock"
+        ),
+        config=config,
+    )
+
+    with pytest.raises(MockException):
+        # Should raise MockException
+        bittensor.neurons.core_validator.neuron.__enter__(
+            self=mock_self_neuron
+        )
+
+    # Should try to register the neuron
+    mock_register_func.assert_called_once()
+
+def test_templateminer_reregister_flag_false_exit():
+    config = bittensor.Config()
+    config.neuron = bittensor.Config()
+    config.neuron.reregister = False
+
+    mock_register_func = MagicMock()
+
+    class MockException(Exception):
+        pass
+
+    def exit_early(*args, **kwargs):
+        raise MockException('exit_early')
+
+    mock_wallet = MagicMock(
+        is_registered=MagicMock(return_value=False), # mock the wallet as not registered
+        register=mock_register_func,
+        get_uid=exit_early
+    )
+
+    mock_self_neuron=MagicMock(
+        wallet=mock_wallet,
+        spec=bittensor.neurons.core_validator.neuron,
+        subtensor=MagicMock(
+            network="mock"
+        ),
+        config=config,
+    )
+
+    # Should not raise MockException
+    bittensor.neurons.template_miner.neuron.__enter__(
+        self=mock_self_neuron
+    )
+
+    # Should not try to register the neuron
+    mock_register_func.assert_not_called()
+
+def test_templateminer_reregister_flag_true():
+    config = bittensor.Config()
+    config.neuron = bittensor.Config()
+    config.neuron.reregister = True
+
+    mock_register_func = MagicMock()
+
+    class MockException(Exception):
+        pass
+
+    def exit_early(*args, **kwargs):
+        raise MockException('exit_early')
+
+    mock_wallet = MagicMock(
+        is_registered=MagicMock(return_value=False), # mock the wallet as not registered
+        register=mock_register_func,
+        get_uid=exit_early
+    )
+
+    mock_self_neuron=MagicMock(
+        wallet=mock_wallet,
+        spec=bittensor.neurons.template_miner.neuron,
+        subtensor=MagicMock(
+            network="mock"
+        ),
+        config=config,
+    )
+
+    with pytest.raises(MockException):
+        # Should raise MockException
+        bittensor.neurons.core_validator.neuron.__enter__(
+            self=mock_self_neuron
+        )
+
+    # Should try to register the neuron
+    mock_register_func.assert_called_once()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR addresses #804 
If the wallet is not registered, by default, it will attempt to re-register the wallet
if the flag `--wallet.reregister` is set to `false`, it will exit with `0` instead.

If using pm2, the restart of the miner can be prevented using:  
https://pm2.keymetrics.io/docs/usage/restart-strategies/#skip-auto-restart-for-specific-exit-codes

Edit: changed the flag to `--wallet.reregister`