### PR TITLE
[BIT-484] Add TextCausalLMNext

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -129,6 +129,7 @@ from bittensor._threadpool.priority_thread_pool_impl import PriorityThreadPoolEx
 from bittensor._ipfs.ipfs_impl import Ipfs as Ipfs
 from bittensor._synapse.synapse_impl import Synapse as Synapse
 from bittensor._synapse.text_causallm_impl import TextCausalLM as TextCausalLM
+from bittensor._synapse.text_causallmnext_impl import TextCausalLMNext as TextCausalLMNext
 from bittensor._synapse.text_lasthiddenstate_impl import TextLastHiddenState as TextLastHiddenState
 from bittensor._synapse.text_seq2seq_impl import TextSeq2Seq as TextSeq2Seq
 

--- a/bittensor/_axon/__init__.py
+++ b/bittensor/_axon/__init__.py
@@ -53,6 +53,7 @@ class axon:
             backward_text: 'Callable' = None,
             synapse_last_hidden: 'Callable' = None,
             synapse_causal_lm: 'Callable' = None,
+            synapse_causal_lm_next: 'Callable' = None,
             synapse_seq_2_seq: 'Callable' = None,
             synapse_checks: 'Callable' = None,
             thread_pool: 'futures.ThreadPoolExecutor' = None,
@@ -81,6 +82,8 @@ class axon:
                     function which is called by the last hidden synapse
                 synapse_causal_lm (:obj:`callable`, `optional`):
                     function which is called by the causal lm synapse
+                synapse_causal_lm_next (:obj:`callable`, `optional`):
+                    function which is called by the TextCausalLMNext synapse
                 synapse_seq_2_seq (:obj:`callable`, `optional`):
                     function which is called by the seq2seq synapse   
                 synapse_checks (:obj:`callable`, 'optional'):
@@ -142,6 +145,7 @@ class axon:
         synapses = {}
         synapses[bittensor.proto.Synapse.SynapseType.TEXT_LAST_HIDDEN_STATE] = synapse_last_hidden
         synapses[bittensor.proto.Synapse.SynapseType.TEXT_CAUSAL_LM] = synapse_causal_lm
+        synapses[bittensor.proto.Synapse.SynapseType.TEXT_CAUSAL_LM_NEXT] = synapse_causal_lm_next
         synapses[bittensor.proto.Synapse.SynapseType.TEXT_SEQ_2_SEQ] = synapse_seq_2_seq
         
         synapse_check_function = synapse_checks if synapse_checks != None else axon.default_synapse_check

--- a/bittensor/_proto/bittensor.proto
+++ b/bittensor/_proto/bittensor.proto
@@ -1,3 +1,5 @@
+// python3 -m grpc.tools.protoc bittensor/_proto/bittensor.proto  -I. --python_out=. --grpc_python_out=.
+
 syntax = "proto3";
 
 // Service definition for tensor processing servers.
@@ -100,6 +102,7 @@ message Synapse {
 		TEXT_LAST_HIDDEN_STATE = 1;
 		TEXT_CAUSAL_LM = 2;
 		TEXT_SEQ_2_SEQ = 3;
+		TEXT_CAUSAL_LM_NEXT = 4;
 	}
 
 	// Position of Tensor inputs for corresponding synapse call.
@@ -211,6 +214,27 @@ message Synapse {
 
 		//groups for beam search
 		int32 num_beam_groups = 19;
+	}
+
+	message TextCausalLMNext {
+		// Specifies messaging of topk server token phrases with probabilities.
+		// Server last position token predictions are retokenized to token phrases with the bittensor tokenizer.
+		// Allows for zero translation loss CausalLM next generation between different tokenizers.
+
+		// Might as well have this
+		SynapseType synapse_type = 1;
+
+		// Specifies the number of topk server token phrases to return.
+		int32 topk = 2;
+
+		// Serializer typing.
+		Serializer forward_request_serializer_type = 3;
+		Serializer forward_response_serializer_type = 4;
+		Serializer backward_request_serializer_type = 5;
+		Serializer backward_response_serializer_type = 6;
+
+		// Requires grad: [OPTIONAL] Does this synapse call require a gradient.
+		bool requires_grad = 7;
 	}
 }
 

