### PR TITLE
[BIT-484] Add serving and validation for TextCausalLMNext synapse

### DIFF
--- a/bittensor/_neuron/text/core_server/__init__.py
+++ b/bittensor/_neuron/text/core_server/__init__.py
@@ -49,6 +49,8 @@ class neuron:
                 lasthidden synapse control
             causallm (:obj:bool, `optional`):
                 causallm synapse control
+            causallmnext (:obj:bool, `optional`):
+                causallmnext synapse control
             seq2seq (:obj:bittensor.metagraph, `optional`):
                 seq2seq synapse control
             synapse_list (:obj:list of int, `optional`):
@@ -68,6 +70,7 @@ class neuron:
         metagraph: 'bittensor.metagraph' = None,
         lasthidden = None,
         causallm = None,
+        causallmnext = None,
         seq2seq = None,
         synapse_list = None,
 
@@ -78,6 +81,7 @@ class neuron:
         if synapse_list != None:
             config.neuron.lasthidden = False
             config.neuron.causallm = False
+            config.neuron.causallmnext = False
             config.neuron.seq2seq = False
 
             if bittensor.proto.Synapse.SynapseType.TEXT_LAST_HIDDEN_STATE in synapse_list:
@@ -85,12 +89,16 @@ class neuron:
             
             if bittensor.proto.Synapse.SynapseType.TEXT_CAUSAL_LM in synapse_list:
                 config.neuron.causallm = True
-            
+
+            if bittensor.proto.Synapse.SynapseType.TEXT_CAUSAL_LM_NEXT in synapse_list:
+                config.neuron.causallmnext = True
+
             if bittensor.proto.Synapse.SynapseType.TEXT_SEQ_2_SEQ in synapse_list:
                 config.neuron.seq2seq = True
 
         config.neuron.lasthidden = lasthidden if lasthidden != None else config.neuron.lasthidden
         config.neuron.causallm = causallm if causallm != None else config.neuron.causallm
+        config.neuron.causallmnext = causallmnext if causallmnext is not None else config.neuron.causallmnext
         config.neuron.seq2seq = seq2seq if seq2seq != None else config.neuron.seq2seq
 
         self.check_config( config )

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -392,7 +392,7 @@ class neuron:
                 clip_grad_norm_(self.nucleus.parameters(), self.config.neuron.clip_gradients)
                 self.optimizer.step()
                 self.optimizer.zero_grad()
-                print(f'complete [{time.time() - start_time:.3g}s]')
+                print(f'complete \[{time.time() - start_time:.3g}s]')
                 
                 # === Get another round of forward requests ===
                 self.forward_thread_queue.resume()

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -163,7 +163,7 @@ class neuron:
 
         # === Neuron statistics variables ===
         self.alpha = 0.05  # EMA coefficient in [0, 1], higher alpha discounts older observations faster
-        self.weight_key = 'shapley_values_min!'  # stat key to calculate neuron weights with
+        self.weight_key = 'shapley_values_min'  # stat key + ! to calculate neuron weights with
         # stat keys to duplicate (['key']->['key!']) and push zero to its EMA if neuron non-responsive
         self.synapse_keys = ['shapley_values_min', 'shapley_values_nxt']
         self.neuron_stats = {}

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -736,20 +736,19 @@ class nucleus( torch.nn.Module ):
         )
 
         if not self.config.nucleus.dendrite_backward:
-            query_responses = [(res[0].detach(),) for res in query_responses]
-            return_ops = [ops.detach() for ops in return_ops]
-            times = [time.detach() for time in times]
+            query_responses = [[syn.detach().to(self.device) for syn in res] for res in query_responses]
+            return_ops = [ops.detach().to(self.device) for ops in return_ops]
+            times = [t.detach().to(self.device) for t in times]
+
+        # Send responses to device. This is required to ensure we move the responses
+        # Onto the correct device.
+        for responses in query_responses:
+            for response in responses:
+                response.to(self.device)
 
         print(f'complete \[{time.time() - request_start_time:.3g}s]')
         print(f'Shapley values \t| Calculating ... ', end='')
         shapley_start_time = time.time()
-
-        # Send responses to device. This is required to ensure we move the responses
-        # Onto the correct device.
-        query_responses = [[response.to(self.device) for response in responses] for responses in query_responses]
-
-        # Send return ops to device.
-        return_ops = [ops.to(self.device) for ops in return_ops]
 
         stats = []
         routing_loss = torch.tensor(0.).to( self.device )

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -618,6 +618,34 @@ class neuron:
                                                                            multiple=max_allowed_ratio)
         return topk_uids, topk_weights
 
