### PR TITLE
Fix python version for code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,17 +78,21 @@ jobs:
       - store_artifacts:
           path: test-results
 
-      - run:
-          name: Upload Coverage
-          command: |
-            . env/bin/activate && coveralls
-          env:
-            CI_NAME: circleci
-            CI_BUILD_NUMBER: $CIRCLE_BUILD_NUM
-            CI_BUILD_URL: $CIRCLE_BUILD_URL
-            CI_BRANCH: $CIRCLE_BRANCH
-            CI_JOB_ID: $CIRCLE_NODE_INDEX
-            COVERALLS_PARALLEL: true
+      -when:
+        condition:
+          equal: ["3.10.5", << parameters.python_version >> ]
+        steps:
+          - run:
+              name: Upload Coverage
+              command: |
+                . env/bin/activate && coveralls
+              env:
+                CI_NAME: circleci
+                CI_BUILD_NUMBER: $CIRCLE_BUILD_NUM
+                CI_BUILD_URL: $CIRCLE_BUILD_URL
+                CI_BRANCH: $CIRCLE_BRANCH
+                CI_JOB_ID: $CIRCLE_NODE_INDEX
+                COVERALLS_PARALLEL: true
 
   unit-tests-all-python-versions:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,21 +78,21 @@ jobs:
       - store_artifacts:
           path: test-results
 
-      -when:
-        condition:
-          equal: ["3.10.5", << parameters.python_version >> ]
-        steps:
-          - run:
-              name: Upload Coverage
-              command: |
-                . env/bin/activate && coveralls
-              env:
-                CI_NAME: circleci
-                CI_BUILD_NUMBER: $CIRCLE_BUILD_NUM
-                CI_BUILD_URL: $CIRCLE_BUILD_URL
-                CI_BRANCH: $CIRCLE_BRANCH
-                CI_JOB_ID: $CIRCLE_NODE_INDEX
-                COVERALLS_PARALLEL: true
+      - when:
+          condition:
+            equal: ["3.10.5", << parameters.python_version >> ]
+          steps:
+            - run:
+                name: Upload Coverage
+                command: |
+                  . env/bin/activate && coveralls
+                env:
+                  CI_NAME: circleci
+                  CI_BUILD_NUMBER: $CIRCLE_BUILD_NUM
+                  CI_BUILD_URL: $CIRCLE_BUILD_URL
+                  CI_BRANCH: $CIRCLE_BRANCH
+                  CI_JOB_ID: $CIRCLE_NODE_INDEX
+                  COVERALLS_PARALLEL: true
 
   unit-tests-all-python-versions:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
 
       - when:
           condition:
-            equal: ["3.10.5", << parameters.python_version >> ]
+            equal: ["3.10.5", << parameters.python-version >> ]
           steps:
             - run:
                 name: Upload Coverage


### PR DESCRIPTION
Coverage reports are giving weird stochastic numbers. This may be a consequence of mixing results from different python versions. Regardless, we only report coverage for the highest python version we run tests for now.