--- a/bittensor/_proto/bittensor_pb2.py
+++ b/bittensor/_proto/bittensor_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n bittensor/_proto/bittensor.proto\"\x8f\x01\n\x06Neuron\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x0b\n\x03uid\x18\x02 \x01(\x03\x12\x0e\n\x06hotkey\x18\x03 \x01(\t\x12\x0f\n\x07\x63oldkey\x18\x04 \x01(\t\x12\n\n\x02ip\x18\x05 \x01(\t\x12\x0c\n\x04port\x18\x06 \x01(\x05\x12\x0f\n\x07ip_type\x18\x07 \x01(\x05\x12\x1b\n\x08modality\x18\x08 \x01(\x0e\x32\t.Modality\"\xb0\x01\n\rTensorMessage\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x0e\n\x06hotkey\x18\x02 \x01(\t\x12\x18\n\x07tensors\x18\x05 \x03(\x0b\x32\x07.Tensor\x12 \n\x0breturn_code\x18\x06 \x01(\x0e\x32\x0b.ReturnCode\x12\x0f\n\x07message\x18\x07 \x01(\t\x12\x15\n\rrequires_grad\x18\x08 \x01(\x08\x12\x1a\n\x08synapses\x18\t \x03(\x0b\x32\x08.Synapse\"\xd6\x0b\n\x07Synapse\x12\x12\n\ntensor_pos\x18\x01 \x03(\x05\x12\x14\n\x0csynapse_data\x18\x02 \x01(\x0c\x12*\n\x0csynapse_type\x18\x03 \x01(\x0e\x32\x14.Synapse.SynapseType\x12 \n\x0breturn_code\x18\x04 \x01(\x0e\x32\x0b.ReturnCode\x12\x0f\n\x07message\x18\x05 \x01(\t\x12\x15\n\rrequires_grad\x18\x06 \x01(\x08\x1a\xb4\x02\n\x13TextLastHiddenState\x12*\n\x0csynapse_type\x18\x01 \x01(\x0e\x32\x14.Synapse.SynapseType\x12\x34\n\x1f\x66orward_request_serializer_type\x18\x02 \x01(\x0e\x32\x0b.Serializer\x12\x35\n forward_response_serializer_type\x18\x03 \x01(\x0e\x32\x0b.Serializer\x12\x35\n backward_request_serializer_type\x18\x04 \x01(\x0e\x32\x0b.Serializer\x12\x36\n!backward_response_serializer_type\x18\x05 \x01(\x0e\x32\x0b.Serializer\x12\x15\n\rrequires_grad\x18\x06 \x01(\x08\x1a\xbb\x02\n\x0cTextCausalLM\x12*\n\x0csynapse_type\x18\x01 \x01(\x0e\x32\x14.Synapse.SynapseType\x12\x0c\n\x04topk\x18\x02 \x01(\x05\x12\x34\n\x1f\x66orward_request_serializer_type\x18\x03 \x01(\x0e\x32\x0b.Serializer\x12\x35\n forward_response_serializer_type\x18\x04 \x01(\x0e\x32\x0b.Serializer\x12\x35\n backward_request_serializer_type\x18\x05 \x01(\x0e\x32\x0b.Serializer\x12\x36\n!backward_response_serializer_type\x18\x06 \x01(\x0e\x32\x0b.Serializer\x12\x15\n\rrequires_grad\x18\x07 \x01(\x08\x1a\xd0\x04\n\x0bTextSeq2Seq\x12*\n\x0csynapse_type\x18\x01 \x01(\x0e\x32\x14.Synapse.SynapseType\x12\x0c\n\x04topk\x18\x02 \x01(\x05\x12\x17\n\x0fnum_to_generate\x18\x03 \x01(\x05\x12\x34\n\x1f\x66orward_request_serializer_type\x18\x04 \x01(\x0e\x32\x0b.Serializer\x12\x35\n forward_response_serializer_type\x18\x05 \x01(\x0e\x32\x0b.Serializer\x12\x35\n backward_request_serializer_type\x18\x06 \x01(\x0e\x32\x0b.Serializer\x12\x36\n!backward_response_serializer_type\x18\x07 \x01(\x0e\x32\x0b.Serializer\x12\x11\n\tnum_beams\x18\x08 \x01(\x05\x12\x1c\n\x14no_repeat_ngram_size\x18\t \x01(\x05\x12\x16\n\x0e\x65\x61rly_stopping\x18\n \x01(\x08\x12\x1c\n\x14num_return_sequences\x18\x0b \x01(\x05\x12\x11\n\tdo_sample\x18\x0c \x01(\x08\x12\r\n\x05top_p\x18\r \x01(\x02\x12\x15\n\rrequires_grad\x18\x0e \x01(\x08\x12\x13\n\x0btemperature\x18\x0f \x01(\x02\x12\x1a\n\x12repetition_penalty\x18\x10 \x01(\x02\x12\x16\n\x0elength_penalty\x18\x11 \x01(\x02\x12\x10\n\x08max_time\x18\x12 \x01(\x02\x12\x17\n\x0fnum_beam_groups\x18\x13 \x01(\x05\"c\n\x0bSynapseType\x12\x10\n\x0cNULL_SYNAPSE\x10\x00\x12\x1a\n\x16TEXT_LAST_HIDDEN_STATE\x10\x01\x12\x12\n\x0eTEXT_CAUSAL_LM\x10\x02\x12\x12\n\x0eTEXT_SEQ_2_SEQ\x10\x03\"\xc9\x01\n\x06Tensor\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x0e\n\x06\x62uffer\x18\x02 \x01(\x0c\x12\r\n\x05shape\x18\x03 \x03(\x03\x12\x1f\n\nserializer\x18\x04 \x01(\x0e\x32\x0b.Serializer\x12 \n\x0btensor_type\x18\x05 \x01(\x0e\x32\x0b.TensorType\x12\x18\n\x05\x64type\x18\x06 \x01(\x0e\x32\t.DataType\x12\x1b\n\x08modality\x18\x07 \x01(\x0e\x32\t.Modality\x12\x15\n\rrequires_grad\x18\x08 \x01(\x08*\xc9\x04\n\nReturnCode\x12\x0c\n\x08NoReturn\x10\x00\x12\x0b\n\x07Success\x10\x01\x12\x0b\n\x07Timeout\x10\x02\x12\x0b\n\x07\x42\x61\x63koff\x10\x03\x12\x0f\n\x0bUnavailable\x10\x04\x12\x12\n\x0eNotImplemented\x10\x05\x12\x10\n\x0c\x45mptyRequest\x10\x06\x12\x11\n\rEmptyResponse\x10\x07\x12\x13\n\x0fInvalidResponse\x10\x08\x12\x12\n\x0eInvalidRequest\x10\t\x12\x19\n\x15RequestShapeException\x10\n\x12\x1a\n\x16ResponseShapeException\x10\x0b\x12!\n\x1dRequestSerializationException\x10\x0c\x12\"\n\x1eResponseSerializationException\x10\r\x12#\n\x1fRequestDeserializationException\x10\x0e\x12$\n ResponseDeserializationException\x10\x0f\x12\x15\n\x11NotServingNucleus\x10\x10\x12\x12\n\x0eNucleusTimeout\x10\x11\x12\x0f\n\x0bNucleusFull\x10\x12\x12\x1e\n\x1aRequestIncompatibleVersion\x10\x13\x12\x1f\n\x1bResponseIncompatibleVersion\x10\x14\x12\x11\n\rSenderUnknown\x10\x15\x12\x14\n\x10UnknownException\x10\x16\x12\x13\n\x0fUnauthenticated\x10\x17\x12\x0f\n\x0b\x42\x61\x64\x45ndpoint\x10\x18*&\n\nSerializer\x12\x0b\n\x07MSGPACK\x10\x00\x12\x0b\n\x07\x43MPPACK\x10\x01*2\n\nTensorType\x12\t\n\x05TORCH\x10\x00\x12\x0e\n\nTENSORFLOW\x10\x01\x12\t\n\x05NUMPY\x10\x02*^\n\x08\x44\x61taType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07\x46LOAT32\x10\x01\x12\x0b\n\x07\x46LOAT64\x10\x02\x12\t\n\x05INT32\x10\x03\x12\t\n\x05INT64\x10\x04\x12\x08\n\x04UTF8\x10\x05\x12\x0b\n\x07\x46LOAT16\x10\x06*+\n\x08Modality\x12\x08\n\x04TEXT\x10\x00\x12\t\n\x05IMAGE\x10\x01\x12\n\n\x06TENSOR\x10\x02*8\n\x0bRequestType\x12\x0e\n\nNOTDEFINED\x10\x00\x12\x0b\n\x07\x46ORWARD\x10\x01\x12\x0c\n\x08\x42\x41\x43KWARD\x10\x02\x32\x66\n\tBittensor\x12+\n\x07\x46orward\x12\x0e.TensorMessage\x1a\x0e.TensorMessage\"\x00\x12,\n\x08\x42\x61\x63kward\x12\x0e.TensorMessage\x1a\x0e.TensorMessage\"\x00\x62\x06proto3'
+  serialized_pb=b'\n bittensor/_proto/bittensor.proto\"\x8f\x01\n\x06Neuron\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x0b\n\x03uid\x18\x02 \x01(\x03\x12\x0e\n\x06hotkey\x18\x03 \x01(\t\x12\x0f\n\x07\x63oldkey\x18\x04 \x01(\t\x12\n\n\x02ip\x18\x05 \x01(\t\x12\x0c\n\x04port\x18\x06 \x01(\x05\x12\x0f\n\x07ip_type\x18\x07 \x01(\x05\x12\x1b\n\x08modality\x18\x08 \x01(\x0e\x32\t.Modality\"\xb0\x01\n\rTensorMessage\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x0e\n\x06hotkey\x18\x02 \x01(\t\x12\x18\n\x07tensors\x18\x05 \x03(\x0b\x32\x07.Tensor\x12 \n\x0breturn_code\x18\x06 \x01(\x0e\x32\x0b.ReturnCode\x12\x0f\n\x07message\x18\x07 \x01(\t\x12\x15\n\rrequires_grad\x18\x08 \x01(\x08\x12\x1a\n\x08synapses\x18\t \x03(\x0b\x32\x08.Synapse\"\xb1\x0e\n\x07Synapse\x12\x12\n\ntensor_pos\x18\x01 \x03(\x05\x12\x14\n\x0csynapse_data\x18\x02 \x01(\x0c\x12*\n\x0csynapse_type\x18\x03 \x01(\x0e\x32\x14.Synapse.SynapseType\x12 \n\x0breturn_code\x18\x04 \x01(\x0e\x32\x0b.ReturnCode\x12\x0f\n\x07message\x18\x05 \x01(\t\x12\x15\n\rrequires_grad\x18\x06 \x01(\x08\x1a\xb4\x02\n\x13TextLastHiddenState\x12*\n\x0csynapse_type\x18\x01 \x01(\x0e\x32\x14.Synapse.SynapseType\x12\x34\n\x1f\x66orward_request_serializer_type\x18\x02 \x01(\x0e\x32\x0b.Serializer\x12\x35\n forward_response_serializer_type\x18\x03 \x01(\x0e\x32\x0b.Serializer\x12\x35\n backward_request_serializer_type\x18\x04 \x01(\x0e\x32\x0b.Serializer\x12\x36\n!backward_response_serializer_type\x18\x05 \x01(\x0e\x32\x0b.Serializer\x12\x15\n\rrequires_grad\x18\x06 \x01(\x08\x1a\xbb\x02\n\x0cTextCausalLM\x12*\n\x0csynapse_type\x18\x01 \x01(\x0e\x32\x14.Synapse.SynapseType\x12\x0c\n\x04topk\x18\x02 \x01(\x05\x12\x34\n\x1f\x66orward_request_serializer_type\x18\x03 \x01(\x0e\x32\x0b.Serializer\x12\x35\n forward_response_serializer_type\x18\x04 \x01(\x0e\x32\x0b.Serializer\x12\x35\n backward_request_serializer_type\x18\x05 \x01(\x0e\x32\x0b.Serializer\x12\x36\n!backward_response_serializer_type\x18\x06 \x01(\x0e\x32\x0b.Serializer\x12\x15\n\rrequires_grad\x18\x07 \x01(\x08\x1a\xd0\x04\n\x0bTextSeq2Seq\x12*\n\x0csynapse_type\x18\x01 \x01(\x0e\x32\x14.Synapse.SynapseType\x12\x0c\n\x04topk\x18\x02 \x01(\x05\x12\x17\n\x0fnum_to_generate\x18\x03 \x01(\x05\x12\x34\n\x1f\x66orward_request_serializer_type\x18\x04 \x01(\x0e\x32\x0b.Serializer\x12\x35\n forward_response_serializer_type\x18\x05 \x01(\x0e\x32\x0b.Serializer\x12\x35\n backward_request_serializer_type\x18\x06 \x01(\x0e\x32\x0b.Serializer\x12\x36\n!backward_response_serializer_type\x18\x07 \x01(\x0e\x32\x0b.Serializer\x12\x11\n\tnum_beams\x18\x08 \x01(\x05\x12\x1c\n\x14no_repeat_ngram_size\x18\t \x01(\x05\x12\x16\n\x0e\x65\x61rly_stopping\x18\n \x01(\x08\x12\x1c\n\x14num_return_sequences\x18\x0b \x01(\x05\x12\x11\n\tdo_sample\x18\x0c \x01(\x08\x12\r\n\x05top_p\x18\r \x01(\x02\x12\x15\n\rrequires_grad\x18\x0e \x01(\x08\x12\x13\n\x0btemperature\x18\x0f \x01(\x02\x12\x1a\n\x12repetition_penalty\x18\x10 \x01(\x02\x12\x16\n\x0elength_penalty\x18\x11 \x01(\x02\x12\x10\n\x08max_time\x18\x12 \x01(\x02\x12\x17\n\x0fnum_beam_groups\x18\x13 \x01(\x05\x1a\xbf\x02\n\x10TextCausalLMNext\x12*\n\x0csynapse_type\x18\x01 \x01(\x0e\x32\x14.Synapse.SynapseType\x12\x0c\n\x04topk\x18\x02 \x01(\x05\x12\x34\n\x1f\x66orward_request_serializer_type\x18\x03 \x01(\x0e\x32\x0b.Serializer\x12\x35\n forward_response_serializer_type\x18\x04 \x01(\x0e\x32\x0b.Serializer\x12\x35\n backward_request_serializer_type\x18\x05 \x01(\x0e\x32\x0b.Serializer\x12\x36\n!backward_response_serializer_type\x18\x06 \x01(\x0e\x32\x0b.Serializer\x12\x15\n\rrequires_grad\x18\x07 \x01(\x08\"|\n\x0bSynapseType\x12\x10\n\x0cNULL_SYNAPSE\x10\x00\x12\x1a\n\x16TEXT_LAST_HIDDEN_STATE\x10\x01\x12\x12\n\x0eTEXT_CAUSAL_LM\x10\x02\x12\x12\n\x0eTEXT_SEQ_2_SEQ\x10\x03\x12\x17\n\x13TEXT_CAUSAL_LM_NEXT\x10\x04\"\xc9\x01\n\x06Tensor\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x0e\n\x06\x62uffer\x18\x02 \x01(\x0c\x12\r\n\x05shape\x18\x03 \x03(\x03\x12\x1f\n\nserializer\x18\x04 \x01(\x0e\x32\x0b.Serializer\x12 \n\x0btensor_type\x18\x05 \x01(\x0e\x32\x0b.TensorType\x12\x18\n\x05\x64type\x18\x06 \x01(\x0e\x32\t.DataType\x12\x1b\n\x08modality\x18\x07 \x01(\x0e\x32\t.Modality\x12\x15\n\rrequires_grad\x18\x08 \x01(\x08*\xc9\x04\n\nReturnCode\x12\x0c\n\x08NoReturn\x10\x00\x12\x0b\n\x07Success\x10\x01\x12\x0b\n\x07Timeout\x10\x02\x12\x0b\n\x07\x42\x61\x63koff\x10\x03\x12\x0f\n\x0bUnavailable\x10\x04\x12\x12\n\x0eNotImplemented\x10\x05\x12\x10\n\x0c\x45mptyRequest\x10\x06\x12\x11\n\rEmptyResponse\x10\x07\x12\x13\n\x0fInvalidResponse\x10\x08\x12\x12\n\x0eInvalidRequest\x10\t\x12\x19\n\x15RequestShapeException\x10\n\x12\x1a\n\x16ResponseShapeException\x10\x0b\x12!\n\x1dRequestSerializationException\x10\x0c\x12\"\n\x1eResponseSerializationException\x10\r\x12#\n\x1fRequestDeserializationException\x10\x0e\x12$\n ResponseDeserializationException\x10\x0f\x12\x15\n\x11NotServingNucleus\x10\x10\x12\x12\n\x0eNucleusTimeout\x10\x11\x12\x0f\n\x0bNucleusFull\x10\x12\x12\x1e\n\x1aRequestIncompatibleVersion\x10\x13\x12\x1f\n\x1bResponseIncompatibleVersion\x10\x14\x12\x11\n\rSenderUnknown\x10\x15\x12\x14\n\x10UnknownException\x10\x16\x12\x13\n\x0fUnauthenticated\x10\x17\x12\x0f\n\x0b\x42\x61\x64\x45ndpoint\x10\x18*&\n\nSerializer\x12\x0b\n\x07MSGPACK\x10\x00\x12\x0b\n\x07\x43MPPACK\x10\x01*2\n\nTensorType\x12\t\n\x05TORCH\x10\x00\x12\x0e\n\nTENSORFLOW\x10\x01\x12\t\n\x05NUMPY\x10\x02*^\n\x08\x44\x61taType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07\x46LOAT32\x10\x01\x12\x0b\n\x07\x46LOAT64\x10\x02\x12\t\n\x05INT32\x10\x03\x12\t\n\x05INT64\x10\x04\x12\x08\n\x04UTF8\x10\x05\x12\x0b\n\x07\x46LOAT16\x10\x06*+\n\x08Modality\x12\x08\n\x04TEXT\x10\x00\x12\t\n\x05IMAGE\x10\x01\x12\n\n\x06TENSOR\x10\x02*8\n\x0bRequestType\x12\x0e\n\nNOTDEFINED\x10\x00\x12\x0b\n\x07\x46ORWARD\x10\x01\x12\x0c\n\x08\x42\x41\x43KWARD\x10\x02\x32\x66\n\tBittensor\x12+\n\x07\x46orward\x12\x0e.TensorMessage\x1a\x0e.TensorMessage\"\x00\x12,\n\x08\x42\x61\x63kward\x12\x0e.TensorMessage\x1a\x0e.TensorMessage\"\x00\x62\x06proto3'
 )
 
 _RETURNCODE = _descriptor.EnumDescriptor(
@@ -158,8 +158,8 @@ _RETURNCODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2063,
-  serialized_end=2648,
+  serialized_start=2410,
+  serialized_end=2995,
 )
 _sym_db.RegisterEnumDescriptor(_RETURNCODE)
 