+    def weights_table(self, topk_uids, topk_weights):
+        r""" Prints weights table given topk_uids and topk_weights.
+        """
+        n_topk_peer_weights = self.subtensor.min_allowed_weights
+        max_allowed_ratio = self.subtensor.max_allowed_min_max_ratio
+
+        # === Weight table ===
+        # Prints exponential moving average statistics of valid neurons and latest weights
+        _neuron_stats = {}
+        unvalidated = []
+        for uid, weight in zip(topk_uids.tolist(), topk_weights.tolist()):
+            if uid in self.neuron_stats:
+                _neuron_stats[uid] = {k: v for k, v in self.neuron_stats[uid].items()}
+                _neuron_stats[uid]['weight'] = weight
+            else:
+                unvalidated += [uid]
+
+        print()
+        stats_table(_neuron_stats, 'weight', self.config.get('width', None),
+                    f'[white] Neuron weights [/white] | ' + str(self),  # title
+                    f'Validated [bold]{(n_topk_peer_weights - len(unvalidated))}[/bold]'
+                    f'/{n_topk_peer_weights}/{self.metagraph.n} (valid/min/total) | '
+                    f'sum:{topk_weights.sum().item():.2g} '
+                    f'[white] max:[bold]{topk_weights.max().item():.4g}[/bold] / '
+                    f'min:[bold]{topk_weights.min().item():.4g}[/bold] [/white] '
+                    f'\[{topk_weights.max().item() / topk_weights.min().item():.1f}:1] '
+                    f'({max_allowed_ratio} allowed)')  # caption
+
 
 class nucleus( torch.nn.Module ):
     """ Nucleus class which holds the validator model.

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -921,3 +921,42 @@ def synergy_table(stats, syn_loss_diff, sort_col, console_width):
     if len(rows):
         print(table)
         print()
+
+
+def stats_table(stats, sort_col, console_width, title, caption):
+    r""" Gathers data and constructs neuron statistics table and prints it
+    """
+    # === Gather columns and rows ===
+    stats_keys = [set(k for k in stat)
+                  for stat in stats.values() if sort_col in stat]  # all available stats keys with sort_col
+
+    if len(stats_keys) == 0:
+        return  # nothing to print
+
+    stats_keys = set.union(*stats_keys)
+    columns = [c[:] for c in neuron_stats_columns if c[1] in stats_keys]  # available columns intersecting with stats_keys
+    rows = [['' if key not in stat else txt.format(stat[key]) for _, key, txt, _ in columns]
+            for stat in stats.values() if sort_col in stat]  # only keep rows with at least one non-empty cell
+
+    if len(columns) == 0 or len(rows) == 0:
+        return  # nothing to print
+
+    # === Sort rows ===
+    col_keys = [c[1] for c in columns]
+    if sort_col in col_keys:
+        sort_idx = col_keys.index(sort_col)  # sort column with key of sort_col
+        columns[sort_idx][0] += '\u2193'  # ↓ downwards arrow (sort)
+        rows = sorted(rows, reverse=True, key=lambda _row: _row[sort_idx])  # sort according to _sortcol
+
+    # === Instantiate stats table ===
+    table = Table(width=console_width, box=None, row_styles=[Style(bgcolor='grey15'), ""])
+    table.title = title
+    table.caption = caption
+
+    for col, _, _, stl in columns:  # [Column_name, key_name, format_string, rich_style]
+        table.add_column(col, style=stl, justify='right')
+    for row in rows:
+        table.add_row(*row)
+
+    # === Print table ===
+    print(table)

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -971,3 +971,13 @@ def synapse_table(name, stats, sort_col, console_width, start_time):
                 f'[bold]{len([s for s in stats.values() if len(s)])}[/bold]/{len(stats)} (respond/topk) | '
                 f'[bold]Synapse[/bold] | [white]\[{time.time() - start_time:.3g}s][/white]'  # caption
                 )
+
+
+def unsuccess(_name, _unsuccessful):
+    r""" Prints the return codes and response times of unsuccessful responses
+    """
+    # === Unsuccessful responses ===
+    unsuccess_txt = f'\[{_name}] Unsuccessful \t| [cyan]UID[/cyan]\[[red]return_op[/red] [yellow]time[/yellow]]: '
+    for _uid, _return_op, _time in _unsuccessful:
+        unsuccess_txt += f'{_uid}[[red]{_return_op}[/red] [yellow not bold]{_time:.2f}[/yellow not bold]] '
+    print(unsuccess_txt)

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -203,7 +203,15 @@ class neuron:
         bittensor.dataset.add_args( parser )
         bittensor.wandb.add_args(parser)
         return bittensor.config( parser )
-    
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def __str__(self) -> str:
+        return (f'[bold]UID {self.uid}[/bold] \[{self.dendrite.receptor_pool.external_ip}] '
+                f'({self.wallet.name}:[bold]{self.wallet.coldkeypub.ss58_address[:7]}[/bold]/'
+                f'{self.config.wallet.hotkey}:[bold]{self.wallet.hotkey.ss58_address[:7]}[/bold])')
+
     def __del__(self):
         self.__exit__()
 

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -155,7 +155,6 @@ class neuron:
         # stat keys to duplicate (['key']->['key!']) and push zero to its EMA if neuron non-responsive
         self.synapse_keys = ['shapley_values_min', 'shapley_values_nxt']
         self.neuron_stats = {}
-        self.server_stats = {}
 
     @classmethod
     def check_config( cls, config: 'bittensor.Config' ):
@@ -379,8 +378,8 @@ class neuron:
                 wandb.log({'epoch/epoch': self.epoch, 'epoch/epoch_steps': epoch_steps,
                            'epoch/global_steps': self.global_step, 'epoch/loss': loss.item(),
                            'epoch/time': step_time}, step=current_block)
-                for uid, vals in self.server_stats.items():
-                    for key in vals:  # detailed server evaluation fields, e.g. loss, shapley_values, synergy
+                for uid, vals in self.neuron_stats.items():
+                    for key in vals:  # detailed neuron evaluation fields, e.g. loss, shapley_values, synergy
                         wandb.log({f'stats/{key}_{uid}': vals[key]}, step=current_block)
 
             # Do the backward request after the a queue of forward requests got finished.  
@@ -431,11 +430,11 @@ class neuron:
         old_hotkeys = self.metagraph.hotkeys 
         self.metagraph.sync()
 
-        # === Reset server stats if uid got replaced
+        # === Reset neuron stats if uid got replaced
         for uid, old_hotkey in enumerate(old_hotkeys):
             if old_hotkey != self.metagraph.hotkeys[uid]:
-                if uid in self.server_stats:
-                    del self.server_stats[uid]
+                if uid in self.neuron_stats:
+                    del self.neuron_stats[uid]
 
     def neuron_stats_update(self, neuron_stats: Dict[int, Dict[str, Any]]):
         r""" Updates self.neuron_stats with new individual dictionaries per uid.

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -899,6 +899,14 @@ class nucleus( torch.nn.Module ):
         return routing_loss, stats
 
 
