### PR TITLE
[hotfix] fix flags for multiproc register limit

### DIFF
--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -571,23 +571,6 @@ class cli:
             help='''Set true to avoid prompting the user.''',
             default=False,
         )
-        register_parser.add_argument(
-            '--num_processes',
-            '--num',
-            '-n',
-            dest='num_processes',
-            help="Number of processors to use for registration",
-            type=int,
-            default=None,
-        )
-        register_parser.add_argument(
-            '--update_interval',
-            '-u',
-            dest='update_interval',
-            help="The number of nonces to process before checking for next block during registration",
-            type=int,
-            default=None,
-        )
 
         bittensor.wallet.add_args( register_parser )
         bittensor.subtensor.add_args( register_parser )

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -239,7 +239,7 @@ class CLI:
         """
         wallet = bittensor.wallet( config = self.config )
         subtensor = bittensor.subtensor( config = self.config )
-        subtensor.register( wallet = wallet, prompt = not self.config.no_prompt, num_processes = self.config.num_processes, update_interval = self.config.update_interval )
+        subtensor.register( wallet = wallet, prompt = not self.config.no_prompt, num_processes = self.config.get('num_processes', None), update_interval = self.config.get('update_interval', None) )
 
     def transfer( self ):
         r""" Transfer token of amount to destination.

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -239,7 +239,7 @@ class CLI:
         """
         wallet = bittensor.wallet( config = self.config )
         subtensor = bittensor.subtensor( config = self.config )
-        subtensor.register( wallet = wallet, prompt = not self.config.no_prompt, num_processes = self.config.get('num_processes', None), update_interval = self.config.get('update_interval', None) )
+        subtensor.register( wallet = wallet, prompt = not self.config.no_prompt, num_processes = self.config.subtensor.register.num_processes, update_interval = self.config.subtensor.register.update_interval )
 
     def transfer( self ):
         r""" Transfer token of amount to destination.

--- a/bittensor/_subtensor/__init__.py
+++ b/bittensor/_subtensor/__init__.py
@@ -184,6 +184,8 @@ class subtensor:
                                 help='''The subtensor endpoint flag. If set, overrides the --network flag.
                                     ''')       
             parser.add_argument('--' + prefix_str + 'subtensor._mock', action='store_true', help='To turn on subtensor mocking for testing purposes.', default=bittensor.defaults.subtensor._mock)
+            parser.add_argument('--' + prefix_str + 'num_processes', '--num', '-n', dest='register.num_processes', help="Number of processors to use for registration", type=int, default=None, default=bittensor.defaults.subtensor.register.num_processes)
+            parser.add_argument('--' + prefix_str + 'update_interval', '-u', dest='register.update_interval', help="The number of nonces to process before checking for next block during registration", type=int, default=None, default=bittensor.defaults.subtensor.register.update_interval)
         except argparse.ArgumentError:
             # re-parsing arguments.
             pass
@@ -196,6 +198,10 @@ class subtensor:
         defaults.subtensor.network = os.getenv('BT_SUBTENSOR_NETWORK') if os.getenv('BT_SUBTENSOR_NETWORK') != None else 'nakamoto'
         defaults.subtensor.chain_endpoint = os.getenv('BT_SUBTENSOR_CHAIN_ENDPOINT') if os.getenv('BT_SUBTENSOR_CHAIN_ENDPOINT') != None else None
         defaults.subtensor._mock = os.getenv('BT_SUBTENSOR_MOCK') if os.getenv('BT_SUBTENSOR_MOCK') != None else False
+
+        defaults.subtensor.register = bittensor.Config()
+        defaults.subtensor.register.num_processes = os.getenv('BT_SUBTENSOR_REGISTER_NUM_PROCESSES') if os.getenv('BT_SUBTENSOR_REGISTER_NUM_PROCESSES') != None else None # uses processor count by default within the function
+        defaults.subtensor.register.update_interval = os.getenv('BT_SUBTENSOR_REGISTER_UPDATE_INTERVAL') if os.getenv('BT_SUBTENSOR_REGISTER_UPDATE_INTERVAL') != None else 50_000
 
     @staticmethod   
     def check_config( config: 'bittensor.Config' ):

--- a/bittensor/_subtensor/__init__.py
+++ b/bittensor/_subtensor/__init__.py
@@ -184,8 +184,9 @@ class subtensor:
                                 help='''The subtensor endpoint flag. If set, overrides the --network flag.
                                     ''')       
             parser.add_argument('--' + prefix_str + 'subtensor._mock', action='store_true', help='To turn on subtensor mocking for testing purposes.', default=bittensor.defaults.subtensor._mock)
-            parser.add_argument('--' + prefix_str + 'num_processes', '--num', '-n', dest='register.num_processes', help="Number of processors to use for registration", type=int, default=None, default=bittensor.defaults.subtensor.register.num_processes)
-            parser.add_argument('--' + prefix_str + 'update_interval', '-u', dest='register.update_interval', help="The number of nonces to process before checking for next block during registration", type=int, default=None, default=bittensor.defaults.subtensor.register.update_interval)
+
+            parser.add_argument('--' + prefix_str + 'subtensor.register.num_processes', '-n', dest='subtensor.register.num_processes', help="Number of processors to use for registration", type=int, default=bittensor.defaults.subtensor.register.num_processes)
+            parser.add_argument('--' + prefix_str + 'subtensor.register.update_interval', '-u', dest='subtensor.register.update_interval', help="The number of nonces to process before checking for next block during registration", type=int, default=bittensor.defaults.subtensor.register.update_interval)
         except argparse.ArgumentError:
             # re-parsing arguments.
             pass

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -1082,8 +1082,8 @@ class TestCli(unittest.TestCase):
         config = self.config
         config.subtensor._mock = True
         config.command = "register"
-        config.num_processes = 1
-        config.update_interval = 50_000
+        config.subtensor.register.num_processes = 1
+        config.subtensor.register.update_interval = 50_000
         config.subtensor.network = "mock"
         config.no_prompt = True
 


### PR DESCRIPTION
btcli run calls cli.register() without the correct config flags, so I added them to subtensor args