@@ -184,8 +184,8 @@ _SERIALIZER = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2650,
-  serialized_end=2688,
+  serialized_start=2997,
+  serialized_end=3035,
 )
 _sym_db.RegisterEnumDescriptor(_SERIALIZER)
 
@@ -215,8 +215,8 @@ _TENSORTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2690,
-  serialized_end=2740,
+  serialized_start=3037,
+  serialized_end=3087,
 )
 _sym_db.RegisterEnumDescriptor(_TENSORTYPE)
 
@@ -266,8 +266,8 @@ _DATATYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2742,
-  serialized_end=2836,
+  serialized_start=3089,
+  serialized_end=3183,
 )
 _sym_db.RegisterEnumDescriptor(_DATATYPE)
 
@@ -297,8 +297,8 @@ _MODALITY = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2838,
-  serialized_end=2881,
+  serialized_start=3185,
+  serialized_end=3228,
 )
 _sym_db.RegisterEnumDescriptor(_MODALITY)
 
@@ -328,8 +328,8 @@ _REQUESTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2883,
-  serialized_end=2939,
+  serialized_start=3230,
+  serialized_end=3286,
 )
 _sym_db.RegisterEnumDescriptor(_REQUESTTYPE)
 
@@ -406,11 +406,16 @@ _SYNAPSE_SYNAPSETYPE = _descriptor.EnumDescriptor(
       serialized_options=None,
       type=None,
       create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='TEXT_CAUSAL_LM_NEXT', index=4, number=4,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1757,
-  serialized_end=1856,
+  serialized_start=2079,
+  serialized_end=2203,
 )
 _sym_db.RegisterEnumDescriptor(_SYNAPSE_SYNAPSETYPE)
 
@@ -866,6 +871,79 @@ _SYNAPSE_TEXTSEQ2SEQ = _descriptor.Descriptor(
   serialized_end=1755,
 )
 
+_SYNAPSE_TEXTCAUSALLMNEXT = _descriptor.Descriptor(
+  name='TextCausalLMNext',
+  full_name='Synapse.TextCausalLMNext',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='synapse_type', full_name='Synapse.TextCausalLMNext.synapse_type', index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='topk', full_name='Synapse.TextCausalLMNext.topk', index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='forward_request_serializer_type', full_name='Synapse.TextCausalLMNext.forward_request_serializer_type', index=2,
+      number=3, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='forward_response_serializer_type', full_name='Synapse.TextCausalLMNext.forward_response_serializer_type', index=3,
+      number=4, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='backward_request_serializer_type', full_name='Synapse.TextCausalLMNext.backward_request_serializer_type', index=4,
+      number=5, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='backward_response_serializer_type', full_name='Synapse.TextCausalLMNext.backward_response_serializer_type', index=5,
+      number=6, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='requires_grad', full_name='Synapse.TextCausalLMNext.requires_grad', index=6,
+      number=7, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1758,
+  serialized_end=2077,
+)
+
 _SYNAPSE = _descriptor.Descriptor(
   name='Synapse',
   full_name='Synapse',
@@ -919,7 +997,7 @@ _SYNAPSE = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_SYNAPSE_TEXTLASTHIDDENSTATE, _SYNAPSE_TEXTCAUSALLM, _SYNAPSE_TEXTSEQ2SEQ, ],
+  nested_types=[_SYNAPSE_TEXTLASTHIDDENSTATE, _SYNAPSE_TEXTCAUSALLM, _SYNAPSE_TEXTSEQ2SEQ, _SYNAPSE_TEXTCAUSALLMNEXT, ],
   enum_types=[
     _SYNAPSE_SYNAPSETYPE,
   ],
@@ -930,7 +1008,7 @@ _SYNAPSE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=362,
-  serialized_end=1856,
+  serialized_end=2203,
 )
 
 
@@ -1010,8 +1088,8 @@ _TENSOR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1859,
-  serialized_end=2060,
+  serialized_start=2206,
+  serialized_end=2407,
 )
 
 _NEURON.fields_by_name['modality'].enum_type = _MODALITY
@@ -1036,6 +1114,12 @@ _SYNAPSE_TEXTSEQ2SEQ.fields_by_name['forward_response_serializer_type'].enum_typ
 _SYNAPSE_TEXTSEQ2SEQ.fields_by_name['backward_request_serializer_type'].enum_type = _SERIALIZER
 _SYNAPSE_TEXTSEQ2SEQ.fields_by_name['backward_response_serializer_type'].enum_type = _SERIALIZER
 _SYNAPSE_TEXTSEQ2SEQ.containing_type = _SYNAPSE
+_SYNAPSE_TEXTCAUSALLMNEXT.fields_by_name['synapse_type'].enum_type = _SYNAPSE_SYNAPSETYPE
+_SYNAPSE_TEXTCAUSALLMNEXT.fields_by_name['forward_request_serializer_type'].enum_type = _SERIALIZER
+_SYNAPSE_TEXTCAUSALLMNEXT.fields_by_name['forward_response_serializer_type'].enum_type = _SERIALIZER
+_SYNAPSE_TEXTCAUSALLMNEXT.fields_by_name['backward_request_serializer_type'].enum_type = _SERIALIZER
+_SYNAPSE_TEXTCAUSALLMNEXT.fields_by_name['backward_response_serializer_type'].enum_type = _SERIALIZER
+_SYNAPSE_TEXTCAUSALLMNEXT.containing_type = _SYNAPSE
 _SYNAPSE.fields_by_name['synapse_type'].enum_type = _SYNAPSE_SYNAPSETYPE
 _SYNAPSE.fields_by_name['return_code'].enum_type = _RETURNCODE
 _SYNAPSE_SYNAPSETYPE.containing_type = _SYNAPSE
@@ -1091,6 +1175,13 @@ Synapse = _reflection.GeneratedProtocolMessageType('Synapse', (_message.Message,
     # @@protoc_insertion_point(class_scope:Synapse.TextSeq2Seq)
     })
   ,
+
+  'TextCausalLMNext' : _reflection.GeneratedProtocolMessageType('TextCausalLMNext', (_message.Message,), {
+    'DESCRIPTOR' : _SYNAPSE_TEXTCAUSALLMNEXT,
+    '__module__' : 'bittensor._proto.bittensor_pb2'
+    # @@protoc_insertion_point(class_scope:Synapse.TextCausalLMNext)
+    })
+  ,
   'DESCRIPTOR' : _SYNAPSE,
   '__module__' : 'bittensor._proto.bittensor_pb2'
   # @@protoc_insertion_point(class_scope:Synapse)
@@ -1099,6 +1190,7 @@ _sym_db.RegisterMessage(Synapse)
 _sym_db.RegisterMessage(Synapse.TextLastHiddenState)
 _sym_db.RegisterMessage(Synapse.TextCausalLM)
 _sym_db.RegisterMessage(Synapse.TextSeq2Seq)