+def scaling_law_loss_to_params(loss):
+    r""" (OpenAI scaling laws) Kaplan, Jared, et al. "Scaling laws for neural language models." arXiv:2001.08361 (2020)
+    """
+    num_params = torch.exp(torch.log(torch.tensor(8.8e13)) - torch.log(torch.clamp(loss, 1.69)) / 0.076)
+    pow_num_params = torch.pow(num_params, 0.5)  # powered down number of params, dynamic range 3 → 6 nats
+    return pow_num_params  # modified scaling law, powered down to improve dynamic range (subject to change)
+
+
 def shapley_base(uids: torch.Tensor, query_responses: List[List[torch.FloatTensor]], return_ops: List[torch.LongTensor],
                  times: List[torch.FloatTensor], routing_score: torch.FloatTensor,
                  base_params: Callable, index_s: int = 0, ext: str = None) -> Tuple[torch.FloatTensor, Dict, List]:

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -59,22 +59,34 @@ install(show_locals=True)
 #   [Column_name, key_name, format_string, rich_style]  # description
 neuron_stats_columns = [
     ['UID', 'uid', '{:.0f}', 'cyan'],  # neuron UID
-    ['Upd', 'updates', '{}', 'bright_yellow'],  # number of exponential moving average updates
-    ['Time', 'response_time', '{:.2f}', 'yellow'],  # response time to forward requests
+    ['Upd!', 'updates!', '{}', 'bright_yellow'],  # number of exponential moving average updates with zeroing on
+    ['mUpd', 'updates_shapley_values_min', '{}', 'bright_yellow'],  # number of exponential moving average updates to mShap
+    ['nUpd', 'updates_shapley_values_nxt', '{}', 'bright_yellow'],  # number of exponential moving average updates to nShap
+    ['sTime', 'response_time', '{:.2f}', 'yellow'],  # response time to TextCausalLM forward requests
+    ['nTime', 'response_time_nxt', '{:.2f}', 'yellow'],  # response time to TextCausalLMNext forward requests
     ['Route', 'routing_score', '{:.3f}', 'grey30'],  # validator routing score (higher preferred)
     ['Weight', 'weight', '{:.5f}', 'green'],  # weight set on substrate (each epoch)
+    ['mShap!', 'shapley_values_min!', '{:.0f}', 'bright_magenta'],  # min(Shap, vShap) of sequence and validation Shapley (zeroing)
     ['mShap', 'shapley_values_min', '{:.0f}', 'bright_magenta'],  # min(Shap, vShap) of sequence and validation Shapley
-    ['Loss', 'loss', '{:.2f}', 'bright_cyan'],  # next token prediction loss average over sequence
+    ['sLoss', 'loss', '{:.2f}', 'bright_cyan'],  # next token prediction loss average over sequence
     ['vLoss', 'loss_val', '{:.2f}', 'bright_cyan'],  # next token prediction loss for validation task
+    ['nLoss', 'loss_nxt', '{:.2f}', 'bright_cyan'],  # next token phrase prediction loss for phrase validation task
     ['RLoss', 'routing_loss', '{:.3f}', 'grey30'],  # MSE between routing_score and conditioned loss
-    ['Shap', 'shapley_values', '{:.0f}', 'magenta'],  # Shapley value (=Base+Syn) over sequence
+    ['nRLoss', 'routing_loss_nxt', '{:.3f}', 'grey30'],  # MSE between routing_score_nxt and conditioned loss
+    ['sShap', 'shapley_values', '{:.0f}', 'magenta'],  # Shapley value (=Base+Syn) over sequence
     ['vShap', 'shapley_values_val', '{:.0f}', 'magenta'],  # Shapley value (=vBase+vSyn) for validation
-    ['Base', 'base_params', '{:.0f}', ''],  # parameter count estimate via adjusted scaling law
+    ['nShap!', 'shapley_values_nxt!', '{:.0f}', 'magenta'],  # Shapley value (=vBase+vSyn) for phrase validation (zeroing)
+    ['nShap', 'shapley_values_nxt', '{:.0f}', 'magenta'],  # Shapley value (=vBase+vSyn) for phrase validation
+    ['sBase', 'base_params', '{:.0f}', ''],  # parameter count estimate via adjusted scaling law
     ['vBase', 'base_params_val', '{:.0f}', ''],  # parameter count estimate for validation task
-    ['Syn', 'synergy', '{:.0f}', 'white'],  # Shapley pairwise synergy over sequence loss (parameter count estimate)
+    ['nBase', 'base_params_nxt', '{:.0f}', ''],  # parameter count estimate for phrase validation task
+    ['sSyn', 'synergy', '{:.0f}', 'white'],  # Shapley pairwise synergy over sequence loss (parameter count estimate)
     ['vSyn', 'synergy_val', '{:.0f}', 'white'],  # Shapley pairwise synergy over validation loss (count estimate)
-    ['SynD', 'synergy_loss_diff', '{:.2f}', 'bright_blue'],  # Shapley pairwise synergy over sequence loss (loss difference)
-    ['vSynD', 'synergy_loss_diff_val', '{:.2f}', 'bright_blue']]  # Shapley pairwise synergy over validation loss (loss difference)
+    ['nSyn', 'synergy_nxt', '{:.0f}', 'white'],  # Shapley pairwise synergy over phrase validation loss (count estimate)
+    ['sSynD', 'synergy_loss_diff', '{:.2f}', 'bright_blue'],  # Shapley pairwise synergy over sequence loss (loss difference)
+    ['vSynD', 'synergy_loss_diff_val', '{:.2f}', 'bright_blue'],  # Shapley pairwise synergy over validation loss (loss difference)
+    ['nSynD', 'synergy_loss_diff_nxt', '{:.2f}', 'bright_blue'],  # Shapley pairwise synergy over phrase validation loss (loss difference)
+]
 
 
 class neuron:

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -148,6 +148,13 @@ class neuron:
         self.forward_thread_queue = ThreadQueue(num_jobs = self.config.neuron.forward_num, target = self.forward)
         self.loss = None
         self.loss_agg_mutex = Lock()
