### PR TITLE
[BIT-525] Tokenizer improvements (whitespace-preserving)

### DIFF
--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -9,7 +9,7 @@ from typing import Tuple, Optional
 
 from transformers import AutoModel,AutoTokenizer,AutoConfig, AutoModelForCausalLM
 from torch.nn.utils.rnn import pad_sequence
-from bittensor.utils.tokenizer_utils import get_translation_map, translate_logits_to_probs_std, \
+from bittensor.utils.tokenizer_utils import prep_tokenizer, get_translation_map, translate_logits_to_probs_std, \
     translate_special_token_text, pad_offsets, topk_token_phrases
 
 from loguru import logger; logger = logger.opt(colors=True)
@@ -81,7 +81,7 @@ class server(torch.nn.Module):
         if self.pre_model.config.pad_token_id is None and self.pre_model.config.eos_token_id is not None:
             self.pre_model.config.pad_token_id = self.pre_model.config.eos_token_id
 
-        self.tokenizer = self.std_tokenizer.prep_tokenizer(self.tokenizer)
+        self.tokenizer = prep_tokenizer(self.tokenizer)
         self.to_translation_map = get_translation_map(self.tokenizer, self.std_tokenizer)
         self.from_translation_map = get_translation_map(self.std_tokenizer, self.tokenizer)
         self.split_map_cache = {}

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1041,8 +1041,8 @@ def shapley_base(uids: torch.Tensor, query_responses: List[List[torch.FloatTenso
 
                 stats[_uid] = _stats
             except Exception as e:
-                logger.warning(f'Synapse {index_s} shapley_base error\t| '
-                               f'UID {_uid} <dim>[{times[index][index_s]}s]</dim>: {e}')
+                logger.warning(f'Synapse {index_s} error (shapley_base)\t| '
+                               f'UID {_uid} <dim>[{times[index][index_s]:.2f}s]</dim>: {e}')
                 stats[_uid] = _stats
                 unsuccessful += [(_uid, return_ops[index][index_s], times[index][index_s])]
         else:

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1024,21 +1024,27 @@ def shapley_base(uids: torch.Tensor, query_responses: List[List[torch.FloatTenso
                       'response_time' + ext: times[index][index_s],
                       'routing_score': routing_score[_uid]}
 
-            base_params(_stats, query_responses[index][index_s])
+            try:
+                base_params(_stats, query_responses[index][index_s])
 
-            neuron_loss += _stats['loss' + ext]  # add sequence loss to be backward() to neuron
+                neuron_loss += _stats['loss' + ext]  # add sequence loss to be backward() to neuron
 
-            # === Add routing loss ===
-            # MSE loss between predicted routing score and ideal target routing score.
-            # The Bayes risk approx. 1.69, i.e. the minimal loss achievable for next-token
-            # prediction on the full distribution 𝑃, a.k.a the "entropy of natural text"
-            # Hoffmann, Jordan, et al. "Training Compute-Optimal Large Language Models." arXiv:2203.15556 (2022).
-            routing_score_target = torch.exp(-torch.clamp(_stats['loss' + ext].detach() - 1.69, 0))
-            _routing_loss = (routing_score[_uid] - routing_score_target) ** 2  # MSE loss
-            routing_loss += _routing_loss
-            _stats.update({'routing_score_target' + ext: routing_score_target, 'routing_loss' + ext: _routing_loss})
+                # === Add routing loss ===
+                # MSE loss between predicted routing score and ideal target routing score.
+                # The Bayes risk approx. 1.69, i.e. the minimal loss achievable for next-token
+                # prediction on the full distribution 𝑃, a.k.a the "entropy of natural text"
+                # Hoffmann, Jordan, et al. "Training Compute-Optimal Large Language Models." arXiv:2203.15556 (2022).
+                routing_score_target = torch.exp(-torch.clamp(_stats['loss' + ext].detach() - 1.69, 0))
+                _routing_loss = (routing_score[_uid] - routing_score_target) ** 2  # MSE loss
+                routing_loss += _routing_loss
+                _stats.update({'routing_score_target' + ext: routing_score_target, 'routing_loss' + ext: _routing_loss})
 
-            stats[_uid] = _stats
+                stats[_uid] = _stats
+            except Exception as e:
+                logger.warning(f'Synapse {index_s} shapley_base error\t| '
+                               f'UID {_uid} <dim>[{times[index][index_s]}s]</dim>: {e}')
+                stats[_uid] = _stats
+                unsuccessful += [(_uid, return_ops[index][index_s], times[index][index_s])]
         else:
             stats[_uid] = {'uid': _uid,
                            'response_time' + ext: times[index][index_s],

--- a/bittensor/_tokenizer/__init__.py
+++ b/bittensor/_tokenizer/__init__.py
@@ -19,7 +19,7 @@
 
 from transformers import AutoTokenizer
 import bittensor
-from bittensor.utils.tokenizer_utils import set_vocab_len, set_whitespace_preserving
+from bittensor.utils.tokenizer_utils import prep_tokenizer
 
 
 class tokenizer:
@@ -46,46 +46,5 @@ class tokenizer:
         """ Return the GPT2 tokenizer with bittersor's special tokens
         """
         _tokenizer = AutoTokenizer.from_pretrained('gpt2', local_files_only=False)
-        _tokenizer = cls.prep_tokenizer(_tokenizer)
+        _tokenizer = prep_tokenizer(_tokenizer)
         return _tokenizer
-    
-    @staticmethod
-    def prep_tokenizer(tokenizer):
-        tokenizer.padding_side = "left"  # Generative default expects most recent token on right-hand side with padding on left. https://github.com/huggingface/transformers/pull/10552
-        # tokenizer.add_prefix_space = False
-        # tokenizer.add_special_tokens({'bos_token': "[BOS]"}) # A special token representing the beginning of a sentence.
-        # tokenizer.add_special_tokens({'eos_token': "[EOS]"}) # A special token representing the end of a sentence.
-        # tokenizer.add_special_tokens({'unk_token': "[UNK]"}) # A special token representing an out-of-vocabulary token.
-        # tokenizer.add_special_tokens({'sep_token': "[SEP]"}) # A special token separating two different sentences in the same input (used by BERT for instance)
-        # tokenizer.add_special_tokens({'pad_token': "[PAD]"}) # A special token used to make arrays of tokens the same size for batching purpose. Will then be ignored by attention mechanisms or loss computation.
-        # tokenizer.add_special_tokens({'cls_token': "[CLS]"}) # A special token representing the class of the input (used by BERT for instance).
-        # tokenizer.add_special_tokens({'mask_token': "[MASK]"}) # A special token representing a masked token (used by masked-language modeling pretraining objectives, like BERT).
-        # additional_special_tokens = [
-        #     "<s>NOTUSED",  # Used by BARThez
-        #     "</s>NOTUSED", # Used by BARThez
-        #     "<eop>", # Used by MarianMT
-        #     "<eod>", # Used by MarianMT
-        #     "<formula>", # Used by Transformer XL
-        #     "<mask_1>" # Used by Pegasus
-        #     "<special0>", # Used by XLM
-        #     "<special1>", # Used by XLM
-        #     "<special2>", # Used by XLM
-        #     "<special3>", # Used by XLM
-        #     "<special4>", # Used by XLM
-        #     "<special5>", # Used by XLM
-        #     "<special6>", # Used by XLM
-        #     "<special7>", # Used by XLM
-        #     "<special8>", # Used by XLM
-        #     "<special9>", # Used by XLM
-        # ]
-        # tokenizer.additional_special_tokens = additional_special_tokens
-
-        # Define PAD Token = EOS Token (GPT2 generate convention, when PAD Token is None)
-        # https://github.com/huggingface/transformers/blob/49c8c67fb815a277405f84dea4a66353e19fb347/tests/models/gpt2/test_modeling_gpt2.py#L532
-        if tokenizer.pad_token is None and tokenizer.eos_token is not None:
-            tokenizer.pad_token = tokenizer.eos_token
-        set_vocab_len(tokenizer)
-        set_whitespace_preserving(tokenizer)
-
-        return tokenizer
-    

--- a/bittensor/_tokenizer/__init__.py
+++ b/bittensor/_tokenizer/__init__.py
@@ -18,7 +18,9 @@
 # DEALINGS IN THE SOFTWARE.
 
 from transformers import AutoTokenizer
-import bittensor 
+import bittensor
+from bittensor.utils.tokenizer_utils import set_vocab_len, set_whitespace_preserving
+
 
 class tokenizer:
     """ Implementation of the bittensor tokenizer
@@ -44,40 +46,11 @@ class tokenizer:
         """ Return the GPT2 tokenizer with bittersor's special tokens
         """
         _tokenizer = AutoTokenizer.from_pretrained('gpt2', local_files_only=False)
-        _tokenizer.pad_token = _tokenizer.eos_token  # Define PAD Token = EOS Token = 50256. https://github.com/huggingface/transformers/blob/49c8c67fb815a277405f84dea4a66353e19fb347/tests/models/gpt2/test_modeling_gpt2.py#L532
-        _tokenizer.padding_side = "left"  # Generative default expects most recent token on right-hand side with padding on left. https://github.com/huggingface/transformers/pull/10552
-        # _tokenizer.add_prefix_space = False
-        # _tokenizer.add_special_tokens({'bos_token': "[BOS]"}) # A special token representing the beginning of a sentence.
-        # _tokenizer.add_special_tokens({'eos_token': "[EOS]"}) # A special token representing the end of a sentence.
-        # _tokenizer.add_special_tokens({'unk_token': "[UNK]"}) # A special token representing an out-of-vocabulary token.
-        # _tokenizer.add_special_tokens({'sep_token': "[SEP]"}) # A special token separating two different sentences in the same input (used by BERT for instance)
-        # _tokenizer.add_special_tokens({'pad_token': "[PAD]"}) # A special token used to make arrays of tokens the same size for batching purpose. Will then be ignored by attention mechanisms or loss computation.
-        # _tokenizer.add_special_tokens({'cls_token': "[CLS]"}) # A special token representing the class of the input (used by BERT for instance).
-        # _tokenizer.add_special_tokens({'mask_token': "[MASK]"}) # A special token representing a masked token (used by masked-language modeling pretraining objectives, like BERT).
-        # additional_special_tokens = [
-        #     "<s>NOTUSED",  # Used by BARThez
-        #     "</s>NOTUSED", # Used by BARThez
-        #     "<eop>", # Used by MarianMT
-        #     "<eod>", # Used by MarianMT
-        #     "<formula>", # Used by Transformer XL
-        #     "<mask_1>" # Used by Pegasus
-        #     "<special0>", # Used by XLM
-        #     "<special1>", # Used by XLM
-        #     "<special2>", # Used by XLM
-        #     "<special3>", # Used by XLM
-        #     "<special4>", # Used by XLM
-        #     "<special5>", # Used by XLM
-        #     "<special6>", # Used by XLM
-        #     "<special7>", # Used by XLM
-        #     "<special8>", # Used by XLM
-        #     "<special9>", # Used by XLM
-        # ]
-        # _tokenizer.additional_special_tokens = additional_special_tokens
+        _tokenizer = cls.prep_tokenizer(_tokenizer)
         return _tokenizer
     
     @staticmethod
     def prep_tokenizer(tokenizer):
-        tokenizer.pad_token = tokenizer.eos_token  # Define PAD Token = EOS Token = 50256. https://github.com/huggingface/transformers/blob/49c8c67fb815a277405f84dea4a66353e19fb347/tests/models/gpt2/test_modeling_gpt2.py#L532
         tokenizer.padding_side = "left"  # Generative default expects most recent token on right-hand side with padding on left. https://github.com/huggingface/transformers/pull/10552
         # tokenizer.add_prefix_space = False
         # tokenizer.add_special_tokens({'bos_token': "[BOS]"}) # A special token representing the beginning of a sentence.
@@ -106,5 +79,13 @@ class tokenizer:
         #     "<special9>", # Used by XLM
         # ]
         # tokenizer.additional_special_tokens = additional_special_tokens
+
+        # Define PAD Token = EOS Token (GPT2 generate convention, when PAD Token is None)
+        # https://github.com/huggingface/transformers/blob/49c8c67fb815a277405f84dea4a66353e19fb347/tests/models/gpt2/test_modeling_gpt2.py#L532
+        if tokenizer.pad_token is None and tokenizer.eos_token is not None:
+            tokenizer.pad_token = tokenizer.eos_token
+        set_vocab_len(tokenizer)
+        set_whitespace_preserving(tokenizer)
+
         return tokenizer
     

--- a/bittensor/utils/tokenizer_utils.py
+++ b/bittensor/utils/tokenizer_utils.py
@@ -1230,3 +1230,43 @@ def translate_special_token_text(text_batch: List[str], from_tokenizer: PreTrain
         pad_offsets_batch += [padding_offsets]
 
     return to_text_batch, from_offsets_batch, to_offsets_batch, pad_offsets_batch
+
+
+def prep_tokenizer(tokenizer):
+    tokenizer.padding_side = "left"  # Generative default expects most recent token on right-hand side with padding on left. https://github.com/huggingface/transformers/pull/10552
+    # tokenizer.add_prefix_space = False
+    # tokenizer.add_special_tokens({'bos_token': "[BOS]"}) # A special token representing the beginning of a sentence.
+    # tokenizer.add_special_tokens({'eos_token': "[EOS]"}) # A special token representing the end of a sentence.
+    # tokenizer.add_special_tokens({'unk_token': "[UNK]"}) # A special token representing an out-of-vocabulary token.
+    # tokenizer.add_special_tokens({'sep_token': "[SEP]"}) # A special token separating two different sentences in the same input (used by BERT for instance)
+    # tokenizer.add_special_tokens({'pad_token': "[PAD]"}) # A special token used to make arrays of tokens the same size for batching purpose. Will then be ignored by attention mechanisms or loss computation.
+    # tokenizer.add_special_tokens({'cls_token': "[CLS]"}) # A special token representing the class of the input (used by BERT for instance).
+    # tokenizer.add_special_tokens({'mask_token': "[MASK]"}) # A special token representing a masked token (used by masked-language modeling pretraining objectives, like BERT).
+    # additional_special_tokens = [
+    #     "<s>NOTUSED",  # Used by BARThez
+    #     "</s>NOTUSED", # Used by BARThez
+    #     "<eop>", # Used by MarianMT
+    #     "<eod>", # Used by MarianMT
+    #     "<formula>", # Used by Transformer XL
+    #     "<mask_1>" # Used by Pegasus
+    #     "<special0>", # Used by XLM
+    #     "<special1>", # Used by XLM
+    #     "<special2>", # Used by XLM
+    #     "<special3>", # Used by XLM
+    #     "<special4>", # Used by XLM
+    #     "<special5>", # Used by XLM
+    #     "<special6>", # Used by XLM
+    #     "<special7>", # Used by XLM
+    #     "<special8>", # Used by XLM
+    #     "<special9>", # Used by XLM
+    # ]
+    # tokenizer.additional_special_tokens = additional_special_tokens
+
+    # Define PAD Token = EOS Token (GPT2 generate convention, when PAD Token is None)
+    # https://github.com/huggingface/transformers/blob/49c8c67fb815a277405f84dea4a66353e19fb347/tests/models/gpt2/test_modeling_gpt2.py#L532
+    if tokenizer.pad_token is None and tokenizer.eos_token is not None:
+        tokenizer.pad_token = tokenizer.eos_token
+    set_vocab_len(tokenizer)
+    set_whitespace_preserving(tokenizer)
+
+    return tokenizer


### PR DESCRIPTION
### [BIT-525] Tokenizer improvements (whitespace-preserving)

Add support for non whitespace-preserving tokenizers.

Prepends strings with a space, in the case of non whitespace-preserving tokenizers like BERT, which should mimic whitespace-preserving token strings more often than not.

Adds error catching on per-UID basis in shapley_base for synapse validation to be more robust.

[BIT-525]: https://opentensor.atlassian.net/browse/BIT-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