+_sym_db.RegisterMessage(Synapse.TextCausalLMNext)
 
 Tensor = _reflection.GeneratedProtocolMessageType('Tensor', (_message.Message,), {
   'DESCRIPTOR' : _TENSOR,
@@ -1116,8 +1208,8 @@ _BITTENSOR = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=2941,
-  serialized_end=3043,
+  serialized_start=3288,
+  serialized_end=3390,
   methods=[
   _descriptor.MethodDescriptor(
     name='Forward',

--- a/bittensor/_synapse/__init__.py
+++ b/bittensor/_synapse/__init__.py
@@ -25,6 +25,7 @@ from typing import Union, List, Tuple, Optional
 from bittensor._serializer import serializer
 from .synapse_impl import Synapse, NullSynapse
 from .text_causallm_impl import TextCausalLM
+from .text_causallmnext_impl import TextCausalLMNext
 from .text_lasthiddenstate_impl import TextLastHiddenState
 from .text_seq2seq_impl import TextSeq2Seq
 
@@ -99,6 +100,38 @@ class synapse:
             forward_response_serializer_type = forward_response_serializer_type,
             backward_request_serializer_type = backward_request_serializer_type,
             backward_response_serializer_type = backward_response_serializer_type,
+        )
+
+    @staticmethod
+    def TextCausalLMNext(
+        topk: int = 4096,
+        forward_request_serializer_type: 'bittensor.proto.Serializer.Type' = bittensor.proto.Serializer.MSGPACK,
+        forward_response_serializer_type: 'bittensor.proto.Serializer.Type' = bittensor.proto.Serializer.MSGPACK,
+        backward_request_serializer_type: 'bittensor.proto.Serializer.Type' = bittensor.proto.Serializer.MSGPACK,
+        backward_response_serializer_type: 'bittensor.proto.Serializer.Type' = bittensor.proto.Serializer.MSGPACK,
+    ) -> TextCausalLMNext:
+        """ Factory function which returns a TextCausalLMNext synapse adapter given arguments.
+            Args:
+                topk (:obj:`int`):
+                    Specifies the number of topk server token phrases to return.
+                forward_request_serializer_type (:obj:`bittensor.proto.Serializer.Type` of shape :obj:`(1)`, `optional`, :default: `bittensor.proto.Serializer.MSGPACK`):
+                    Serializer used to pack torch tensors on forward request.
+                forward_response_serializer_type (:obj:`bittensor.proto.Serializer.Type` of shape :obj:`(1)`, `optional`, :default: `bittensor.proto.Serializer.MSGPACK`):
+                    Serializer used to pack torch tensors on forward response.
+                backward_request_serializer_type (:obj:`bittensor.proto.Serializer.Type` of shape :obj:`(1)`, `optional`, :default: `bittensor.proto.Serializer.MSGPACK`):
+                    Serializer used to pack torch tensors on forward request.
+                backward_response_serializer_type (:obj:`bittensor.proto.Serializer.Type` of shape :obj:`(1)`, `optional`, :default: `bittensor.proto.Serializer.MSGPACK`):
+                    Serializer used to pack torch tensors on backward response.
+            Returns:
+                TextCausalLMNext (:obj:`TextCausalLMNext`, `required`):
+                    TextCausalLMNext instance adapter class.
+        """
+        return TextCausalLMNext(
+            topk=topk,
+            forward_request_serializer_type=forward_request_serializer_type,
+            forward_response_serializer_type=forward_response_serializer_type,
+            backward_request_serializer_type=backward_request_serializer_type,
+            backward_response_serializer_type=backward_response_serializer_type,
         )
 
     @staticmethod
@@ -187,6 +220,8 @@ class synapse:
             return TextLastHiddenState.deserialize_from_wire_proto ( synapse_wire_proto )
         elif synapse_wire_proto.synapse_type == bittensor.proto.Synapse.SynapseType.TEXT_CAUSAL_LM:
             return TextCausalLM.deserialize_from_wire_proto( synapse_wire_proto )
+        elif synapse_wire_proto.synapse_type == bittensor.proto.Synapse.SynapseType.TEXT_CAUSAL_LM_NEXT:
+            return TextCausalLMNext.deserialize_from_wire_proto(synapse_wire_proto)
         elif synapse_wire_proto.synapse_type == bittensor.proto.Synapse.SynapseType.TEXT_SEQ_2_SEQ:
             return TextSeq2Seq.deserialize_from_wire_proto( synapse_wire_proto )
         else:

--- a/bittensor/_synapse/text_causallmnext_impl.py
+++ b/bittensor/_synapse/text_causallmnext_impl.py
@@ -1,0 +1,170 @@
+# The MIT License (MIT)
+# Copyright © 2021 Yuma Rao
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import bittensor
+import torch
+from .synapse_impl import Synapse
+
+
+class TextCausalLMNext(Synapse):
+    """ TextCausalLMNext Synapse type for next token prediction from language models.
+    """
+    synapse_type: bittensor.proto.Synapse.SynapseType = bittensor.proto.Synapse.SynapseType.TEXT_CAUSAL_LM_NEXT
+
+    def __init__(
+            self,
+            topk: int = 4096,
+            forward_request_serializer_type: 'bittensor.proto.Serializer.Type' = bittensor.proto.Serializer.MSGPACK,
+            forward_response_serializer_type: 'bittensor.proto.Serializer.Type' = bittensor.proto.Serializer.MSGPACK,
+            backward_request_serializer_type: 'bittensor.proto.Serializer.Type' = bittensor.proto.Serializer.MSGPACK,
+            backward_response_serializer_type: 'bittensor.proto.Serializer.Type' = bittensor.proto.Serializer.MSGPACK,
+    ):
+        """ TextCausalLMNext Synapse initializer.
+        Args:
+            topk (:obj:`int`):
+                Specifies the number of topk server token phrases to return.
+            forward_request_serializer_type (:obj:`bittensor.proto.Serializer.Type` of shape :obj:`(1)`, `optional`, :default: `bittensor.proto.Serializer.MSGPACK`):
+                Serializer used to pack torch tensors on forward request.
+            forward_response_serializer_type (:obj:`bittensor.proto.Serializer.Type` of shape :obj:`(1)`, `optional`, :default: `bittensor.proto.Serializer.MSGPACK`):
+                Serializer used to pack torch tensors on forward response.
+            backward_request_serializer_type (:obj:`bittensor.proto.Serializer.Type` of shape :obj:`(1)`, `optional`, :default: `bittensor.proto.Serializer.MSGPACK`):
+                Serializer used to pack torch tensors on forward request.
+            backward_response_serializer_type (:obj:`bittensor.proto.Serializer.Type` of shape :obj:`(1)`, `optional`, :default: `bittensor.proto.Serializer.MSGPACK`):
+                Serializer used to pack torch tensors on backward response.
+        Returns:
+            TextCausalLMNext (:obj:`TextCausalLMNext`, `required`):
+                TextCausalLMNext instance adapter class.
+    """
+        super().__init__(
+            forward_request_serializer_type,
+            forward_response_serializer_type,
+            backward_request_serializer_type,
+            backward_response_serializer_type
+        )
+        self.topk = topk
+        self.synapse_type = TextCausalLMNext.synapse_type
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def __str__(self) -> str:
+        return "TextCausalLMNext"
+
+    @staticmethod
+    def deserialize_from_instance_proto(instance_proto: bittensor.proto.Synapse) -> 'TextCausalLMNext':
+        return TextCausalLMNext(
+            topk=instance_proto.topk,
+            forward_request_serializer_type=instance_proto.forward_request_serializer_type,
+            forward_response_serializer_type=instance_proto.forward_response_serializer_type,
+            backward_request_serializer_type=instance_proto.backward_request_serializer_type,
+            backward_response_serializer_type=instance_proto.backward_response_serializer_type,
+        )
+
+    @staticmethod
+    def deserialize_from_wire_proto(wire_proto: bittensor.proto.Synapse) -> 'TextCausalLMNext':
+        instance_proto = bittensor.proto.Synapse.TextCausalLMNext()
+        instance_proto.ParseFromString(wire_proto.synapse_data)
+        return TextCausalLMNext.deserialize_from_instance_proto(instance_proto)
+
+    def serialize_to_instance_proto(self) -> 'bittensor.proto.Synapse.TextCausalLMNext':
+        return bittensor.proto.Synapse.TextCausalLMNext(
+            topk=self.topk,
+            forward_request_serializer_type=self.forward_request_serializer_type,
+            forward_response_serializer_type=self.forward_response_serializer_type,
+            backward_request_serializer_type=self.backward_request_serializer_type,
+            backward_response_serializer_type=self.backward_response_serializer_type,
+        )
+
+    def serialize_to_wire_proto(self, code: 'bittensor.proto.ReturnCode' = 0,
+                                message: str = '') -> bittensor.proto.Synapse:
+        return bittensor.proto.Synapse(
+            synapse_data=self.serialize_to_instance_proto().SerializeToString(),
+            synapse_type=TextCausalLMNext.synapse_type,
+            return_code=code,
+            message=message
+        )
+
+    def check_forward_request_tensor(self, forward_request_tensor):
+        # forward_request_tensor: [batch_size, sequence_len]
+        if (
+                len(forward_request_tensor.shape) != 2 or
+                forward_request_tensor.shape[0] == 0 or
+                forward_request_tensor.shape[1] == 0
+        ):
+            raise ValueError(f"forward_request_tensor.shape must be in [-1, -1], "
+                             f"got: {list(forward_request_tensor.shape)} for synapse: {self}")
+
+    def check_forward_response_tensor(self, forward_request_tensor, forward_response_tensor):
+        # forward_request_tensor: [batch_size, sequence_len]
+        # forward_response_tensor: [ >= batch_size * (2 * topk + 1)]
+        if forward_response_tensor is None:
+            raise ValueError("Empty Response")
+
+        if (
+                len(forward_response_tensor.shape) != 1 or
+                forward_response_tensor.size(0) < forward_request_tensor.shape[0] * (2 * self.topk + 1)
+        ):
+            raise ValueError(f"forward_response_tensor.shape must be in "
+                             f"[>={forward_request_tensor.shape[0]} x (2 x {self.topk} + 1)], "
+                             f"got: {forward_response_tensor.size(0)} for synapse: {self}")
+
+    def check_backward_request_gradient(self, forward_request_tensor, backward_request_gradient):
+        # forward_request_tensor: [batch_size, sequence_len]
+        # backward_request_gradient: [ >= batch_size * (2 * topk + 1)]
+        if (
+                len(backward_request_gradient.shape) != 1 or
+                backward_request_gradient.size(0) < forward_request_tensor.shape[0] * (2 * self.topk + 1)
+        ):
+            raise ValueError(f"backward_request_gradient.shape must be in "
+                             f"[>={forward_request_tensor.shape[0]} x (2 x {self.topk} + 1)], "
+                             f"got: {backward_request_gradient.size(0)} for synapse: {self}")
+
+    def encode_forward_request_tensor(self, forward_request_tensor: torch.Tensor) -> torch.Tensor:
+        return forward_request_tensor
+
+    def decode_forward_request_tensor(self, forward_request_tensor: torch.Tensor) -> torch.Tensor:
+        return forward_request_tensor
+
+    def encode_forward_response_tensor(self, forward_response_tensor: torch.Tensor) -> torch.Tensor:
+        return forward_response_tensor
+
+    def decode_forward_response_tensor(self, forward_response_tensor: torch.Tensor) -> torch.Tensor:
+        return forward_response_tensor
+
+    def encode_backward_response_gradient(self, backward_request_gradient: torch.Tensor) -> torch.Tensor:
+        return backward_request_gradient
+
+    def decode_backward_response_gradient(self, backward_request_gradient: torch.Tensor) -> torch.Tensor:
+        return backward_request_gradient
+
+    def encode_backward_request_gradient(self, backward_response_gradient: torch.Tensor) -> torch.Tensor:
+        return backward_response_gradient
+
+    def decode_backward_request_gradient(self, backward_response_gradient: torch.Tensor) -> torch.Tensor:
+        return backward_response_gradient
+
+    def nill_forward_response_tensor(self, forward_request_tensor: torch.Tensor) -> torch.Tensor:
+        try:
+            return torch.zeros((forward_request_tensor.shape[0] * (2 * self.topk + 1)), dtype=torch.float32)
+        except:
+            return torch.tensor([])
+
+    def nill_backward_response_tensor(self, forward_request_tensor: torch.Tensor) -> torch.Tensor:
+        try:
+            return torch.zeros((forward_request_tensor.shape[0] * (2 * self.topk + 1)), dtype=torch.float32)
+        except:
+            return torch.tensor([])

--- a/bittensor/utils/codes.py
+++ b/bittensor/utils/codes.py
@@ -134,5 +134,7 @@ def code_to_synapse( code: 'bittensor.proto.Synapse.SynapseType'):
         return 'text_causal_lm'
     elif code == 3:
         return 'text_seq_2_seq'
+    elif code == 4:
+        return 'text_causal_lm_next'
     else:
         return 'Null'

--- a/bittensor/utils/tokenizer_utils.py
+++ b/bittensor/utils/tokenizer_utils.py
@@ -19,7 +19,7 @@
 
 import torch
 
-from typing import List, Dict, Tuple, Any
+from typing import List, Dict, Tuple, Any, Union
 from transformers import PreTrainedTokenizerBase
 
 EPSILON = 1e-40
@@ -676,7 +676,6 @@ def translate_logits_to_probs_std(logits: torch.FloatTensor,
         padded_probs[..., :vocab_size] = probs
         probs = padded_probs
 
-
     # === Translate to probabilities over standard tokenizer ===
     probs_std = torch.zeros(batch_size, std_sequence_len, std_vocab_size)
     for b in range(batch_size):
@@ -869,6 +868,77 @@ def unravel_topk_token_phrases(input_tensor: torch.Tensor, topk: int, ignore_ind
     topk_tokens = topk_tokens.to(int)  # [batch_size, topk, max_len]
 
     return topk_tokens, topk_probs, floor_probs
+
+
+def phrase_cross_entropy(target_phrases: Union[List[int], torch.Tensor],
+                         topk_tokens: torch.Tensor, topk_probs: torch.Tensor, floor_probs: torch.Tensor,
+                         ignore_index: int = -100, reduce=True, reduction='mean',
+                         vocab_size_min: int = 50257) -> torch.Tensor:
+    r"""
+    Calculates the cross entropy of a phrase prediction against a target phrase, so that this is a multi-token
+    extension of typical cross entropy calculated for next token prediction.
+        Args:
+            target_phrases (:obj:`List[int]`, `required`):
+                [batch_size] Target phrases in standard token sequence list.
+            topk_tokens (:obj:`torch.Tensor`, `required`):
+                [batch_size, topk, max_len] Phrase tokens with ignore_index token for padding.
+            topk_probs (:obj:`torch.Tensor`, `required`):
+                [batch_size, topk] Probabilities for each phrase in topk.
+            floor_probs (:obj:`torch.Tensor`, `required`):
+                [batch_size] Floor probabilities as mean probability for non-topk tokens.
+            ignore_index (:obj:`int`, `optional`):
+                Padding value to use for unfilled token positions in a shorter token phrase.
+            reduce (:obj:`bool`, `optional`):
+                Whether to reduce the cross entropy over the batch dimension.
+            reduction (:obj:`str`, `optional`):
+                Reduction function to perform when reduce is True.
+            vocab_size_min (:obj:`int`, `optional`):
+                Minimum server vocab_size expected, should set to nominal 50257,
+                used to prevent the floor_probs from being too large.
+        Returns:
+            loss (:obj:`torch.Tensor`, `required`):
+                Phrase cross entropy loss, either scalar if reduce or [batch_size].
+    """
+
+    batch_size, topk, max_len = topk_tokens.shape
+
+    # === Ensure total probability is 1 ===
+    total_probs = topk_probs.sum(dim=-1) + max(0, vocab_size_min - topk) * floor_probs  # [batch_size] total probs
+    n_topk_probs = topk_probs / total_probs[:, None]  # [batch_size, topk] normalized topk_probs
+    n_floor_probs = floor_probs / total_probs  # [batch_size] normalized floor_probs
+
+    match_probs = torch.zeros(batch_size)  # accumulate probabilities when sub target matches phrase
+    for b in range(batch_size):
+        # === Integrate sub target matches ===
+        target_phrase = target_phrases[b]
+        if not isinstance(target_phrase, torch.Tensor):
+            target_phrase = torch.tensor(target_phrases[b])
+        check_len = min(max_len, len(target_phrase))
+
+        for c in range(1, check_len + 1):  # progressively increase sub target length
+            target = ignore_index * torch.ones(check_len, dtype=torch.int32)  # [-100, ..., -100]
+            target[:c] = target_phrase[:c]  # [tok0, tok1, ...tokc, -100, ..., -100]
+
+            # Find sub target matches
+            match = (topk_tokens[b, :, :check_len] == target)
+            match_idx = torch.where(match.sum(dim=-1) == check_len)[0]  # phrase indices which match sub target
+
+            if len(match_idx):  # at least one match
+                match_probs[b] += n_topk_probs[b, match_idx].sum()  # accumulate all matches
+            else:  # no matches
+                match_probs[b] += n_floor_probs[b]  # assume match is in non-topk tokens with avg floor_prob
+
+    match_probs = torch.clamp(match_probs, 0, 1)  # [batch_size] ensure 0 <= total probability <= 1
+    loss = - torch.log(match_probs + 1e-40)  # [batch_size] calculate cross entropy loss
+
+    if reduce:
+        if not hasattr(loss, reduction):
+            raise RuntimeError(f'phase_cross_entropy(): Reduction function {reduction} not found.')
+        loss = getattr(loss, reduction)()
+        if loss.numel() > 1:
+            raise ValueError(f'phase_cross_entropy(): Expected reduction to scalar, obtained {loss.shape} instead.')
+
+    return loss
 
 
 def check_tokenizer_equivalence(tokenizer_to_check: PreTrainedTokenizerBase,

--- a/tests/integration_tests/test_dendrite.py
+++ b/tests/integration_tests/test_dendrite.py
@@ -34,14 +34,18 @@ neuron_obj = bittensor.endpoint(
     modality = 0
 )
 
-synapses = [bittensor.synapse.TextLastHiddenState(),bittensor.synapse.TextCausalLM(), bittensor.synapse.TextSeq2Seq(num_to_generate=constant.synapse.num_to_generate)]
+synapses = [bittensor.synapse.TextLastHiddenState(),
+            bittensor.synapse.TextCausalLM(),
+            bittensor.synapse.TextCausalLMNext(),
+            bittensor.synapse.TextSeq2Seq(num_to_generate=constant.synapse.num_to_generate)]
 dataset = bittensor.dataset(num_batches=20, dataset_name = ['Books3'])
 
 def check_resp_shape(resp, num_resp, block_size, seq_len):
     assert len(resp) == num_resp
     assert list(resp[0][0].shape) == [block_size, seq_len, bittensor.__network_dim__]
     assert list(resp[0][1].shape) == [block_size, seq_len, bittensor.__vocab_size__]
-    assert list(resp[0][2].shape) == [block_size, constant.synapse.num_to_generate]
+    assert list(resp[0][2].shape) == [block_size * (2 * synapses[2].topk + 1)]
+    assert list(resp[0][3].shape) == [block_size, constant.synapse.num_to_generate]
     
 def test_dendrite_forward_text_endpoints_tensor():
     endpoints = neuron_obj.to_tensor()
@@ -165,19 +169,19 @@ def test_dendrite_forward_tensor_mismatch_len_error():
 def test_dendrite_forward_text_non_list():
     x = torch.tensor([[1,2,3,4],[5,6,7,8]], dtype=torch.long)
     out, ops, times = dendrite.text( endpoints = neuron_obj, inputs = x, synapses = synapses )
-    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable]*3
+    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable] * len(synapses)
     check_resp_shape(out, 1,2,4)
 
 def test_dendrite_forward_text():
     x = torch.tensor([[1,2,3,4],[5,6,7,8]], dtype=torch.long)
     out, ops, times = dendrite.text( endpoints = [neuron_obj], inputs = [x], synapses = synapses )
-    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable]*3
+    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable] * len(synapses)
     check_resp_shape(out, 1,2,4)
 
 def test_dendrite_forward_tensor():
     x = torch.rand(3, 3, dtype=torch.float32)
     out, ops, times = dendrite.text( endpoints = [neuron_obj], inputs = [x], synapses = synapses)
-    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable]*3
+    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable] * len(synapses)
     check_resp_shape(out, 1, 3, 3)
 
 def test_dendrite_backoff():