+
+        # === Neuron statistics variables ===
+        self.alpha = 0.05  # EMA coefficient in [0, 1], higher alpha discounts older observations faster
+        self.weight_key = 'shapley_values_min!'  # stat key to calculate neuron weights with
+        # stat keys to duplicate (['key']->['key!']) and push zero to its EMA if neuron non-responsive
+        self.synapse_keys = ['shapley_values_min', 'shapley_values_nxt']
+        self.neuron_stats = {}
         self.server_stats = {}
 
     @classmethod

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -960,3 +960,14 @@ def stats_table(stats, sort_col, console_width, title, caption):
 
     # === Print table ===
     print(table)
+
+
+def synapse_table(name, stats, sort_col, console_width, start_time):
+    r""" Prints the evaluation of the neuron responses to the validator request
+    """
+
+    stats_table(stats, sort_col, console_width,
+                f'[white] \[{name}] responses [/white] | Validator forward',  # title
+                f'[bold]{len([s for s in stats.values() if len(s)])}[/bold]/{len(stats)} (respond/topk) | '
+                f'[bold]Synapse[/bold] | [white]\[{time.time() - start_time:.3g}s][/white]'  # caption
+                )

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -38,7 +38,7 @@ from rich.console import Console
 from rich.style import Style
 from rich.table import Table
 from rich.traceback import install
