### PR TITLE
[BIT-526] Improve TextCausalLMNext encoding/decoding

### DIFF
--- a/bittensor/_axon/axon_impl.py
+++ b/bittensor/_axon/axon_impl.py
@@ -29,6 +29,7 @@ import pandas
 from loguru import logger
 import torch.nn.functional as F
 import concurrent
+import traceback
 
 import bittensor
 import bittensor.utils.stats as stat_utils
@@ -489,7 +490,7 @@ class Axon( bittensor.grpc.BittensorServicer ):
             except Exception as e:
                 synapse_codes [index] = bittensor.proto.ReturnCode.RequestDeserializationException
                 synapse_call_times [index] = clock.time() - start_time
-                synapse_messages [index] = 'Input deserialization exception with error:{}'.format(str(e))
+                synapse_messages [index] = 'Input deserialization exception with error:{}'.format(str(e) + str(traceback.format_exc()))
         # Check if the call can stop here.
         if check_if_should_return():
             finalize_codes_stats_and_logs()

--- a/bittensor/_axon/axon_impl.py
+++ b/bittensor/_axon/axon_impl.py
@@ -29,7 +29,6 @@ import pandas
 from loguru import logger
 import torch.nn.functional as F
 import concurrent
-import traceback
 
 import bittensor
 import bittensor.utils.stats as stat_utils
@@ -490,7 +489,7 @@ class Axon( bittensor.grpc.BittensorServicer ):
             except Exception as e:
                 synapse_codes [index] = bittensor.proto.ReturnCode.RequestDeserializationException
                 synapse_call_times [index] = clock.time() - start_time
-                synapse_messages [index] = 'Input deserialization exception with error:{}'.format(str(e) + str(traceback.format_exc()))
+                synapse_messages [index] = 'Input deserialization exception with error:{}'.format(str(e))
         # Check if the call can stop here.
         if check_if_should_return():
             finalize_codes_stats_and_logs()

--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -81,7 +81,7 @@ class server(torch.nn.Module):
         if self.pre_model.config.pad_token_id is None and self.pre_model.config.eos_token_id is not None:
             self.pre_model.config.pad_token_id = self.pre_model.config.eos_token_id
 
-        self.tokenizer = prep_tokenizer(self.tokenizer)
+        self.tokenizer = prep_tokenizer(self.tokenizer, self.std_tokenizer)
         self.to_translation_map = get_translation_map(self.tokenizer, self.std_tokenizer)
         self.from_translation_map = get_translation_map(self.std_tokenizer, self.tokenizer)
         self.split_map_cache = {}

--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -432,7 +432,7 @@ class server(torch.nn.Module):
 
             # Select topk tokenizer logits and retokenize with std_tokenizer,
             # then compact new token phrases and probabilities into 1-D tensor