@@ -197,7 +201,7 @@ def test_dendrite_backoff():
     # Normal call.
     x = torch.rand(3, 3, dtype=torch.float32)
     out, ops, times = _dendrite.text( endpoints = [_endpoint_obj], inputs = [x], synapses = synapses)
-    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable]*3
+    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable] * len(synapses)
     check_resp_shape(out, 1, 3, 3)
     del _dendrite
 
@@ -231,16 +235,16 @@ def test_dendrite_multiple():
     dend4 = bittensor.dendrite( wallet = wallet, multiprocess=True)
     
     out, ops, times = dend1.text( endpoints = endpoint_obj, inputs = x, synapses = synapses )
-    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable]*3
+    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable] * len(synapses)
 
     out, ops, times = dend2.text( endpoints = endpoint_obj, inputs = x, synapses = synapses )
-    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable]*3
+    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable] * len(synapses)
 
     out, ops, times = dend3.text( endpoints = endpoint_obj, inputs = x, synapses = synapses )
-    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable]*3
+    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable] * len(synapses)
 
     out, ops, times = dend4.text( endpoints = endpoint_obj, inputs = x, synapses = synapses )
-    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable]*3
+    assert list(ops[0]) == [bittensor.proto.ReturnCode.Unavailable] * len(synapses)
 
     assert len(receptor_pool.receptors) == 1 
     assert manager_server.connected_count == 4

--- a/tests/unit_tests/bittensor_tests/test_receptor_pool.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor_pool.py
@@ -99,11 +99,13 @@ def test_receptor_pool_forward_success():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
     y_hidden_serialized = serializer.serialize(y_hidden, from_type = bittensor.proto.TensorType.TORCH)
     y_causallm_serialized = serializer.serialize(y_causallm, from_type = bittensor.proto.TensorType.TORCH)