-from ..neuron_utilities import joining_context, partial_contexts, ThreadQueue
+from ..neuron_utilities import ThreadQueue, PositionalEncoding, calc_loss_fct
 import torch.nn as nn
 import random
 from torch.nn.utils import clip_grad_norm_
@@ -528,40 +528,6 @@ class neuron:
             if old_hotkey != self.metagraph.hotkeys[uid]:
                 if uid in self.server_stats:
                     del self.server_stats[uid]
-
-
-class PositionalEncoding(nn.Module):
-    r""" Positional Encoder which adds information based on the relative position of each token
-    
-    """
-    def __init__(self, d_model: int, dropout: float, max_len: int = 5000):
-        super().__init__()
-        self.dropout = nn.Dropout(p=dropout)
-
-        position = torch.arange(max_len).unsqueeze(1)
-        div_term = torch.exp(torch.arange(0, d_model, 2) * (-math.log(10000.0) / d_model))
-
-        # === Create position matrix ===
-        # Creates a positional matrix with alternating frequencies 
-        # pe: (torch.FloatTensor) positional encoding matrix
-        # pe.shape: [1, max_len, network_dim]
-        pe = torch.zeros(1, max_len, d_model)
-        pe[0, :, 0::2] = torch.sin(position * div_term)
-        pe[0, : , 1::2] = torch.cos(position * div_term)
-        self.register_buffer('pe', pe)
-
-    def forward(self, x: torch.tensor) -> torch.tensor:
-        """
-        Args:
-            x: Tensor, shape [batch_size, seq_len, embedding_dim]
-        """
-        # === Positional Encoding ===
-        # Inject some information of the relative position of the token in the sequence.
-        #  Finally, Dropout is applied to tokens
-        # x: (torch.FloatTensor) input sequence tokens with position information injected
-        # x.shape: [batch_size, seq_len, network_dim]
-        x = x + self.pe[0, :x.size(1)]
-        return self.dropout(x)
 
 
 class nucleus( torch.nn.Module ):

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -342,16 +342,9 @@ class neuron:
             # and endpoint scores using shapely approximation of salience.
             loss, stats = self.forward_thread_queue.get()
 
-            # === Scoring ===
+            # === Stats update ===
             # Updates moving averages and history.
