### PR TITLE
[BIT-540] Choose responsive UIDs for setting weights in validator + validator save/load

### DIFF
--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -522,7 +522,7 @@ class neuron:
                     changed_hotkeys += [uid]
 
         if len(changed_hotkeys):
-            logger.info(f"Hotkeys changed \t| {', '.join(changed_hotkeys)}")
+            logger.info(f"Hotkeys changed \t| {', '.join([str(uid) for uid in changed_hotkeys])}")
             # save neuron_stats to filesystem
             self.save()
 

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -533,6 +533,9 @@ class neuron:
 
         non_responsive_uids = queried_uids - responsive_uids
         non_queried_uids = set(range(self.metagraph.n)) - queried_uids
+
+        # random.sample(population, k, *, counts=None): Return a k length list of unique elements chosen from
+        # the population sequence or set. Used for random sampling without replacement (so no uid duplicates expected).
         preferred_uids = (random.sample(list(responsive_uids), len(responsive_uids)) +
                           random.sample(list(non_responsive_uids), len(non_responsive_uids)) +
                           random.sample(list(non_queried_uids), len(non_queried_uids)))  # preferred UID random order
@@ -558,7 +561,6 @@ class neuron:
         # === Normalize and apply max_allowed_ratio ===
         sample_weights = bittensor.utils.weight_utils.normalize_max_multiple(x=sample_weights,
                                                                              multiple=max_allowed_ratio)
-
         return sample_uids, sample_weights
 
     def weights_table(self, sample_uids, sample_weights, include_uids=None, num_rows: int = None):

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -522,9 +522,8 @@ class neuron:
                     changed_hotkeys += [uid]
 
         if len(changed_hotkeys):
-            logger.info(f"Hotkeys changed \t| {', '.join([str(uid) for uid in changed_hotkeys])}")
-            # save neuron_stats to filesystem
-            self.save()
+            logger.info(f"Hotkeys changed: {changed_hotkeys}")
+            self.save()  # save neuron_stats and neuron_hotkeys to filesystem
 
     def neuron_stats_update(self, neuron_stats: Dict[int, Dict[str, Any]]):
         r""" Updates self.neuron_stats with new individual dictionaries per uid.

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -529,6 +529,7 @@ class neuron:
 
         # === Randomize UIDs in preferred order (responsive -> queried -> rest) ===
         min_allowed_weights = self.subtensor.min_allowed_weights
+        max_allowed_ratio = self.subtensor.max_allowed_min_max_ratio
 
         non_responsive_uids = queried_uids - responsive_uids
         non_queried_uids = set(range(self.metagraph.n)) - queried_uids
@@ -554,7 +555,9 @@ class neuron:
         sample_uids = preferred_uids[:min_allowed_weights]  # slice to min_allowed_weights
         sample_weights = neuron_weights[:min_allowed_weights]  # slice to min_allowed_weights
 
-        sample_weights /= sample_weights.sum()  # normalize
+        # === Normalize and apply max_allowed_ratio ===
+        sample_weights = bittensor.utils.weight_utils.normalize_max_multiple(x=sample_weights,
+                                                                             multiple=max_allowed_ratio)
 
         return sample_uids, sample_weights
 


### PR DESCRIPTION
### [BIT-540] Choose responsive UIDs for setting weights in validator

Prefer current epoch's responsive UIDs, randomly sample min_allowed_weights number of UIDs to set weights to.

Discard max_allowed_ratio in favor of filtering non-zero weights, expecting consensus-levels (number of validators setting weights for UID) to be equal on average for responsive nodes. This means max_allowed_ratio is no longer strictly required for boosting consensus.

If there are less than min_allowed_weights non-zero weights, then set_weights should fail.

---

### [BIT-536] Validator save and load from filesystem

1. Uses core_server save/load format and args.
2. Saves neuron_stats and associated hotkeys.
3. Checks for hotkey changes and updates neuron_stats / neuron_hotkeys (and saves).

[BIT-540]: https://opentensor.atlassian.net/browse/BIT-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BIT-536]: https://opentensor.atlassian.net/browse/BIT-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