+    y_causallmnext_serialized = serializer.serialize(y_causallmnext, from_type=bittensor.proto.TensorType.TORCH)
     y_seq_2_seq_serialized = serializer.serialize(y_seq_2_seq, from_type = bittensor.proto.TensorType.TORCH)
             
     mock_return_val = bittensor.proto.TensorMessage(
@@ -111,14 +113,14 @@ def test_receptor_pool_forward_success():
             hotkey = wallet.hotkey.ss58_address,
             synapses = [synapse.serialize_to_wire_proto(code = bittensor.proto.ReturnCode.Success, message= 'Success' ) for synapse in synapses],
             return_code = bittensor.proto.ReturnCode.Success,
-            tensors = [y_hidden_serialized, y_causallm_serialized, y_seq_2_seq_serialized]
+            tensors = [y_hidden_serialized, y_causallm_serialized, y_causallmnext_serialized, y_seq_2_seq_serialized]
         )
 
     receptor_pool._get_or_create_receptor_for_endpoint(neuron_obj)
     receptor_pool.receptors[neuron_obj.hotkey].stub.Forward = MagicMock( return_value = mock_return_val )
     resp1,  codes, _ = receptor_pool.forward( endpoints, synapses, x, timeout=1)
-    assert codes == [[bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success],
-    [bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success]]
+    assert codes == [[bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success],
+    [bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success]]
 
 def test_receptor_pool_forward_timeout():
     endpoints = [neuron_obj,neuron_obj]
@@ -159,11 +161,13 @@ def test_receptor_pool_forward_num_synapse_mismatch():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
     y_hidden_serialized = serializer.serialize(y_hidden, from_type = bittensor.proto.TensorType.TORCH)
     y_causallm_serialized = serializer.serialize(y_causallm, from_type = bittensor.proto.TensorType.TORCH)
+    y_causallmnext_serialized = serializer.serialize(y_causallmnext, from_type=bittensor.proto.TensorType.TORCH)
     y_seq_2_seq_serialized = serializer.serialize(y_seq_2_seq, from_type = bittensor.proto.TensorType.TORCH)
             
     mock_return_val = bittensor.proto.TensorMessage(
@@ -171,14 +175,14 @@ def test_receptor_pool_forward_num_synapse_mismatch():
             hotkey = wallet.hotkey.ss58_address,
             synapses = [synapse.serialize_to_wire_proto(code = bittensor.proto.ReturnCode.Success, message= 'Timeout' ) for synapse in synapses],
             return_code = bittensor.proto.ReturnCode.Success,
-            tensors = [y_hidden_serialized, y_causallm_serialized]
+            tensors = [y_hidden_serialized, y_causallm_serialized, y_causallmnext_serialized]
         )
 
     receptor_pool._get_or_create_receptor_for_endpoint(neuron_obj)
     receptor_pool.receptors[neuron_obj.hotkey].stub.Forward = MagicMock( return_value = mock_return_val )
     resp1,  codes, _ = receptor_pool.forward( endpoints, synapses, x, timeout=1)
-    assert codes == [[bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException],
-    [bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException]]
+    assert codes == [[bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException],
+    [bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException]]
 
 def test_receptor_pool_forward_response_partial_shape_error():
     endpoints = [neuron_obj,neuron_obj]
@@ -186,11 +190,13 @@ def test_receptor_pool_forward_response_partial_shape_error():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(2, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
     y_hidden_serialized = serializer.serialize(y_hidden, from_type = bittensor.proto.TensorType.TORCH)
     y_causallm_serialized = serializer.serialize(y_causallm, from_type = bittensor.proto.TensorType.TORCH)
+    y_causallmnext_serialized = serializer.serialize(y_causallmnext, from_type=bittensor.proto.TensorType.TORCH)
     y_seq_2_seq_serialized = serializer.serialize(y_seq_2_seq, from_type = bittensor.proto.TensorType.TORCH)
             
     mock_return_val = bittensor.proto.TensorMessage(
@@ -198,14 +204,14 @@ def test_receptor_pool_forward_response_partial_shape_error():
             hotkey = wallet.hotkey.ss58_address,
             synapses = [synapse.serialize_to_wire_proto(code = bittensor.proto.ReturnCode.Success, message= 'Success' ) for synapse in synapses],
             return_code = bittensor.proto.ReturnCode.Success,
-            tensors = [y_hidden_serialized, y_causallm_serialized, y_seq_2_seq_serialized]
+            tensors = [y_hidden_serialized, y_causallm_serialized, y_causallmnext_serialized, y_seq_2_seq_serialized]
         )
 
     receptor_pool._get_or_create_receptor_for_endpoint(neuron_obj)
     receptor_pool.receptors[neuron_obj.hotkey].stub.Forward = MagicMock( return_value = mock_return_val )
     resp1,  codes, _ = receptor_pool.forward( endpoints, synapses, x, timeout=1)
-    assert codes == [[bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.ResponseDeserializationException],
-    [bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.ResponseDeserializationException]]
+    assert codes == [[bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.ResponseDeserializationException],
+    [bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.ResponseDeserializationException]]
 
 def test_receptor_pool_partial_remote_success_return_code():
     endpoints = [neuron_obj,neuron_obj]
@@ -213,11 +219,13 @@ def test_receptor_pool_partial_remote_success_return_code():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(2, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
     y_hidden_serialized = serializer.serialize(y_hidden, from_type = bittensor.proto.TensorType.TORCH)
     y_causallm_serialized = serializer.serialize(y_causallm, from_type = bittensor.proto.TensorType.TORCH)
+    y_causallmnext_serialized = serializer.serialize(y_causallmnext, from_type=bittensor.proto.TensorType.TORCH)
     y_seq_2_seq_serialized = serializer.serialize(y_seq_2_seq, from_type = bittensor.proto.TensorType.TORCH)
             
     mock_return_val = bittensor.proto.TensorMessage(
@@ -226,14 +234,14 @@ def test_receptor_pool_partial_remote_success_return_code():
             synapses = [synapse.serialize_to_wire_proto(code = bittensor.proto.ReturnCode.Success, message= 'Success' ) for synapse in synapses[:-1]]
             + [synapses[-1].serialize_to_wire_proto(code = bittensor.proto.ReturnCode.UnknownException, message= 'UnknownException' )],
             return_code = bittensor.proto.ReturnCode.Success,
-            tensors = [y_hidden_serialized, y_causallm_serialized, y_seq_2_seq_serialized]
+            tensors = [y_hidden_serialized, y_causallm_serialized, y_causallmnext_serialized, y_seq_2_seq_serialized]
         )
 
     receptor_pool._get_or_create_receptor_for_endpoint(neuron_obj)
     receptor_pool.receptors[neuron_obj.hotkey].stub.Forward = MagicMock( return_value = mock_return_val )
     resp1,  codes, _ = receptor_pool.forward( endpoints, synapses, x, timeout=1)
-    assert codes == [[bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.UnknownException],
-    [bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.UnknownException]]
+    assert codes == [[bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.UnknownException],
+    [bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.UnknownException]]
 
 def test_receptor_pool_missing_synapse():
     endpoints = [neuron_obj,neuron_obj]
@@ -241,11 +249,13 @@ def test_receptor_pool_missing_synapse():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
     y_hidden_serialized = serializer.serialize(y_hidden, from_type = bittensor.proto.TensorType.TORCH)
     y_causallm_serialized = serializer.serialize(y_causallm, from_type = bittensor.proto.TensorType.TORCH)
+    y_causallmnext_serialized = serializer.serialize(y_causallmnext, from_type=bittensor.proto.TensorType.TORCH)
     y_seq_2_seq_serialized = serializer.serialize(y_seq_2_seq, from_type = bittensor.proto.TensorType.TORCH)
             
     mock_return_val = bittensor.proto.TensorMessage(
@@ -253,7 +263,7 @@ def test_receptor_pool_missing_synapse():
             hotkey = wallet.hotkey.ss58_address,
             synapses = [synapse.serialize_to_wire_proto(code = bittensor.proto.ReturnCode.Success, message= 'Success' ) for synapse in synapses[:2]],
             return_code = bittensor.proto.ReturnCode.Success,
-            tensors = [y_hidden_serialized, y_causallm_serialized, y_seq_2_seq_serialized]
+            tensors = [y_hidden_serialized, y_causallm_serialized, y_causallmnext_serialized, y_seq_2_seq_serialized]
         )
 
     receptor_pool._get_or_create_receptor_for_endpoint(neuron_obj)

--- a/tests/unit_tests/bittensor_tests/test_receptor_pool.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor_pool.py
@@ -50,6 +50,7 @@ receptor_pool = bittensor.receptor_pool(wallet=wallet)
 synapses = [
     bittensor.synapse.TextLastHiddenState(),
     bittensor.synapse.TextCausalLM(), 
+    bittensor.synapse.TextCausalLMNext(),
     bittensor.synapse.TextSeq2Seq(num_to_generate=70)
 ]
 
@@ -59,12 +60,16 @@ def test_receptor_pool_forward():
     resp1,  _, _ = receptor_pool.forward( endpoints, synapses, x, timeout=1)
     assert list(resp1[0][0].shape) == [2, 2, bittensor.__network_dim__]
     assert list(resp1[0][1].shape) == [2, 2, bittensor.__vocab_size__]
-    assert list(resp1[0][2].shape) == [2, 70]
+    assert list(resp1[0][2].shape) == [2 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)]
+    assert list(resp1[0][3].shape) == [2, 70]
 
 def test_receptor_pool_backward():
     endpoints = [neuron_obj]
     x = torch.ones( (1,2,2) )
-    grads = [[torch.ones(2,2, bittensor.__network_dim__), torch.ones(2, 2, bittensor.__vocab_size__), torch.tensor([]) ]]
+    grads = [[torch.ones(2, 2, bittensor.__network_dim__),
+              torch.ones(2, 2, bittensor.__vocab_size__),
+              torch.ones(2 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)),
+              torch.tensor([])]]
     receptor_pool.backward( endpoints, synapses, x, grads, timeout=1)
 
 
@@ -85,7 +90,8 @@ def test_receptor_pool_max_workers_forward():
     resp1,  _, _ = receptor_pool.forward( endpoints, synapses, x, timeout=1)
     assert list(resp1[0][0].shape) == [2, 2, bittensor.__network_dim__]
     assert list(resp1[0][1].shape) == [2, 2, bittensor.__vocab_size__]
-    assert list(resp1[0][2].shape) == [2, 70]
+    assert list(resp1[0][2].shape) == [2 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)]
+    assert list(resp1[0][3].shape) == [2, 70]
 
 def test_receptor_pool_forward_success():
     endpoints = [neuron_obj,neuron_obj]
@@ -120,11 +126,13 @@ def test_receptor_pool_forward_timeout():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
     y_hidden_serialized = serializer.serialize(y_hidden, from_type = bittensor.proto.TensorType.TORCH)
     y_causallm_serialized = serializer.serialize(y_causallm, from_type = bittensor.proto.TensorType.TORCH)