-            for s in stats:
-                history = self.server_stats.setdefault(s['uid'], s)
-                history.setdefault('updates', 0)  # add updates fields for new uid entries
-                history['updates'] += 1  # increase number of updates made
-                sum_ratio = 1. / min(20, history['updates'])  # moving average window size of 20 max
-                for key in s:  # detailed server evaluation fields, e.g. loss, shapley_values, synergy
-                    if key not in ['updates']:
-                        history[key] = (1 - sum_ratio) * history[key] + sum_ratio * s[key]  # update EMA
+            self.neuron_stats_update(stats)
 
             # === State update ===
             # Prints step logs to screen.

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1075,8 +1075,6 @@ def shapley_synergy(stats: Dict, synergy: Callable, ext: str, target: torch.Tens
             if 'loss' + ext not in second or _second <= _first:
                 continue
             second_diff = syn_loss_diff.setdefault(_second, {})
-            second_diff.setdefault(_first, 0.)
-            first_diff.setdefault(_second, 0.)
 
             with torch.no_grad():
                 expected_loss = torch.min(first['loss' + ext], second['loss' + ext])  # expecting min loss
@@ -1088,8 +1086,8 @@ def shapley_synergy(stats: Dict, synergy: Callable, ext: str, target: torch.Tens
                 second['synergy_loss_diff' + ext] += loss_diff_share
 
                 # pairwise loss reduction of expected to measured loss due to synergy between first and second
-                first_diff[_second] = torch.max(loss_diff_share, first_diff[_second])
-                second_diff[_first] = torch.max(loss_diff_share, second_diff[_first])
+                first_diff[_second] = loss_diff_share
+                second_diff[_first] = loss_diff_share
 
                 synergy_share = torch.clamp(scaling_law_loss_to_params(measured_loss) -
                                             scaling_law_loss_to_params(expected_loss), 0) / 2

--- a/bittensor/_neuron/text/neuron_utilities.py
+++ b/bittensor/_neuron/text/neuron_utilities.py
@@ -2,6 +2,7 @@ from numpy import zeros_like
 import bittensor
 import threading
 import time
+import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -232,3 +233,38 @@ class ThreadQueue(threading.Thread):
         
     def get(self):
         return self.queue.get()
+
+
+class PositionalEncoding(nn.Module):
+    r""" Positional Encoder which adds information based on the relative position of each token
+
+    """
+
+    def __init__(self, d_model: int, dropout: float, max_len: int = 5000):
+        super().__init__()
+        self.dropout = nn.Dropout(p=dropout)
+
+        position = torch.arange(max_len).unsqueeze(1)
+        div_term = torch.exp(torch.arange(0, d_model, 2) * (-math.log(10000.0) / d_model))
+
+        # === Create position matrix ===
+        # Creates a positional matrix with alternating frequencies
+        # pe: (torch.FloatTensor) positional encoding matrix
+        # pe.shape: [1, max_len, network_dim]
+        pe = torch.zeros(1, max_len, d_model)
+        pe[0, :, 0::2] = torch.sin(position * div_term)
+        pe[0, :, 1::2] = torch.cos(position * div_term)
+        self.register_buffer('pe', pe)
+
+    def forward(self, x: torch.tensor) -> torch.tensor:
+        """
+        Args:
+            x: Tensor, shape [batch_size, seq_len, embedding_dim]
+        """
+        # === Positional Encoding ===
+        # Inject some information of the relative position of the token in the sequence.
+        #  Finally, Dropout is applied to tokens
+        # x: (torch.FloatTensor) input sequence tokens with position information injected
+        # x.shape: [batch_size, seq_len, network_dim]
+        x = x + self.pe[0, :x.size(1)]
+        return self.dropout(x)

--- a/bittensor/_neuron/text/neuron_utilities.py
+++ b/bittensor/_neuron/text/neuron_utilities.py
@@ -11,6 +11,16 @@ from threading import Thread
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 
+
+def calc_loss_fct(loss_fct, logits, labels):
+    r""" Calculates self.loss_fct with logits and labels that are expected to be aligned already.
+    """
+    _logits = logits.contiguous()
+    _labels = labels.contiguous()
+    loss = loss_fct(_logits.view(-1, _logits.size(-1)), _labels.view(-1))
+    return loss
+
+
 def update_metagraph_peerweight(metagraph, nucleus, device):
     r"""
     Check for the change in hotkey before and after metagraph sync, 

--- a/bittensor/utils/tokenizer_utils.py
+++ b/bittensor/utils/tokenizer_utils.py
@@ -907,7 +907,7 @@ def phrase_cross_entropy(target_phrases: Union[List[int], torch.Tensor],
     n_topk_probs = topk_probs / total_probs[:, None]  # [batch_size, topk] normalized topk_probs
     n_floor_probs = floor_probs / total_probs  # [batch_size] normalized floor_probs
 
-    match_probs = torch.zeros(batch_size)  # accumulate probabilities when sub target matches phrase
+    match_probs = torch.zeros(batch_size).to(topk_probs.device)  # accumulate probabilities when sub target matches phrase
     for b in range(batch_size):
         # === Integrate sub target matches ===
         target_phrase = target_phrases[b]


### PR DESCRIPTION
### [BIT-484] Add serving and validation for TextCausalLMNext

Updates core_server and core_validator with the ability to serve and validate the TextCausalLMNext synapse.

[BIT-484]: https://opentensor.atlassian.net/browse/BIT-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