-            topk_tensor = topk_token_phrases(last_logits, self.tokenizer, topk=topk)  # [batch_size * (topk + 1), max_len]
+            topk_tensor = topk_token_phrases(last_logits, self.tokenizer, topk=topk)  # [batch_size, (topk + 1), max_len]
             compact_topk = compact_topk_token_phrases(topk_tensor)
             # compact_topk: [sum_b(sum_k(len(phrase_k) + 1)_b)] Compacted 1-D tensor >= batch_size * (2 * topk + 1)
 

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -909,8 +909,8 @@ def textcausallmnext(uids: torch.Tensor, query_responses: List[List[torch.FloatT
     inputs_nxt = inputs[..., -validation_len:]  # input validation with next token target phrase [batch_size, val_len]
 
     def _base_params(_stats, query_response):
-        topk_tensor = unravel_topk_token_phrases(query_response, topk=synapse.topk)  # [batch_size, topk + 1, max_len]
-        _losses_val, _losses = phrase_cross_entropy(inputs_nxt, topk_tensor, reduce=False)
+        # topk_tensor = unravel_topk_token_phrases(query_response, topk=synapse.topk)  # [batch_size, topk + 1, max_len]
+        _losses_val, _losses = phrase_cross_entropy(inputs_nxt, query_response, reduce=False)
         _losses_val[_losses_val.isnan()] = 20  # assign large loss
         _losses[_losses.isnan()] = 20  # assign large loss
         _loss_val = _losses_val.mean()

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -909,14 +909,8 @@ def textcausallmnext(uids: torch.Tensor, query_responses: List[List[torch.FloatT
     inputs_nxt = inputs[..., -validation_len:]  # input validation with next token target phrase [batch_size, val_len]
 
     def _base_params(_stats, query_response):
-        result = unravel_topk_token_phrases(query_response, topk=synapse.topk)
-        topk_tokens, topk_probs, floor_probs = result
-        # topk_tokens: [batch_size, topk, max_len] Phrase tokens with ignore_index token for padding.
-        # topk_probs: [batch_size, topk] Probabilities for each phrase in topk.
-        # floor_probs: [batch_size] Floor probabilities as mean probability for non-topk tokens.
-        # inputs_nxt: [batch_size] Target phrases in standard token sequence list.
-
-        _losses_val, _losses = phrase_cross_entropy(inputs_nxt, topk_tokens, topk_probs, floor_probs, reduce=False)
+        topk_tensor = unravel_topk_token_phrases(query_response, topk=synapse.topk)  # [batch_size, topk + 1, max_len]
+        _losses_val, _losses = phrase_cross_entropy(inputs_nxt, topk_tensor, reduce=False)
         _losses_val[_losses_val.isnan()] = 20  # assign large loss
         _losses[_losses.isnan()] = 20  # assign large loss
         _loss_val = _losses_val.mean()

--- a/bittensor/_receptor/receptor_impl.py
+++ b/bittensor/_receptor/receptor_impl.py
@@ -611,8 +611,7 @@ class Receptor(nn.Module):
                 # Input Serialization failed.
                 synapse_codes[index] = bittensor.proto.ReturnCode.ResponseDeserializationException
                 synapse_call_times[index] = clock.time() - start_time
-                synapse_messages[index] = 'Response deserialization exception with error:{}'.format(str(e) + str(traceback.format_exc()))
-                print(synapse_messages[index])
+                synapse_messages[index] = 'Response deserialization exception with error:{}'.format(str(e))
 
 
         # ======================================

--- a/bittensor/_receptor/receptor_impl.py
+++ b/bittensor/_receptor/receptor_impl.py
@@ -16,6 +16,7 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION 
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 # DEALINGS IN THE SOFTWARE.
+import traceback
 
 import bittensor
 from bittensor._synapse import synapse
@@ -610,7 +611,7 @@ class Receptor(nn.Module):
                 # Input Serialization failed.
                 synapse_codes[index] = bittensor.proto.ReturnCode.ResponseDeserializationException
                 synapse_call_times[index] = clock.time() - start_time
-                synapse_messages[index] = 'Response deserialization exception with error:{}'.format(str(e))
+                synapse_messages[index] = 'Response deserialization exception with error:{}'.format(str(e) + str(traceback.format_exc()))
 
 
         # ======================================

--- a/bittensor/_receptor/receptor_impl.py
+++ b/bittensor/_receptor/receptor_impl.py
@@ -612,6 +612,7 @@ class Receptor(nn.Module):
                 synapse_codes[index] = bittensor.proto.ReturnCode.ResponseDeserializationException
                 synapse_call_times[index] = clock.time() - start_time
                 synapse_messages[index] = 'Response deserialization exception with error:{}'.format(str(e) + str(traceback.format_exc()))
+                print(synapse_messages[index])
 
 
         # ======================================

--- a/bittensor/_synapse/text_causallmnext_impl.py
+++ b/bittensor/_synapse/text_causallmnext_impl.py
@@ -175,11 +175,11 @@ class TextCausalLMNext(Synapse):
         return decoded_gradient  # [batch_size, (topk + 1), max_len]
 
     def nill_forward_response_tensor(self, forward_request_tensor: torch.Tensor) -> torch.Tensor:
-        if forward_request_tensor.dim() == 0:
+        if forward_request_tensor.dim() == 0 or forward_request_tensor.shape[0] == 0:
             return torch.tensor([])
         return torch.zeros((forward_request_tensor.shape[0], (self.topk + 1), 1 + 1), dtype=torch.float32)
 
     def nill_backward_response_tensor(self, forward_request_tensor: torch.Tensor) -> torch.Tensor:
-        if forward_request_tensor.dim() == 0:
+        if forward_request_tensor.dim() == 0 or forward_request_tensor.shape[0] == 0:
             return torch.tensor([])
         return torch.zeros((forward_request_tensor.shape[0], (self.topk + 1), 1 + 1), dtype=torch.float32)

--- a/bittensor/_synapse/text_causallmnext_impl.py
+++ b/bittensor/_synapse/text_causallmnext_impl.py
@@ -175,13 +175,11 @@ class TextCausalLMNext(Synapse):
         return decoded_gradient  # [batch_size, (topk + 1), max_len]
 
     def nill_forward_response_tensor(self, forward_request_tensor: torch.Tensor) -> torch.Tensor:
-        try:
-            return torch.zeros((forward_request_tensor.shape[0], (self.topk + 1), 1 + 1), dtype=torch.float32)
-        except:
+        if forward_request_tensor.dim() == 0:
             return torch.tensor([])
+        return torch.zeros((forward_request_tensor.shape[0], (self.topk + 1), 1 + 1), dtype=torch.float32)
 
     def nill_backward_response_tensor(self, forward_request_tensor: torch.Tensor) -> torch.Tensor:
-        try:
-            return torch.zeros((forward_request_tensor.shape[0], (self.topk + 1), 1 + 1), dtype=torch.float32)
-        except:
+        if forward_request_tensor.dim() == 0:
             return torch.tensor([])
+        return torch.zeros((forward_request_tensor.shape[0], (self.topk + 1), 1 + 1), dtype=torch.float32)

--- a/bittensor/_synapse/text_causallmnext_impl.py
+++ b/bittensor/_synapse/text_causallmnext_impl.py
@@ -174,20 +174,21 @@ class TextCausalLMNext(Synapse):
         decoded_gradient[:, :, 0] = backward_response_gradient[2:].reshape(batch_size, self.topk + 1)
         return decoded_gradient  # [batch_size, (topk + 1), max_len]
 
-    def nill_forward_response_tensor(self, forward_request_tensor: torch.Tensor) -> torch.Tensor:
+    def nill_forward_response_tensor(self, forward_request_tensor: torch.Tensor,
+                                     encoded=False, ignore_index=-100) -> torch.Tensor:
         if forward_request_tensor.dim() == 0 or forward_request_tensor.shape[0] == 0:
             return torch.tensor([])
-        return torch.zeros((forward_request_tensor.shape[0], (self.topk + 1), 1 + 1), dtype=torch.float32)
+
+        forward_response_tensor = torch.zeros(forward_request_tensor.shape[0], (self.topk + 1), 1 + 1)
+        forward_response_tensor[:, :, 1] = 2  # set 2 <= token_ids to preserve 0 <= probs <= 1 in column 0
+        forward_response_tensor[:, self.topk::(self.topk + 1), 1] = ignore_index  # add ignore_index padding after floor_prob
+
+        if encoded:
+            return self.encode_forward_response_tensor(forward_response_tensor)
+
+        return forward_response_tensor
 
     def nill_backward_response_tensor(self, forward_request_tensor: torch.Tensor) -> torch.Tensor:
         if forward_request_tensor.dim() == 0 or forward_request_tensor.shape[0] == 0:
             return torch.tensor([])
         return torch.zeros((forward_request_tensor.shape[0], (self.topk + 1), 1 + 1), dtype=torch.float32)
-
-    def template_forward_response_tensor(self, batch_size: int, encoded=True, ignore_index=-100) -> torch.Tensor:
-        forward_response_tensor = torch.zeros(batch_size, (self.topk + 1), 1 + 1)
-        forward_response_tensor[:, :, 1] = 2  # set 2 <= token_ids to preserve 0 <= probs <= 1 in column 0
-        forward_response_tensor[:, self.topk::(self.topk + 1), 1] = ignore_index  # add ignore_index padding after floor_prob
-        if encoded:
-            return self.encode_forward_response_tensor(forward_response_tensor)
-        return forward_response_tensor

--- a/bittensor/_synapse/text_causallmnext_impl.py
+++ b/bittensor/_synapse/text_causallmnext_impl.py
@@ -125,14 +125,15 @@ class TextCausalLMNext(Synapse):
 
     def check_backward_request_gradient(self, forward_request_tensor, backward_request_gradient):
         # forward_request_tensor: [batch_size, sequence_len]
-        # backward_request_gradient: [2 + batch_size * (topk + 1)]
+        # backward_request_gradient: [batch_size, (topk + 1), max_len]
         if (
-                len(backward_request_gradient.shape) != 1 or
-                backward_request_gradient.size(0) < 2 + forward_request_tensor.shape[0] * (self.topk + 1)
+                len(backward_request_gradient.shape) != 3 or
+                backward_request_gradient.size(0) != forward_request_tensor.shape[0] or
+                backward_request_gradient.size(1) != (self.topk + 1)
         ):
             raise ValueError(f"backward_request_gradient.shape must be in "
-                             f"[2 + {forward_request_tensor.shape[0]} x ({self.topk} + 1)], "
-                             f"got: {backward_request_gradient.size(0)} for synapse: {self}")
+                             f"[{forward_request_tensor.shape[0]}, ({self.topk} + 1), max_len], "
+                             f"got: {backward_request_gradient.shape} for synapse: {self}")
 
     def encode_forward_request_tensor(self, forward_request_tensor: torch.Tensor) -> torch.Tensor:
         return forward_request_tensor

--- a/bittensor/_synapse/text_causallmnext_impl.py
+++ b/bittensor/_synapse/text_causallmnext_impl.py
@@ -168,6 +168,7 @@ class TextCausalLMNext(Synapse):
 
     def decode_backward_request_gradient(self, backward_response_gradient: torch.Tensor) -> torch.Tensor:
         """ Restructure [2 + batch_size * (topk + 1)] prob grads into [batch_size, (topk + 1), max_len]. """
+        print('decode_backward_request_gradient, backward_response_gradient.shape', backward_response_gradient.shape)
         batch_size = backward_response_gradient[0].item()
         max_len = backward_response_gradient[1].item()
         decoded_gradient = torch.zeros((batch_size, self.topk + 1, max_len)).to(backward_response_gradient.device)

--- a/bittensor/_synapse/text_causallmnext_impl.py
+++ b/bittensor/_synapse/text_causallmnext_impl.py
@@ -171,6 +171,7 @@ class TextCausalLMNext(Synapse):
         print('decode_backward_request_gradient, backward_response_gradient.shape', backward_response_gradient.shape)
         batch_size = backward_response_gradient[0].item()
         max_len = backward_response_gradient[1].item()
+        print('batch_size', batch_size, 'max_len', max_len, 'shape', (batch_size, self.topk + 1, max_len))
         decoded_gradient = torch.zeros((batch_size, self.topk + 1, max_len)).to(backward_response_gradient.device)
         decoded_gradient[:, :, 0] = backward_response_gradient[2:].reshape(batch_size, self.topk + 1)
         return decoded_gradient  # [batch_size, (topk + 1), max_len]

--- a/bittensor/_synapse/text_causallmnext_impl.py
+++ b/bittensor/_synapse/text_causallmnext_impl.py
@@ -183,3 +183,11 @@ class TextCausalLMNext(Synapse):
         if forward_request_tensor.dim() == 0 or forward_request_tensor.shape[0] == 0:
             return torch.tensor([])
         return torch.zeros((forward_request_tensor.shape[0], (self.topk + 1), 1 + 1), dtype=torch.float32)
+
+    def template_forward_response_tensor(self, batch_size: int, encoded=True, ignore_index=-100) -> torch.Tensor:
+        forward_response_tensor = torch.zeros(batch_size, (self.topk + 1), 1 + 1)
+        forward_response_tensor[:, :, 1] = 2  # set 2 <= token_ids to preserve 0 <= probs <= 1 in column 0
+        forward_response_tensor[:, self.topk::(self.topk + 1), 1] = ignore_index  # add ignore_index padding after floor_prob
+        if encoded:
+            return self.encode_forward_response_tensor(forward_response_tensor)
+        return forward_response_tensor

--- a/bittensor/_synapse/text_causallmnext_impl.py
+++ b/bittensor/_synapse/text_causallmnext_impl.py
@@ -168,10 +168,8 @@ class TextCausalLMNext(Synapse):
 
     def decode_backward_request_gradient(self, backward_response_gradient: torch.Tensor) -> torch.Tensor:
         """ Restructure [2 + batch_size * (topk + 1)] prob grads into [batch_size, (topk + 1), max_len]. """
-        print('decode_backward_request_gradient, backward_response_gradient.shape', backward_response_gradient.shape)
-        batch_size = backward_response_gradient[0].item()
-        max_len = backward_response_gradient[1].item()
-        print('batch_size', batch_size, 'max_len', max_len, 'shape', (batch_size, self.topk + 1, max_len))
+        batch_size = int(backward_response_gradient[0].item())
+        max_len = int(backward_response_gradient[1].item())
         decoded_gradient = torch.zeros((batch_size, self.topk + 1, max_len)).to(backward_response_gradient.device)
         decoded_gradient[:, :, 0] = backward_response_gradient[2:].reshape(batch_size, self.topk + 1)
         return decoded_gradient  # [batch_size, (topk + 1), max_len]

--- a/bittensor/_synapse/text_causallmnext_impl.py
+++ b/bittensor/_synapse/text_causallmnext_impl.py
@@ -176,12 +176,12 @@ class TextCausalLMNext(Synapse):
 
     def nill_forward_response_tensor(self, forward_request_tensor: torch.Tensor) -> torch.Tensor:
         try:
-            return torch.zeros((forward_request_tensor.shape[0] * (2 * self.topk + 1)), dtype=torch.float32)
+            return torch.zeros((forward_request_tensor.shape[0], (self.topk + 1), 1 + 1), dtype=torch.float32)
         except:
             return torch.tensor([])
 
     def nill_backward_response_tensor(self, forward_request_tensor: torch.Tensor) -> torch.Tensor:
         try:
-            return torch.zeros((2 + forward_request_tensor.shape[0] * (self.topk + 1)), dtype=torch.float32)
+            return torch.zeros((forward_request_tensor.shape[0], (self.topk + 1), 1 + 1), dtype=torch.float32)
         except:
             return torch.tensor([])

--- a/bittensor/utils/tokenizer_utils.py
+++ b/bittensor/utils/tokenizer_utils.py
@@ -870,8 +870,7 @@ def unravel_topk_token_phrases(compact_topk: torch.Tensor, topk: int, ignore_ind
     prob_idx = torch.where(compact_topk <= 1.5)[0]  # 0 <= prob <= 1 [batch_size * (topk + 1)], expect token_ids >= 2
 
     batch_size = len(prob_idx) // (topk + 1)  # (batch_size * (topk + floor)) / (topk + floor)
-    assert (batch_size * (topk + 1) == len(prob_idx),
-            f'{batch_size} * ({topk} + 1) != {len(prob_idx)}')  # decoding irregularity otherwise
+    assert batch_size * (topk + 1) == len(prob_idx), f'{batch_size} * ({topk} + 1) != {len(prob_idx)}'  # decoding irregularity otherwise
 
     # split into topk token phrases with prob prepend [prob, tok_0, tok_1, ... tok_n]
     phrases = [s.tolist() for s in torch.tensor_split(compact_topk, prob_idx)]  # tolist for faster list comprehension

--- a/bittensor/utils/tokenizer_utils.py
+++ b/bittensor/utils/tokenizer_utils.py
@@ -870,7 +870,8 @@ def unravel_topk_token_phrases(compact_topk: torch.Tensor, topk: int, ignore_ind
     prob_idx = torch.where(compact_topk <= 1.5)[0]  # 0 <= prob <= 1 [batch_size * (topk + 1)], expect token_ids >= 2
 
     batch_size = len(prob_idx) // (topk + 1)  # (batch_size * (topk + floor)) / (topk + floor)
-    assert batch_size * (topk + 1) == len(prob_idx)  # decoding irregularity otherwise
+    assert (batch_size * (topk + 1) == len(prob_idx),
+            f'{batch_size} * ({topk} + 1) != {len(prob_idx)}')  # decoding irregularity otherwise
 
     # split into topk token phrases with prob prepend [prob, tok_0, tok_1, ... tok_n]
     phrases = [s.tolist() for s in torch.tensor_split(compact_topk, prob_idx)]  # tolist for faster list comprehension

--- a/bittensor/utils/tokenizer_utils.py
+++ b/bittensor/utils/tokenizer_utils.py
@@ -917,8 +917,6 @@ def phrase_cross_entropy(target_phrases: Union[List[List[int]], torch.Tensor],
                   [...],
                   [prob_floor_b=1, ignore_index, ..., ignore_index]],
                  [...]]
-            topk (:obj:`int`, `required`):
-                Amount of top phrases to expect.
             ignore_index (:obj:`int`, `optional`):
                 Padding value to use for unfilled token positions in a shorter token phrase.
             reduce (:obj:`bool`, `optional`):
@@ -961,9 +959,9 @@ def phrase_cross_entropy(target_phrases: Union[List[List[int]], torch.Tensor],
             val_probs[b] = n_floor_probs[b]  # assume match is in non-topk tokens with avg floor_prob
 
         # === Integrate sub target matches ===
-        check_len = min(max_len, len(target_phrase))
+        check_len = min(max_len - 1, len(target_phrase))
         for c in range(1, check_len + 1):  # progressively increase sub target length
-            target = ignore_index * torch.ones(check_len, dtype=torch.int32)  # [-100, ..., -100]
+            target = ignore_index * torch.ones(check_len, dtype=torch.int32).to(topk_tensor.device)  # [-100, ..., -100]
             target[:c] = target_phrase[:c]  # [tok0, tok1, ...tokc, -100, ..., -100]
 
             # Find sub target matches

--- a/tests/unit_tests/bittensor_tests/test_axon.py
+++ b/tests/unit_tests/bittensor_tests/test_axon.py
@@ -611,7 +611,7 @@ def test_backward_causal_lm_shape_error():
 def test_backward_causal_lm_next_shape_error():
     synapses = [bittensor.synapse.TextCausalLMNext()]
     inputs_raw = torch.rand(1, 1, 1)
-    grads_raw = torch.rand(1 * (2 * synapses[0].topk + 1))
+    grads_raw = torch.rand(2 + 1 * (synapses[0].topk + 1))
     serializer = bittensor.serializer(serializer_type=bittensor.proto.Serializer.MSGPACK)
     inputs_serialized = serializer.serialize(inputs_raw, from_type=bittensor.proto.TensorType.TORCH)
     grads_serialized = synapses[0].serialize_backward_request_gradient(inputs_raw, grads_raw)
@@ -702,13 +702,13 @@ def test_backward_response_success_causal_lm():
 
 def test_backward_response_success_causal_lm_next():
     def forward(inputs_x: torch.FloatTensor, synapse, model_output=None):
-        return None, dict(), torch.zeros([1 * (2 * synapses[0].topk + 1)], requires_grad=True)
+        return None, dict(), torch.zeros([2 + 1 * (synapses[0].topk + 1)], requires_grad=True)
 
     axon.attach_synapse_callback(forward, synapse_type=bittensor.proto.Synapse.SynapseType.TEXT_CAUSAL_LM_NEXT)
     synapses = [bittensor.synapse.TextCausalLMNext()]
 
     inputs_raw = torch.ones(1, 1)
-    grads_raw = torch.zeros(1 * (2 * synapses[0].topk + 1))
+    grads_raw = torch.zeros(2 + 1 * (synapses[0].topk + 1))
 
     inputs_serialized = synapses[0].serialize_forward_request_tensor(inputs_raw)
     grads_serialized = synapses[0].serialize_backward_request_gradient(inputs_raw, grads_raw)

--- a/tests/unit_tests/bittensor_tests/test_axon.py
+++ b/tests/unit_tests/bittensor_tests/test_axon.py
@@ -734,7 +734,7 @@ def test_backward_response_success_causal_lm_next():
     synapses = [bittensor.synapse.TextCausalLMNext()]
 
     inputs_raw = torch.ones(1, 1)
-    grads_raw = torch.zeros(1, (synapses[0].topk + 1), 1 + 1)
+    grads_raw = torch.zeros([1, (synapses[0].topk + 1), 1 + 1])
 
     inputs_serialized = synapses[0].serialize_forward_request_tensor(inputs_raw)
     grads_serialized = synapses[0].serialize_backward_request_gradient(inputs_raw, grads_raw)

--- a/tests/unit_tests/bittensor_tests/test_forward_backward.py
+++ b/tests/unit_tests/bittensor_tests/test_forward_backward.py
@@ -77,12 +77,12 @@ def test_dendrite_forward_text_causal_lm():
     assert list(tensors[0][0].shape) == [2, 4, bittensor.__network_dim__]
 
 def test_dendrite_forward_text_causal_lm_next():
-    x = torch.LongTensor([[1, 2, 3, 4], [5, 6, 7, 8]])
+    x = torch.LongTensor([[1, 2, 3, 4], [5, 6, 7, 8]])  # [2, 4]
     synapses = [bittensor.synapse.TextCausalLMNext()]
-    dendrite_mock.receptor_pool.forward = MagicMock(return_value=[[[torch.zeros([2 * (2 * synapses[0].topk + 1)])]], [[1]], [[0]]])
+    dendrite_mock.receptor_pool.forward = MagicMock(return_value=[[[torch.zeros([2, (synapses[0].topk + 1), 1 + 1])]], [[1]], [[0]]])
     tensors, codes, times = dendrite_mock.text(endpoints=[endpoint], inputs=[x], synapses=synapses)
     assert codes[0].item() == bittensor.proto.ReturnCode.Success
-    assert list(tensors[0][0].shape) == [2 * (2 * synapses[0].topk + 1)]
+    assert list(tensors[0][0].shape) == [2, (synapses[0].topk + 1), 1 + 1]  # [batch_size, (topk + 1), max_len]
 
 def test_dendrite_forward_text_last_hidden():
     x = torch.tensor([[1],[8]])
@@ -116,7 +116,7 @@ def test_dendrite_forward_tensor_pass_through_text_causal_lm():
 def test_dendrite_forward_tensor_pass_through_text_causal_lm_next():
     x = torch.ones((3, 3), dtype=torch.int64)
     synapses = [bittensor.synapse.TextCausalLMNext()]
-    y = torch.zeros([3 * (2 * synapses[0].topk + 1)])
+    y = torch.zeros([3, (synapses[0].topk + 1), 1 + 1])
     dendrite_mock.receptor_pool.forward = MagicMock(return_value=[[[y, y, y]], [[1, 1, 1]], [[0, 0, 0]]])
     tensors, codes, times = dendrite_mock.text(endpoints=[endpoint, endpoint, endpoint], inputs=[x, x, x], synapses=synapses)
     assert codes[0][0].item() == bittensor.proto.ReturnCode.Success

--- a/tests/unit_tests/bittensor_tests/test_receptor.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor.py
@@ -155,7 +155,7 @@ def test_receptor_neuron_mock_server():
 def test_receptor_neuron_serve_timeout():
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(3, 70, bittensor.__network_dim__)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -236,7 +236,7 @@ def test_receptor_neuron_server_response_with_nans():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(3, 70)
     
     y_hidden[0][0][0] = np.nan

--- a/tests/unit_tests/bittensor_tests/test_receptor.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor.py
@@ -124,7 +124,7 @@ def test_receptor_neuron_request_empty():
 def test_receptor_neuron_mock_server():
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -145,8 +145,8 @@ def test_receptor_neuron_mock_server():
 
     x = torch.rand(3, 3)
     out, ops, time  = receptor.forward( synapses, x, timeout=1)
-    assert ops == [bittensor.proto.ReturnCode.Success] * len(synapses)
     print([list(o.shape) for o in out])
+    assert ops == [bittensor.proto.ReturnCode.Success] * len(synapses)
     assert [list(o.shape) for o in out] == [[3, 3, bittensor.__network_dim__],
                                             [3, 3, bittensor.__vocab_size__],
                                             [3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1],

--- a/tests/unit_tests/bittensor_tests/test_receptor.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor.py
@@ -70,7 +70,7 @@ def test_dummy_forward():
     assert ops == [bittensor.proto.ReturnCode.BadEndpoint for _ in synapses]
     assert [list(o.shape) for o in out] == [[2, 4,bittensor.__network_dim__],
                                             [2, 4, bittensor.__vocab_size__],
-                                            [2 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)],
+                                            [2, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1],
                                             [2, 70]]
 
 
@@ -84,7 +84,7 @@ def test_dummy_backward():
     assert ops == [bittensor.proto.ReturnCode.BadEndpoint for _ in synapses]
     assert [list(o.shape) for o in out] == [[2,4,bittensor.__network_dim__],
                                             [2,4, bittensor.__vocab_size__],
-                                            [2 + 2 * (bittensor.synapse.TextCausalLMNext().topk + 1)],
+                                            [2, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1],
                                             [0]]
 
 # -- request serialization --
@@ -112,7 +112,7 @@ def test_receptor_neuron_text():
     assert ops == [bittensor.proto.ReturnCode.Unavailable]*len(synapses)
     assert [list(o.shape) for o in out] == [[2, 4,bittensor.__network_dim__],
                                             [2, 4, bittensor.__vocab_size__],
-                                            [2 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)],
+                                            [2, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1],
                                             [2, 70]]
 
 def test_receptor_neuron_request_empty():
@@ -124,7 +124,7 @@ def test_receptor_neuron_request_empty():
 def test_receptor_neuron_mock_server():
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -149,13 +149,13 @@ def test_receptor_neuron_mock_server():
     print([list(o.shape) for o in out])
     assert [list(o.shape) for o in out] == [[3, 3, bittensor.__network_dim__],
                                             [3, 3, bittensor.__vocab_size__],
-                                            [3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)],
+                                            [3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1],
                                             [3, 70]]
 
 def test_receptor_neuron_serve_timeout():
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
     y_seq_2_seq = torch.rand(3, 70, bittensor.__network_dim__)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -180,7 +180,7 @@ def test_receptor_neuron_serve_timeout():
     assert ops == [bittensor.proto.ReturnCode.Timeout] * len(synapses)
     assert [list(o.shape) for o in out] == [[3, 3, bittensor.__network_dim__],
                                             [3, 3, bittensor.__vocab_size__],
-                                            [3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)],
+                                            [3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1],
                                             [3, 70]]
 
 def test_receptor_neuron_mock_server_deserialization_error():
@@ -201,7 +201,7 @@ def test_receptor_neuron_mock_server_deserialization_error():
     assert ops == [bittensor.proto.ReturnCode.ResponseDeserializationException] * len(synapses)
     assert [list(o.shape) for o in out] == [[3, 3, bittensor.__network_dim__],
                                             [3, 3, bittensor.__vocab_size__],
-                                            [3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)],
+                                            [3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1],
                                             [3, 70]]
 
 def test_receptor_neuron_mock_server_shape_error():
@@ -228,7 +228,7 @@ def test_receptor_neuron_mock_server_shape_error():
     assert ops == [bittensor.proto.ReturnCode.ResponseShapeException] * len(synapses)
     assert [list(o.shape) for o in out] == [[3, 3, bittensor.__network_dim__],
                                             [3, 3, bittensor.__vocab_size__],
-                                            [3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)],
+                                            [3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1],
                                             [3, 70]]
 
 def test_receptor_neuron_server_response_with_nans():
@@ -236,7 +236,7 @@ def test_receptor_neuron_server_response_with_nans():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
     y_seq_2_seq = torch.rand(3, 70)
     
     y_hidden[0][0][0] = np.nan
@@ -275,7 +275,7 @@ def test_receptor_neuron_text_backward():
     x = torch.tensor([[1,2,3,4],[5,6,7,8]], dtype=torch.long)
     hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
     causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-    causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
+    causallmnext_grads = torch.ones((x.size(0), (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1))
     seq_2_seq_grads = torch.tensor([])
     out, ops, time = receptor.backward(synapses, x, [hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads], timeout=1)
     assert ops == [bittensor.proto.ReturnCode.Unavailable] * len(synapses)
@@ -305,7 +305,7 @@ def test_receptor_neuron_mock_server_backward():
     x = torch.rand(3, 3)
     hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
     causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-    causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
+    causallmnext_grads = torch.ones((x.size(0), (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1))
     seq_2_seq_grads = torch.tensor([])
     out, ops, time = receptor.backward(synapses, x, [hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads], timeout=1)
     assert ops == [bittensor.proto.ReturnCode.Success] * len(synapses)
@@ -375,7 +375,7 @@ def test_receptor_backward_stub_exception():
         x = torch.rand(3, 3)
         hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
         causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-        causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
+        causallmnext_grads = torch.ones((x.size(0), (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1))
         seq_2_seq_grads = torch.tensor([])
         out, ops, time = receptor.backward(synapses, x, [hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads], timeout=1)
         assert ops == [bittensor.proto.ReturnCode.UnknownException] * len(synapses)
@@ -409,7 +409,7 @@ def test_receptor_backward_endpoint_exception():
         x = torch.rand(3, 3)
         hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
         causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-        causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
+        causallmnext_grads = torch.ones((x.size(0), (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1))
         seq_2_seq_grads = torch.tensor([])
         out, ops, time = receptor.backward(synapses, x, [hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads], timeout=1)
         assert ops == [bittensor.proto.ReturnCode.UnknownException] * len(synapses)
@@ -427,7 +427,7 @@ def test_axon_receptor_connection_forward_works():
         return None, None, torch.zeros( [3, 3, bittensor.__vocab_size__])
 
     def forward_casual_lm_next(input, synapse, model_output=None):
-        return None, None, torch.zeros([3 * (2 * synapse.topk + 1)])
+        return None, None, torch.zeros([3, (synapse.topk + 1), 1 + 1])
 
     axon = bittensor.axon (
         port = 8081,
@@ -473,7 +473,7 @@ def test_axon_receptor_connection_forward_unauthenticated():
         return None, None, torch.zeros( [3, 3, bittensor.__vocab_size__])
 
     def forward_casual_lm_next(input, synapse, model_output=None):
-        return None, None, torch.zeros([3 * (2 * synapse.topk + 1)])
+        return None, None, torch.zeros([3, (synapse.topk + 1), 1 + 1])
 
     axon = bittensor.axon (
         port = 8081,
@@ -519,7 +519,7 @@ def test_axon_receptor_connection_backward_works():
         return torch.zeros( [3, 3, bittensor.__vocab_size__])
 
     def forward_casual_lm_next(input, synapse):
-        return torch.zeros([2 + 3 * (synapse.topk + 1)])
+        return torch.zeros([3, (synapse.topk + 1), 1 + 1])
 
     axon = bittensor.axon (
         port = 8082,
@@ -550,7 +550,7 @@ def test_axon_receptor_connection_backward_works():
     x = torch.rand(3, 3)
     hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
     causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-    causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
+    causallmnext_grads = torch.ones((x.size(0), (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1))
     seq_2_seq_grads = torch.tensor([])
 
     out, ops, time = receptor.backward(synapses, x, [hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads], timeout=1)
@@ -568,7 +568,7 @@ def test_axon_receptor_connection_backward_unauthenticated():
         return torch.zeros( [3, 3, bittensor.__vocab_size__])
 
     def forward_casual_lm_next(input, synapse):
-        return torch.zeros([2 + 3 * (synapse.topk + 1)])
+        return torch.zeros([3, (synapse.topk + 1), 1 + 1])
 
     axon = bittensor.axon (
         port = 8090,
@@ -600,7 +600,7 @@ def test_axon_receptor_connection_backward_unauthenticated():
     x = torch.rand(3, 3)
     hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
     causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-    causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
+    causallmnext_grads = torch.ones((x.size(0), (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1))
     seq_2_seq_grads = torch.tensor([])
 
     receptor.sign = MagicMock( return_value='mock' )
@@ -739,7 +739,7 @@ def test_axon_receptor_connection_backward_timeout():
     x = torch.rand(3, 3)
     hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
     causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-    causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
+    causallmnext_grads = torch.ones((x.size(0), (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1))
     seq_2_seq_grads = torch.tensor([])
     out, ops, time = receptor.backward(synapses, x, [hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads], timeout=1)
 

--- a/tests/unit_tests/bittensor_tests/test_receptor.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor.py
@@ -241,7 +241,7 @@ def test_receptor_neuron_server_response_with_nans():
     
     y_hidden[0][0][0] = np.nan
     y_causallm[0][0][0] = np.nan
-    y_causallmnext[0] = np.nan
+    y_causallmnext[0] = np.nan  # unravel fails because demarcating probability is replaced by nan, ResponseDeserializationException
     y_seq_2_seq[0][0] = np.nan
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -263,10 +263,10 @@ def test_receptor_neuron_server_response_with_nans():
 
     x = torch.rand(3, 3)
     out, ops, time  = receptor.forward( synapses, x, timeout=1)
-    assert ops == [bittensor.proto.ReturnCode.Success] * len(synapses)
+    assert ops == [bittensor.proto.ReturnCode.Success, bittensor.proto.ReturnCode.Success,
+                   bittensor.proto.ReturnCode.ResponseDeserializationException, bittensor.proto.ReturnCode.Success]
     assert out[0][0][0][0] != np.nan
     assert out[1][0][0][0] != np.nan
-    assert out[2][0][0][0] != np.nan
     assert out[3][0][0] != np.nan
 
 # -- backwards testing --

--- a/tests/unit_tests/bittensor_tests/test_receptor.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor.py
@@ -124,7 +124,7 @@ def test_receptor_neuron_request_empty():
 def test_receptor_neuron_mock_server():
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -155,7 +155,7 @@ def test_receptor_neuron_mock_server():
 def test_receptor_neuron_serve_timeout():
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
     y_seq_2_seq = torch.rand(3, 70, bittensor.__network_dim__)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -236,7 +236,7 @@ def test_receptor_neuron_server_response_with_nans():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
     y_seq_2_seq = torch.rand(3, 70)
     
     y_hidden[0][0][0] = np.nan

--- a/tests/unit_tests/bittensor_tests/test_receptor.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor.py
@@ -124,7 +124,7 @@ def test_receptor_neuron_request_empty():
 def test_receptor_neuron_mock_server():
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().nill_forward_response_tensor(torch.ones(3), encoded=True)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -155,7 +155,7 @@ def test_receptor_neuron_mock_server():
 def test_receptor_neuron_serve_timeout():
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().nill_forward_response_tensor(torch.ones(3), encoded=True)
     y_seq_2_seq = torch.rand(3, 70, bittensor.__network_dim__)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -236,7 +236,7 @@ def test_receptor_neuron_server_response_with_nans():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().nill_forward_response_tensor(torch.ones(3), encoded=True)
     y_seq_2_seq = torch.rand(3, 70)
     
     y_hidden[0][0][0] = np.nan

--- a/tests/unit_tests/bittensor_tests/test_receptor.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor.py
@@ -84,7 +84,7 @@ def test_dummy_backward():
     assert ops == [bittensor.proto.ReturnCode.BadEndpoint for _ in synapses]
     assert [list(o.shape) for o in out] == [[2,4,bittensor.__network_dim__],
                                             [2,4, bittensor.__vocab_size__],
-                                            [2 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)],
+                                            [2 + 2 * (bittensor.synapse.TextCausalLMNext().topk + 1)],
                                             [0]]
 
 # -- request serialization --
@@ -275,7 +275,7 @@ def test_receptor_neuron_text_backward():
     x = torch.tensor([[1,2,3,4],[5,6,7,8]], dtype=torch.long)
     hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
     causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-    causallmnext_grads = torch.ones((x.size(0) * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)))
+    causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
     seq_2_seq_grads = torch.tensor([])
     out, ops, time = receptor.backward(synapses, x, [hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads], timeout=1)
     assert ops == [bittensor.proto.ReturnCode.Unavailable] * len(synapses)
@@ -305,7 +305,7 @@ def test_receptor_neuron_mock_server_backward():
     x = torch.rand(3, 3)
     hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
     causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-    causallmnext_grads = torch.ones((x.size(0) * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)))
+    causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
     seq_2_seq_grads = torch.tensor([])
     out, ops, time = receptor.backward(synapses, x, [hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads], timeout=1)
     assert ops == [bittensor.proto.ReturnCode.Success] * len(synapses)
@@ -375,7 +375,7 @@ def test_receptor_backward_stub_exception():
         x = torch.rand(3, 3)
         hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
         causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-        causallmnext_grads = torch.ones((x.size(0) * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)))
+        causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
         seq_2_seq_grads = torch.tensor([])
         out, ops, time = receptor.backward(synapses, x, [hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads], timeout=1)
         assert ops == [bittensor.proto.ReturnCode.UnknownException] * len(synapses)
@@ -409,7 +409,7 @@ def test_receptor_backward_endpoint_exception():
         x = torch.rand(3, 3)
         hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
         causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-        causallmnext_grads = torch.ones((x.size(0) * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)))
+        causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
         seq_2_seq_grads = torch.tensor([])
         out, ops, time = receptor.backward(synapses, x, [hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads], timeout=1)
         assert ops == [bittensor.proto.ReturnCode.UnknownException] * len(synapses)
@@ -519,7 +519,7 @@ def test_axon_receptor_connection_backward_works():
         return torch.zeros( [3, 3, bittensor.__vocab_size__])
 
     def forward_casual_lm_next(input, synapse):
-        return torch.zeros([3 * (2 * synapse.topk + 1)])
+        return torch.zeros([2 + 3 * (synapse.topk + 1)])
 
     axon = bittensor.axon (
         port = 8082,
@@ -550,7 +550,7 @@ def test_axon_receptor_connection_backward_works():
     x = torch.rand(3, 3)
     hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
     causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-    causallmnext_grads = torch.ones((x.size(0) * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)))
+    causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
     seq_2_seq_grads = torch.tensor([])
 
     out, ops, time = receptor.backward(synapses, x, [hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads], timeout=1)
@@ -568,7 +568,7 @@ def test_axon_receptor_connection_backward_unauthenticated():
         return torch.zeros( [3, 3, bittensor.__vocab_size__])
 
     def forward_casual_lm_next(input, synapse):
-        return torch.zeros([3 * (2 * synapse.topk + 1)])
+        return torch.zeros([2 + 3 * (synapse.topk + 1)])
 
     axon = bittensor.axon (
         port = 8090,
@@ -600,7 +600,7 @@ def test_axon_receptor_connection_backward_unauthenticated():
     x = torch.rand(3, 3)
     hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
     causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-    causallmnext_grads = torch.ones((x.size(0) * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)))
+    causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
     seq_2_seq_grads = torch.tensor([])
 
     receptor.sign = MagicMock( return_value='mock' )
@@ -739,7 +739,7 @@ def test_axon_receptor_connection_backward_timeout():
     x = torch.rand(3, 3)
     hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
     causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-    causallmnext_grads = torch.ones((x.size(0) * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)))
+    causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
     seq_2_seq_grads = torch.tensor([])
     out, ops, time = receptor.backward(synapses, x, [hidden_grads, causal_grads, causallmnext_grads, seq_2_seq_grads], timeout=1)
 

--- a/tests/unit_tests/bittensor_tests/test_receptor.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor.py
@@ -266,7 +266,7 @@ def test_receptor_neuron_server_response_with_nans():
     assert ops == [bittensor.proto.ReturnCode.Success] * len(synapses)
     assert out[0][0][0][0] != np.nan
     assert out[1][0][0][0] != np.nan
-    assert out[2][0] != np.nan
+    assert out[2][0][0][0] != np.nan
     assert out[3][0][0] != np.nan
 
 # -- backwards testing --

--- a/tests/unit_tests/bittensor_tests/test_receptor_pool.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor_pool.py
@@ -99,7 +99,7 @@ def test_receptor_pool_forward_success():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -128,7 +128,7 @@ def test_receptor_pool_forward_timeout():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -161,7 +161,7 @@ def test_receptor_pool_forward_num_synapse_mismatch():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -190,7 +190,7 @@ def test_receptor_pool_forward_response_partial_shape_error():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
     y_seq_2_seq = torch.rand(2, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -219,7 +219,7 @@ def test_receptor_pool_partial_remote_success_return_code():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
     y_seq_2_seq = torch.rand(2, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -249,7 +249,7 @@ def test_receptor_pool_missing_synapse():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )

--- a/tests/unit_tests/bittensor_tests/test_receptor_pool.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor_pool.py
@@ -99,7 +99,7 @@ def test_receptor_pool_forward_success():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -128,7 +128,7 @@ def test_receptor_pool_forward_timeout():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -161,7 +161,7 @@ def test_receptor_pool_forward_num_synapse_mismatch():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -190,7 +190,7 @@ def test_receptor_pool_forward_response_partial_shape_error():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
+    y_causallmnext = torch.rand(3 * (bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(2, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -219,7 +219,7 @@ def test_receptor_pool_partial_remote_success_return_code():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(2, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -249,7 +249,7 @@ def test_receptor_pool_missing_synapse():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
+    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )

--- a/tests/unit_tests/bittensor_tests/test_receptor_pool.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor_pool.py
@@ -99,7 +99,7 @@ def test_receptor_pool_forward_success():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().nill_forward_response_tensor(torch.ones(3), encoded=True)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -128,7 +128,7 @@ def test_receptor_pool_forward_timeout():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().nill_forward_response_tensor(torch.ones(3), encoded=True)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -161,7 +161,7 @@ def test_receptor_pool_forward_num_synapse_mismatch():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().nill_forward_response_tensor(torch.ones(3), encoded=True)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -190,7 +190,7 @@ def test_receptor_pool_forward_response_partial_shape_error():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().nill_forward_response_tensor(torch.ones(3), encoded=True)
     y_seq_2_seq = torch.rand(2, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -219,7 +219,7 @@ def test_receptor_pool_partial_remote_success_return_code():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().nill_forward_response_tensor(torch.ones(3), encoded=True)
     y_seq_2_seq = torch.rand(2, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -249,7 +249,7 @@ def test_receptor_pool_missing_synapse():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = bittensor.synapse.TextCausalLMNext().template_forward_response_tensor(3)
+    y_causallmnext = bittensor.synapse.TextCausalLMNext().nill_forward_response_tensor(torch.ones(3), encoded=True)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )

--- a/tests/unit_tests/bittensor_tests/test_receptor_pool.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor_pool.py
@@ -60,7 +60,7 @@ def test_receptor_pool_forward():
     resp1,  _, _ = receptor_pool.forward( endpoints, synapses, x, timeout=1)
     assert list(resp1[0][0].shape) == [2, 2, bittensor.__network_dim__]
     assert list(resp1[0][1].shape) == [2, 2, bittensor.__vocab_size__]
-    assert list(resp1[0][2].shape) == [2 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)]
+    assert list(resp1[0][2].shape) == [2, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1]
     assert list(resp1[0][3].shape) == [2, 70]
 
 def test_receptor_pool_backward():
@@ -68,7 +68,7 @@ def test_receptor_pool_backward():
     x = torch.ones( (1,2,2) )
     grads = [[torch.ones(2, 2, bittensor.__network_dim__),
               torch.ones(2, 2, bittensor.__vocab_size__),
-              torch.ones(2 + 2 * (bittensor.synapse.TextCausalLMNext().topk + 1)),
+              torch.ones(1, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1),
               torch.tensor([])]]
     receptor_pool.backward( endpoints, synapses, x, grads, timeout=1)
 
@@ -90,7 +90,7 @@ def test_receptor_pool_max_workers_forward():
     resp1,  _, _ = receptor_pool.forward( endpoints, synapses, x, timeout=1)
     assert list(resp1[0][0].shape) == [2, 2, bittensor.__network_dim__]
     assert list(resp1[0][1].shape) == [2, 2, bittensor.__vocab_size__]
-    assert list(resp1[0][2].shape) == [2 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)]
+    assert list(resp1[0][2].shape) == [2, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1]
     assert list(resp1[0][3].shape) == [2, 70]
 
 def test_receptor_pool_forward_success():
@@ -99,7 +99,7 @@ def test_receptor_pool_forward_success():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -128,7 +128,7 @@ def test_receptor_pool_forward_timeout():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -161,7 +161,7 @@ def test_receptor_pool_forward_num_synapse_mismatch():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -190,7 +190,7 @@ def test_receptor_pool_forward_response_partial_shape_error():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
     y_seq_2_seq = torch.rand(2, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -219,7 +219,7 @@ def test_receptor_pool_partial_remote_success_return_code():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
     y_seq_2_seq = torch.rand(2, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -249,7 +249,7 @@ def test_receptor_pool_missing_synapse():
 
     y_hidden = torch.rand(3, 3, bittensor.__network_dim__)
     y_causallm = torch.rand(3, 3, bittensor.__network_dim__)
-    y_causallmnext = torch.rand(3 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1))
+    y_causallmnext = torch.rand(3, (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1)
     y_seq_2_seq = torch.rand(3, 70)
     
     serializer = bittensor.serializer( serializer_type = bittensor.proto.Serializer.MSGPACK )
@@ -283,7 +283,7 @@ def test_receptor_pool_backward_hang():
     
     hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
     causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-    causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
+    causallmnext_grads = torch.ones((x.size(0), (bittensor.synapse.TextCausalLMNext().topk + 1), 1 + 1))
     seq_2_seq_grads = torch.tensor([])
 
     receptor_pool._get_or_create_receptor_for_endpoint(neuron_obj)

--- a/tests/unit_tests/bittensor_tests/test_receptor_pool.py
+++ b/tests/unit_tests/bittensor_tests/test_receptor_pool.py
@@ -68,7 +68,7 @@ def test_receptor_pool_backward():
     x = torch.ones( (1,2,2) )
     grads = [[torch.ones(2, 2, bittensor.__network_dim__),
               torch.ones(2, 2, bittensor.__vocab_size__),
-              torch.ones(2 * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)),
+              torch.ones(2 + 2 * (bittensor.synapse.TextCausalLMNext().topk + 1)),
               torch.tensor([])]]
     receptor_pool.backward( endpoints, synapses, x, grads, timeout=1)
 
@@ -283,7 +283,7 @@ def test_receptor_pool_backward_hang():
     
     hidden_grads = torch.ones((x.size(0), x.size(1), bittensor.__network_dim__))
     causal_grads = torch.ones((x.size(0), x.size(1), bittensor.__vocab_size__))
-    causallmnext_grads = torch.ones((x.size(0) * (2 * bittensor.synapse.TextCausalLMNext().topk + 1)))
+    causallmnext_grads = torch.ones((2 + x.size(0) * (bittensor.synapse.TextCausalLMNext().topk + 1)))
     seq_2_seq_grads = torch.tensor([])
 
     receptor_pool._get_or_create_receptor_for_endpoint(neuron_obj)

--- a/tests/unit_tests/bittensor_tests/utils/test_tokenizer_utils.py
+++ b/tests/unit_tests/bittensor_tests/utils/test_tokenizer_utils.py
@@ -392,8 +392,8 @@ def tokenizer_topk_phrases(text_batch: List[str], model_name: str, max_length: i
 
     last_logits = dec_pre_logits[:, -1, :]  # last token predictions: [batch_size, vocab_size]
 
-    result = topk_token_phrases(last_logits, tokenizer, std_tokenizer, topk=topk)
-    compact_topk, _topk_tokens, _topk_probs, _floor_probs = result
+    topk_tensor = topk_token_phrases(last_logits, tokenizer, topk=topk)  # [batch_size * (topk + 1), max_len]
+    compact_topk = compact_topk_token_phrases(topk_tensor)
     # compact_topk: [sum_b(sum_k(len(phrase_k) + 1)_b)] Compacted 1-D tensor >= batch_size * (2 * topk + 1)
 
     topk_tokens, topk_probs, floor_probs = unravel_topk_token_phrases(compact_topk, topk=topk)
@@ -547,8 +547,8 @@ def topk_phrases_crossentropy(text_batch: List[str], model_name: str, max_length
         target_phrases = tokenizer.batch_decode(tokens['input_ids'][:, last_idx+1:])
         target_phrases = std_tokenizer(target_phrases)['input_ids']
 
-        result = topk_token_phrases(last_logits, tokenizer, std_tokenizer, topk=topk)
-        compact_topk, _topk_tokens, _topk_probs, _floor_probs = result
+        topk_tensor = topk_token_phrases(last_logits, tokenizer, topk=topk)  # [batch_size * (topk + 1), max_len]
+        compact_topk = compact_topk_token_phrases(topk_tensor)
         # compact_topk: [sum_b(sum_k(len(phrase_k) + 1)_b)] Compacted 1-D tensor >= batch_size * (2 * topk + 1)
 
         topk_tokens, topk_probs, floor_probs = unravel_topk_token_phrases(compact_topk, topk=topk)

--- a/tests/unit_tests/bittensor_tests/utils/test_tokenizer_utils.py
+++ b/tests/unit_tests/bittensor_tests/utils/test_tokenizer_utils.py
@@ -342,13 +342,7 @@ def tokenizer_topk_phrases(text_batch: List[str], model_name: str, max_length: i
     # ============================
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    # Generative default expects most recent token on right-hand side with padding on left. https://github.com/huggingface/transformers/pull/10552
-    tokenizer.padding_side = "left"
-
-    # Define PAD Token = EOS Token (GPT2 generate convention, when PAD Token is None)
-    # https://github.com/huggingface/transformers/blob/49c8c67fb815a277405f84dea4a66353e19fb347/tests/models/gpt2/test_modeling_gpt2.py#L532
-    if tokenizer.pad_token is None and tokenizer.eos_token is not None:
-        tokenizer.pad_token = tokenizer.eos_token
+    prep_tokenizer(tokenizer, std_tokenizer)
 
     # ================================================
     # ==== Server-side: CausalLM task translation ====
@@ -491,13 +485,7 @@ def topk_phrases_crossentropy(text_batch: List[str], model_name: str, max_length
     # ============================
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    # Generative default expects most recent token on right-hand side with padding on left. https://github.com/huggingface/transformers/pull/10552
-    tokenizer.padding_side = "left"
-
-    # Define PAD Token = EOS Token (GPT2 generate convention, when PAD Token is None)
-    # https://github.com/huggingface/transformers/blob/49c8c67fb815a277405f84dea4a66353e19fb347/tests/models/gpt2/test_modeling_gpt2.py#L532
-    if tokenizer.pad_token is None and tokenizer.eos_token is not None:
-        tokenizer.pad_token = tokenizer.eos_token
+    prep_tokenizer(tokenizer, std_tokenizer)
 
     # ================================================
     # ==== Server-side: CausalLM task translation ====

--- a/tests/unit_tests/bittensor_tests/utils/test_tokenizer_utils.py
+++ b/tests/unit_tests/bittensor_tests/utils/test_tokenizer_utils.py
@@ -392,7 +392,7 @@ def tokenizer_topk_phrases(text_batch: List[str], model_name: str, max_length: i
 
     last_logits = dec_pre_logits[:, -1, :]  # last token predictions: [batch_size, vocab_size]
 
-    _topk_tensor = topk_token_phrases(last_logits, tokenizer, topk=topk)  # [batch_size * (topk + 1), max_len]
+    _topk_tensor = topk_token_phrases(last_logits, tokenizer, topk=topk)  # [batch_size, (topk + 1), max_len]
     compact_topk = compact_topk_token_phrases(_topk_tensor)
     # compact_topk: [sum_b(sum_k(len(phrase_k) + 1)_b)] Compacted 1-D tensor >= batch_size * (2 * topk + 1)
 
@@ -545,7 +545,7 @@ def topk_phrases_crossentropy(text_batch: List[str], model_name: str, max_length
         target_phrases = tokenizer.batch_decode(tokens['input_ids'][:, last_idx+1:])
         target_phrases = std_tokenizer(target_phrases)['input_ids']
 
-        _topk_tensor = topk_token_phrases(last_logits, tokenizer, topk=topk)  # [batch_size * (topk + 1), max_len]
+        _topk_tensor = topk_token_phrases(last_logits, tokenizer, topk=topk)  # [batch_size, (topk + 1), max_len]
         compact_topk = compact_topk_token_phrases(_topk_tensor)
         # compact_topk: [sum_b(sum_k(len(phrase_k) + 1)_b)] Compacted 1-D tensor >= batch_size * (2 * topk + 1)
 
@@ -553,7 +553,7 @@ def topk_phrases_crossentropy(text_batch: List[str], model_name: str, max_length
 
         assert (_topk_tensor - topk_tensor).abs().sum() < 1e-9
 
-        loss_val, loss = phrase_cross_entropy(target_phrases, topk_tensor, topk)
+        loss_val, loss = phrase_cross_entropy(target_phrases, topk_tensor)
         recorded_losses += [loss.item()]
 
     return recorded_losses


### PR DESCRIPTION
### [BIT-526] Improve TextCausalLMNext encoding/decoding

1. Improve TextCausalLMNext encoding/decoding by moving decoding into dendrite receptor_pool multithreading.
2. Wall time is 100x less than before for TextCausalLMNext decoding at dendrite/validator.
3. Updated unit tests with new TextCausalLMNext shapes.
4. Corrected backward shaping.

Tested core_server and core_validator on nobunaga, successful operation.

[BIT-526]: https://opentensor.atlassian.net/browse/BIT-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