+    y_causallmnext_serialized = serializer.serialize(y_causallmnext, from_type=bittensor.proto.TensorType.TORCH)
     y_seq_2_seq_serialized = serializer.serialize(y_seq_2_seq, from_type = bittensor.proto.TensorType.TORCH)
             
     mock_return_val = bittensor.proto.TensorMessage(
@@ -132,15 +140,18 @@ def test_receptor_pool_forward_timeout():
             hotkey = wallet.hotkey.ss58_address,
             synapses = [synapse.serialize_to_wire_proto(code = bittensor.proto.ReturnCode.Timeout, message= 'Timeout' ) for synapse in synapses],
             return_code = bittensor.proto.ReturnCode.Timeout,
-            tensors = [y_hidden_serialized, y_causallm_serialized, y_seq_2_seq_serialized]
+            tensors=[y_hidden_serialized, y_causallm_serialized, y_causallmnext_serialized, y_seq_2_seq_serialized]
         )
 
 
     receptor_pool._get_or_create_receptor_for_endpoint(neuron_obj)
     receptor_pool.receptors[neuron_obj.hotkey].stub.Forward = MagicMock( return_value = mock_return_val )
     resp1,  codes, _ = receptor_pool.forward( endpoints, synapses, x, timeout=1)
-    assert codes == [[bittensor.proto.ReturnCode.Timeout, bittensor.proto.ReturnCode.Timeout, bittensor.proto.ReturnCode.Timeout],
-    [bittensor.proto.ReturnCode.Timeout, bittensor.proto.ReturnCode.Timeout, bittensor.proto.ReturnCode.Timeout]]
+    assert codes == [
+        [bittensor.proto.ReturnCode.Timeout, bittensor.proto.ReturnCode.Timeout, bittensor.proto.ReturnCode.Timeout,
+         bittensor.proto.ReturnCode.Timeout],
+        [bittensor.proto.ReturnCode.Timeout, bittensor.proto.ReturnCode.Timeout, bittensor.proto.ReturnCode.Timeout,
+         bittensor.proto.ReturnCode.Timeout]]
 
 def test_receptor_pool_forward_num_synapse_mismatch():
     endpoints = [neuron_obj,neuron_obj]
@@ -262,11 +273,13 @@ def test_receptor_pool_backward_hang():
     
     hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
     causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
+    causallmnext_grads = torch.ones((x.size(0) * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)))
     seq_2_seq_grads = torch.tensor([])
 
     receptor_pool._get_or_create_receptor_for_endpoint(neuron_obj)
     receptor_pool.receptors[neuron_obj.hotkey].stub.Backward = MagicMock( return_value = mock_return_val )
-    receptor_pool.backward( endpoints, synapses, x, [[hidden_grads, causal_grads, seq_2_seq_grads], [hidden_grads, causal_grads, seq_2_seq_grads]], timeout=1)
+    receptor_pool.backward(endpoints, synapses, x, [[hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads],
+                                                    [hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads]], timeout=1)
 
 if __name__ == "__main__":
     test_receptor_pool_missing_synapse()

--- a/tests/unit_tests/bittensor_tests/test_receptor_pool.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor_pool.py
@@ -269,8 +269,8 @@ def test_receptor_pool_missing_synapse():
     receptor_pool._get_or_create_receptor_for_endpoint(neuron_obj)
     receptor_pool.receptors[neuron_obj.hotkey].stub.Forward = MagicMock( return_value = mock_return_val )
     resp1,  codes, _ = receptor_pool.forward( endpoints, synapses, x, timeout=1)
-    assert codes == [[bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException],
-    [bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException]]
+    assert codes == [[bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException],
+    [bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException, bittensor.proto.ReturnCode.ResponseShapeException]]
 
 def test_receptor_pool_backward_hang():
     endpoints = [neuron_obj,neuron_obj]

--- a/tests/unit_tests/bittensor_tests/utils/test_tokenizer_utils.py
+++ b/tests/unit_tests/bittensor_tests/utils/test_tokenizer_utils.py
@@ -424,7 +424,164 @@ def test_topk_token_phrases():
         tokenizer_topk_phrases(sample_text[text_name], model_name, max_length, _enc_pre_logits, topk=128)
 
 
+def topk_phrases_crossentropy(text_batch: List[str], model_name: str, max_length: int,
+                              last_indices: List[int],
+                              enc_pre_logits: torch.FloatTensor = None,
+                              device: str = 'cpu', topk: int = 128):
+    r"""
+    Tests the phrase cross entropy calculation to support loss calculation not just for next token
+    but also for next phrase consisting of standard tokenized token sequence that should be matched.
+    Emulates validator -> server -> validator interaction where the server-side logits phrases are
+    standard tokenized to token sequences / phrase with associated probabilities.
+    This allows the validator to receive full server continuation possibilities consisting of multiple tokens
+    per phrase, and not just a single token, without having to know any server tokenizer/model/decoder particulars.
+    Topk logit encoding is only used to save the server model response to avoid CUDA-device requirement
+    when routinely running the unit test.
+        Args:
+            text_batch (:obj:`List[str]`, `required`):
+                Input text_batch to test tokenizer translation with.
+            model_name (:obj:`str`, `required`):
+                Name of transformer model to use as template server.
+            max_length (:obj:`int`, `required`):
+                Specific tokenization max length, small enough to prevent padding,
+                since GPT2 tokenization doesn't have padding.
+            last_indices (:obj:`int`, `required`):
+                Sequence indices to use as last token indicator, with continuation forming target phrase.
+            enc_pre_logits (:obj:`torch.FloatTensor`, `optional`):
+                [batch_size, sequence_len, vocab_size] Encoded pre_logits from saved source, to
+                bypass server model forward call.
+            device (:obj:`str`, `optional`):
+                CUDA device for server model forward call.
+            topk (:obj:`int`, `optional`):
+                Amount of top logits to encode the server model pre_logits with (for saving purposes).
+
+        Returns:
+
+    """
+    # =============================================
+    # ==== Validator-side: CausalLM task setup ====
+    # =============================================
+
+    std_tokenizer = AutoTokenizer.from_pretrained('gpt2')
+
+    input_batch = std_tokenizer(text_batch, return_offsets_mapping=True, add_special_tokens=False,
+                                max_length=max_length, truncation=True, return_tensors='pt')
+
+    token_batch = input_batch['input_ids']
+
+    # ============================
+    # ==== Server-side: Setup ====
+    # ============================
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+    # ================================================
+    # ==== Server-side: CausalLM task translation ====
+    # ================================================
+
+    text_batch = std_tokenizer.batch_decode(token_batch)  # decode tokens to original text
+    result = translate_special_token_text(text_batch, std_tokenizer, tokenizer)
+    to_text_batch, from_offsets_batch, to_offsets_batch, pad_offsets_batch = result
+
+    std_tokens = std_tokenizer(text_batch, return_offsets_mapping=True)  # encode to get offsets
+    tokens = tokenizer(to_text_batch, return_offsets_mapping=True, add_special_tokens=False)
+
+    std_tokens['offset_mapping'] = pad_offsets(std_tokens['offset_mapping'], from_offsets_batch, pad_offsets_batch)
+    tokens['offset_mapping'] = pad_offsets(tokens['offset_mapping'], to_offsets_batch, pad_offsets_batch)
+    tokens['offset_mapping_std'] = std_tokens['offset_mapping']
+
+    for key in ['input_ids', 'attention_mask']:
+        tokens[key] = pad_sequence([torch.LongTensor(tensor) for tensor in tokens[key]], batch_first=True)
+        tokens[key] = torch.LongTensor(tokens[key])
+
+    # ==============================================
+    # ==== Server-side: CausalLM task execution ====
+    # ==============================================
+
+    if enc_pre_logits is None:
+        server_model = AutoModelForCausalLM.from_pretrained(model_name).to(device)
+
+        with torch.no_grad():
+            pre_model_output = server_model(input_ids=tokens['input_ids'].to(device),
+                                            attention_mask=tokens['attention_mask'].to(device),
+                                            output_hidden_states=True)
+            pre_logits = pre_model_output.logits
+
+        enc_pre_logits = encode_forward_response_tensor(pre_logits, topk=topk).cpu()
+
+    dec_pre_logits = decode_forward_response_tensor(enc_pre_logits, len(tokenizer.vocab), topk=topk)
+    # dec_pre_logits.shape = [batch_size, sequence_len, vocab_size]
+
+    recorded_losses = []
+    for last_idx in last_indices:
+        last_logits = dec_pre_logits[:, last_idx, :]  # last token predictions: [batch_size]
+        target_phrases = tokenizer.batch_decode(tokens['input_ids'][:, last_idx+1:])
+        target_phrases = std_tokenizer(target_phrases)['input_ids']
+
+        result = topk_token_phrases(last_logits, tokenizer, std_tokenizer, topk=topk)
+        compact_topk, _topk_tokens, _topk_probs, _floor_probs = result
+        # compact_topk: [sum_b(sum_k(len(phrase_k) + 1)_b)] Compacted 1-D tensor >= batch_size * (2 * topk + 1)
+
+        topk_tokens, topk_probs, floor_probs = unravel_topk_token_phrases(compact_topk, topk=topk)
+
+        assert (_topk_tokens - topk_tokens).abs().sum() < 1e-9
+        assert (_topk_probs - topk_probs).abs().sum() < 1e-9
+        assert (_floor_probs - floor_probs).abs().sum() < 1e-9
+
+        loss = phrase_cross_entropy(target_phrases, topk_tokens, topk_probs, floor_probs)
+        recorded_losses += [loss.item()]
+
+    return recorded_losses
+
+
+def test_topk_phrases_crossentropy():
+    r"""
+    Unit test for calculating topk token phrases cross entropy with target phrases.
+
+        Returns:
+            Asserts that phrase cross entropy calculation yields previously observed value.
+    """
+    test_pairs = [('German-1', 'benjamin/gerpt2-large', 172, list(range(50, 111, 5)),
+                   [1.08, 1.62, 5.00, 1.42, 5.31, 3.66, 4.36, 0.07, 7.11, 14.67, 5.97, 5.85, 92.10])]
+
+    try:
+        encodings = torch.load(encodings_cache_file)
+
+    except FileNotFoundError as e:
+        print('FileNotFoundError: Server model results not yet saved to', encodings_cache_file)
+        raise
+
+        # # === Run server models to obtain encoded logits ===
+        # print('Will first run server models (requires CUDA)...')
+        #
+        # encodings = {}
+        # for text_name, model_name, max_length in test_pairs:
+        #     result = tokenizer_translation(sample_text[text_name], model_name, max_length, topk=128)
+        #     original_loss, encoded_loss, translated_loss, enc_pre_logits = result
+        #     encodings[(text_name, model_name)] = (encoded_loss, translated_loss, enc_pre_logits)
+        #
+        #     print(text_name, model_name, original_loss, encoded_loss, translated_loss)
+        #
+        #     # English-1 EleutherAI/gpt-j-6B tensor(1.2531) tensor(1.3274) tensor(1.3274)
+        #     # English-1 benjamin/gerpt2-large tensor(3.7499) tensor(4.2219) tensor(4.5502)
+        #     # German-1 benjamin/gerpt2-large tensor(3.5197) tensor(4.0664) tensor(4.1428)
+        #
+        # torch.save(encodings, encodings_cache_file)
+        # encodings = torch.load(encodings_cache_file)
+
+    # === Run test on saved encoded logits ===
+    for text_name, model_name, max_length, last_indices, _recorded_losses in test_pairs:
+        _encoded_loss, _translated_loss, _enc_pre_logits = encodings[(text_name, model_name)]
+        recorded_losses = topk_phrases_crossentropy(sample_text[text_name], model_name, max_length,
+                                                    last_indices, _enc_pre_logits, topk=128)
+
+        recorded_losses = [round(r, 2) for r in recorded_losses]
+        # print(', '.join([f'{loss:.2f}' for loss in recorded_losses]))
+        assert _recorded_losses == recorded_losses
+
+
 if __name__ == '__main__':
     test_tokenizer_equivalence()
     test_tokenizer_translation()
     test_topk_token_phrases()
+    test_topk_phrases_crossentropy()

--- a/tests/unit_tests/bittensor_tests/utils/test_tokenizer_utils.py
+++ b/tests/unit_tests/bittensor_tests/utils/test_tokenizer_utils.py
@@ -25,6 +25,7 @@ from torch.nn.utils.rnn import pad_sequence
 from bittensor.utils.tokenizer_utils import *
 
 EPSILON = 1e-40
+encodings_cache_file = "tests/unit_tests/bittensor_tests/utils/test_tokenizer_utils.pt"
 
 sample_text = {'English-1': ['''The Three Laws of Robotics (often shortened to The Three Laws or known as Asimov's Laws) are a set of rules devised by science fiction author Isaac Asimov. The rules were introduced in his 1942 short story "Runaround" (included in the 1950 collection I, Robot), although they had been foreshadowed in some earlier stories. The Three Laws, quoted from the "Handbook of Robotics, 56th Edition, 2058 A.D.", are:''',
 
@@ -250,8 +251,6 @@ def test_tokenizer_translation():
                   ('English-1', 'benjamin/gerpt2-large', 95),
                   ('German-1', 'benjamin/gerpt2-large', 172)]
 
-    encodings_cache_file = "tests/unit_tests/bittensor_tests/utils/test_tokenizer_utils.pt"
-
     try:
         encodings = torch.load(encodings_cache_file)
 
@@ -287,6 +286,145 @@ def test_tokenizer_translation():
         assert torch.isclose(translated_loss, _translated_loss, rtol=1e-2)
 
 
+def tokenizer_topk_phrases(text_batch: List[str], model_name: str, max_length: int,
+                           enc_pre_logits: torch.FloatTensor = None,
+                           device: str = 'cuda', topk: int = 128):
+    r"""
+    Emulates validator -> server -> validator interaction where the server-side logits phrases are
+    standard tokenized to token sequences / phrase with associated probabilities.
+    This allows the validator to receive full server continuation possibilities consisting of multiple tokens
+    per phrase, and not just a single token, without having to know any server tokenizer/model/decoder particulars.
+    Topk logit encoding is only used to save the server model response to avoid CUDA-device requirement
+    when routinely running the unit test.
+        Args:
+            text_batch (:obj:`List[str]`, `required`):
+                Input text_batch to test tokenizer translation with.
+            model_name (:obj:`str`, `required`):
+                Name of transformer model to use as template server.
+            max_length (:obj:`int`, `required`):
+                Specific tokenization max length, small enough to prevent padding,
+                since GPT2 tokenization doesn't have padding.
+            enc_pre_logits (:obj:`torch.FloatTensor`, `optional`):
+                [batch_size, sequence_len, vocab_size] Encoded pre_logits from saved source, to
+                bypass server model forward call.
+            device (:obj:`str`, `optional`):
+                CUDA device for server model forward call.
+            topk (:obj:`int`, `optional`):
+                Amount of top logits to encode the server model pre_logits with (for saving purposes).
+
+        Returns:
+
+    """
+    # =============================================
+    # ==== Validator-side: CausalLM task setup ====
+    # =============================================
+
+    std_tokenizer = AutoTokenizer.from_pretrained('gpt2')
+
+    input_batch = std_tokenizer(text_batch, return_offsets_mapping=True, add_special_tokens=False,
+                                max_length=max_length, truncation=True, return_tensors='pt')
+
+    token_batch = input_batch['input_ids']
+
+    # ============================
+    # ==== Server-side: Setup ====
+    # ============================
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+    # ================================================
+    # ==== Server-side: CausalLM task translation ====
+    # ================================================
+
+    text_batch = std_tokenizer.batch_decode(token_batch)  # decode tokens to original text
+    result = translate_special_token_text(text_batch, std_tokenizer, tokenizer)
+    to_text_batch, from_offsets_batch, to_offsets_batch, pad_offsets_batch = result
+
+    std_tokens = std_tokenizer(text_batch, return_offsets_mapping=True)  # encode to get offsets
+    tokens = tokenizer(to_text_batch, return_offsets_mapping=True, add_special_tokens=False)
+
+    std_tokens['offset_mapping'] = pad_offsets(std_tokens['offset_mapping'], from_offsets_batch, pad_offsets_batch)
+    tokens['offset_mapping'] = pad_offsets(tokens['offset_mapping'], to_offsets_batch, pad_offsets_batch)
+    tokens['offset_mapping_std'] = std_tokens['offset_mapping']
+
+    for key in ['input_ids', 'attention_mask']:
+        tokens[key] = pad_sequence([torch.LongTensor(tensor) for tensor in tokens[key]], batch_first=True)
+        tokens[key] = torch.LongTensor(tokens[key])
+
+    # ==============================================
+    # ==== Server-side: CausalLM task execution ====
+    # ==============================================
+
+    if enc_pre_logits is None:
+        server_model = AutoModelForCausalLM.from_pretrained(model_name).to(device)
+
+        with torch.no_grad():
+            pre_model_output = server_model(input_ids=tokens['input_ids'].to(device),
+                                            attention_mask=tokens['attention_mask'].to(device),
+                                            output_hidden_states=True)
+            pre_logits = pre_model_output.logits
+
+        enc_pre_logits = encode_forward_response_tensor(pre_logits, topk=topk).cpu()
+
+    dec_pre_logits = decode_forward_response_tensor(enc_pre_logits, len(tokenizer.vocab), topk=topk)
+    # dec_pre_logits.shape = [batch_size, sequence_len, vocab_size]
+
+    last_logits = dec_pre_logits[:, -1, :]  # last token predictions: [batch_size, vocab_size]
+
+    result = topk_token_phrases(last_logits, tokenizer, std_tokenizer, topk=topk)
+    compact_topk, _topk_tokens, _topk_probs, _floor_probs = result
+    # compact_topk: [sum_b(sum_k(len(phrase_k) + 1)_b)] Compacted 1-D tensor >= batch_size * (2 * topk + 1)
+
+    topk_tokens, topk_probs, floor_probs = unravel_topk_token_phrases(compact_topk, topk=topk)
+
+    assert (_topk_tokens - topk_tokens).abs().sum() < 1e-9
+    assert (_topk_probs - topk_probs).abs().sum() < 1e-9
+    assert (_floor_probs - floor_probs).abs().sum() < 1e-9
+
+
+def test_topk_token_phrases():
+    r"""
+    Unit test for topk token phrases raveling and unraveling.
+
+        Returns:
+            Asserts that compact tensor of topk token phrases can be unraveled to recover original topk tensors.
+    """
+    test_pairs = [('English-1', 'EleutherAI/gpt-j-6B', 95),
+                  ('English-1', 'benjamin/gerpt2-large', 95),
+                  ('German-1', 'benjamin/gerpt2-large', 172)]
+
+    try:
+        encodings = torch.load(encodings_cache_file)
+
+    except FileNotFoundError as e:
+        print('FileNotFoundError: Server model results not yet saved to', encodings_cache_file)
+        raise
+
+        # # === Run server models to obtain encoded logits ===
+        # print('Will first run server models (requires CUDA)...')
+        #
+        # encodings = {}
+        # for text_name, model_name, max_length in test_pairs:
+        #     result = tokenizer_translation(sample_text[text_name], model_name, max_length, topk=128)
+        #     original_loss, encoded_loss, translated_loss, enc_pre_logits = result
+        #     encodings[(text_name, model_name)] = (encoded_loss, translated_loss, enc_pre_logits)
+        #
+        #     print(text_name, model_name, original_loss, encoded_loss, translated_loss)
+        #
+        #     # English-1 EleutherAI/gpt-j-6B tensor(1.2531) tensor(1.3274) tensor(1.3274)
+        #     # English-1 benjamin/gerpt2-large tensor(3.7499) tensor(4.2219) tensor(4.5502)
+        #     # German-1 benjamin/gerpt2-large tensor(3.5197) tensor(4.0664) tensor(4.1428)
+        #
+        # torch.save(encodings, encodings_cache_file)
+        # encodings = torch.load(encodings_cache_file)
+
+    # === Run test on saved encoded logits ===
+    for text_name, model_name, max_length in test_pairs:
+        _encoded_loss, _translated_loss, _enc_pre_logits = encodings[(text_name, model_name)]
+        tokenizer_topk_phrases(sample_text[text_name], model_name, max_length, _enc_pre_logits, topk=128)
+
+
 if __name__ == '__main__':
     test_tokenizer_equivalence()
     test_tokenizer_translation()
+    test_topk_token_phrases()


### PR DESCRIPTION
Adds the TextCausalLMNext Synapse, as well as the tokenizer_utils needed to encode/decode the synapse. Both core_server and core_validator are running successfully on Nobunaga with this branch.

TextCausalLMNext sends a user-defined topk of server token phrases for input context continuation, which validator/client uses for validated generation where server phrase probabilities are evaluated against a groundtruth continuation. Supports backward gradients from validator/client to server.

Check detailed commit explanations.