### PR TITLE
[Fix] --help command

### DIFF
--- a/bin/btcli
+++ b/bin/btcli
@@ -6,7 +6,7 @@ import bittensor
 
 if __name__ == '__main__':
     args = sys.argv[1:]
-    bittensor.cli(args).run()
+    bittensor.cli(args=args).run()
 
 # The MIT License (MIT)
 # Copyright © 2021 Yuma Rao

--- a/bin/btcli
+++ b/bin/btcli
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 
-import bittensor 
+import sys
+
+import bittensor
+
 if __name__ == '__main__':
-    bittensor.cli().run()
+    args = sys.argv[1:]
+    bittensor.cli(args).run()
 
 # The MIT License (MIT)
 # Copyright © 2021 Yuma Rao
+# Copyright © 2022 Opentensor Foundation
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
 # documentation files (the “Software”), to deal in the Software without restriction, including without limitation 

--- a/bittensor/_axon/__init__.py
+++ b/bittensor/_axon/__init__.py
@@ -227,13 +227,13 @@ class axon:
     def add_defaults(cls, defaults):
         """ Adds parser defaults to object from enviroment variables.
         """
-        defaults.axon = bittensor.config()
+        defaults.axon = bittensor.Config()
         defaults.axon.port = os.getenv('BT_AXON_PORT') if os.getenv('BT_AXON_PORT') != None else 8091
         defaults.axon.ip = os.getenv('BT_AXON_IP') if os.getenv('BT_AXON_IP') != None else '[::]'
         defaults.axon.max_workers = os.getenv('BT_AXON_MAX_WORERS') if os.getenv('BT_AXON_MAX_WORERS') != None else 10
         defaults.axon.maximum_concurrent_rpcs = os.getenv('BT_AXON_MAXIMUM_CONCURRENT_RPCS') if os.getenv('BT_AXON_MAXIMUM_CONCURRENT_RPCS') != None else 400
         
-        defaults.axon.priority = bittensor.config()
+        defaults.axon.priority = bittensor.Config()
         defaults.axon.priority.max_workers = os.getenv('BT_AXON_PRIORITY_MAX_WORKERS') if os.getenv('BT_AXON_PRIORITY_MAX_WORKERS') != None else 10
         defaults.axon.priority.maxsize = os.getenv('BT_AXON_PRIORITY_MAXSIZE') if os.getenv('BT_AXON_PRIORITY_MAXSIZE') != None else -1
 

--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -3,6 +3,7 @@ Create and init the CLI class, which handles the coldkey, hotkey and money trans
 """
 # The MIT License (MIT)
 # Copyright © 2021 Yuma Rao
+# Copyright © 2022 Opentensor Foundation
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
 # documentation files (the “Software”), to deal in the Software without restriction, including without limitation 
@@ -21,12 +22,11 @@ Create and init the CLI class, which handles the coldkey, hotkey and money trans
 import argparse
 import os
 import sys
-from typing import List
+from typing import List, Optional
 
 import bittensor
 import torch
 from rich.prompt import Confirm, Prompt
-from substrateinterface.utils.ss58 import ss58_decode, ss58_encode
 
 from . import cli_impl
 
@@ -34,24 +34,27 @@ console = bittensor.__console__
 
 class cli:
     """
-    Create and init the CLI class, which handles the coldkey, hotkey and tau transfer 
+    Create and init the CLI class, which handles the coldkey, hotkey and tao transfer 
     """
     def __new__(
-            cls, 
-            config: 'bittensor.Config' = None,
+            cls,
+            args: Optional[List[str]] = None, 
+            config: Optional['bittensor.Config'] = None,
         ) -> 'bittensor.CLI':
         r""" Creates a new bittensor.cli from passed arguments.
             Args:
+                args (`List[str]`, `optional`): 
+                    The arguments to parse from the command line.
                 config (:obj:`bittensor.Config`, `optional`): 
                     bittensor.cli.config()
         """
         if config == None: 
-            config = cli.config()
+            config = cli.config(args)
         cli.check_config( config )
         return cli_impl.CLI( config = config)
 
     @staticmethod   
-    def config() -> 'bittensor.config':
+    def config(args: List[str]) -> 'bittensor.config':
         """ From the argument parser, add config to bittensor.executor and local config 
             Return: bittensor.config object
         """
@@ -611,7 +614,7 @@ class cli:
             required=False
         )
 
-        return bittensor.config( parser )
+        return bittensor.config( parser, args=args )
 
     @staticmethod   
     def check_config (config: 'bittensor.Config'):

--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -38,15 +38,15 @@ class cli:
     """
     def __new__(
             cls,
-            args: Optional[List[str]] = None, 
             config: Optional['bittensor.Config'] = None,
+            args: Optional[List[str]] = None, 
         ) -> 'bittensor.CLI':
         r""" Creates a new bittensor.cli from passed arguments.
             Args:
-                args (`List[str]`, `optional`): 
-                    The arguments to parse from the command line.
                 config (:obj:`bittensor.Config`, `optional`): 
                     bittensor.cli.config()
+                args (`List[str]`, `optional`): 
+                    The arguments to parse from the command line.
         """
         if config == None: 
             config = cli.config(args)

--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -58,7 +58,10 @@ class cli:
         """ From the argument parser, add config to bittensor.executor and local config 
             Return: bittensor.config object
         """
-        parser = argparse.ArgumentParser(description="Bittensor cli", usage="btcli <command> <command args>", add_help=True)
+        parser = argparse.ArgumentParser(
+            description=f"bittensor cli v{bittensor.__version__}",
+            usage="btcli <command> <command args>",
+            add_help=True)
 
         cmd_parsers = parser.add_subparsers(dest='command')
         overview_parser = cmd_parsers.add_parser(

--- a/bittensor/_config/__init__.py
+++ b/bittensor/_config/__init__.py
@@ -95,8 +95,7 @@ class config:
                 print('Error in loading: {} using default parser settings'.format(e))
 
         # 2. Continue with loading in params.
-        if strict:
-            params = cls.__parse_args__(args=args, parser=parser, strict=True)
+        params = cls.__parse_args__(args=args, parser=parser, strict=strict)
 
         _config = config_impl.Config()
 

--- a/bittensor/_config/__init__.py
+++ b/bittensor/_config/__init__.py
@@ -3,6 +3,7 @@ Create and init the config class, which manages the config of different bittenso
 """
 # The MIT License (MIT)
 # Copyright © 2021 Yuma Rao
+# Copyright © 2022 Opentensor Foundation
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
 # documentation files (the “Software”), to deal in the Software without restriction, including without limitation 
@@ -19,12 +20,14 @@ Create and init the config class, which manages the config of different bittenso
 # DEALINGS IN THE SOFTWARE.
 
 import os
-from argparse import ArgumentParser
+import sys
+from argparse import ArgumentParser, Namespace
+from typing import List, Optional
 
+import bittensor
 import yaml
 from loguru import logger
 
-import bittensor
 from . import config_impl
 
 logger = logger.opt(colors=True)
@@ -37,13 +40,15 @@ class config:
         """ In place of YAMLError
         """
 
-    def __new__( cls, parser: ArgumentParser = None, strict: bool = False ):
+    def __new__( cls, parser: ArgumentParser = None, strict: bool = False, args: Optional[List[str]] = None ):
         r""" Translates the passed parser into a nested Bittensor config.
         Args:
             parser (argparse.Parser):
                 Command line parser object.
             strict (bool):
                 If true, the command line arguments are strictly parsed.
+            args (list of str):
+                Command line arguments.
         Returns:
             config (bittensor.Config):
                 Nested config object created from parser arguments.
@@ -69,8 +74,15 @@ class config:
         except Exception as e:
             config_file_path = None
 
+        # Get args from argv if not passed in.
+        if args == None:
+            args = sys.argv[1:]
+
+        # Parse args not strict
+        params = cls.__parse_args__(args=args, parser=parser, strict=False)
+
         # 2. Optionally check for --strict, if stict we will parse the args strictly.
-        strict = parser.parse_known_args()[0].strict
+        strict = params.strict
                         
         if config_file_path != None:
             config_file_path = os.path.expanduser(config_file_path)
@@ -83,10 +95,9 @@ class config:
                 print('Error in loading: {} using default parser settings'.format(e))
 
         # 2. Continue with loading in params.
-        if not strict:
-            params = parser.parse_known_args()[0]
-        else:
-            params = parser.parse_args()
+        if strict:
+            params = cls.__parse_args__(args=args, parser=parser, strict=True)
+
         _config = config_impl.Config()
 
         # Splits params on dot syntax i.e neuron.axon_port            
@@ -106,6 +117,27 @@ class config:
                 head[keys[0]] = arg_val
 
         return _config
+
+    @staticmethod
+    def __parse_args__( args: List[str], parser: ArgumentParser = None, strict: bool = False) -> Namespace:
+        """Parses the passed args use the passed parser.
+        Args:
+            args (List[str]):
+                List of arguments to parse.
+            parser (argparse.ArgumentParser):
+                Command line parser object.
+            strict (bool):
+                If true, the command line arguments are strictly parsed.
+        Returns:
+            Namespace:
+                Namespace object created from parser arguments.
+        """
+        if not strict:
+            params = parser.parse_known_args(args=args)[0]
+        else:
+            params = parser.parse_args(args=args)
+
+        return params
 
     @staticmethod
     def full():

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -1,5 +1,6 @@
 # The MIT License (MIT)
 # Copyright © 2022 Yuma Rao
+# Copyright © 2022 Opentensor Foundation
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
 # documentation files (the “Software”), to deal in the Software without restriction, including without limitation 
@@ -16,7 +17,6 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-import sys
 import unittest
 from types import SimpleNamespace
 from typing import Dict
@@ -26,8 +26,6 @@ import bittensor
 from bittensor._subtensor.subtensor_mock import mock_subtensor
 from bittensor.utils.balance import Balance
 from substrateinterface.base import Keypair
-from substrateinterface.exceptions import SubstrateRequestException
-
 from tests.helpers import CLOSE_IN_VALUE
 
 
@@ -1326,6 +1324,31 @@ class TestCli(unittest.TestCase):
             cli = bittensor.cli(config)
             # This shouldn't raise an error anymore
             cli.run()
+
+def test_btcli_help():
+    """
+    Verify the correct help text is output when the --help flag is passed
+    """
+    with patch('argparse.ArgumentParser._print_message', return_value=None) as mock_print_message:
+        args = [
+            '--help'
+        ]
+        bittensor.cli(args).run()
+
+    # Should try to print help
+    mock_print_message.assert_called_once()
+
+    call_args = mock_print_message.call_args
+    args, _ = call_args
+    help_out = args[0]
+
+    # Expected help output even if parser isn't working well
+    assert 'optional arguments' in help_out
+    # Expected help output if all commands are listed
+    assert 'positional arguments' in help_out
+    # Verify that cli is printing the help message for 
+    assert 'overview' in help_out
+    assert 'run' in help_out
 
 
 if __name__ == "__main__":

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -1333,7 +1333,7 @@ def test_btcli_help():
         args = [
             '--help'
         ]
-        bittensor.cli(args).run()
+        bittensor.cli(args=args).run()
 
     # Should try to print help
     mock_print_message.assert_called_once()

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -1345,7 +1345,8 @@ def test_btcli_help():
     help_out = args[0]
 
     # Expected help output even if parser isn't working well
-    assert 'optional arguments' in help_out
+    ## py3.6-3.9 or py3.10+
+    assert 'optional arguments' in help_out or 'options' in help_out
     # Expected help output if all commands are listed
     assert 'positional arguments' in help_out
     # Verify that cli is printing the help message for 

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -21,6 +21,7 @@ import unittest
 from types import SimpleNamespace
 from typing import Dict
 from unittest.mock import ANY, MagicMock, call, patch
+import pytest
 
 import bittensor
 from bittensor._subtensor.subtensor_mock import mock_subtensor
@@ -1329,11 +1330,12 @@ def test_btcli_help():
     """
     Verify the correct help text is output when the --help flag is passed
     """
-    with patch('argparse.ArgumentParser._print_message', return_value=None) as mock_print_message:
-        args = [
-            '--help'
-        ]
-        bittensor.cli(args=args).run()
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        with patch('argparse.ArgumentParser._print_message', return_value=None) as mock_print_message:
+            args = [
+                '--help'
+            ]
+            bittensor.cli(args=args).run()
 
     # Should try to print help
     mock_print_message.assert_called_once()


### PR DESCRIPTION
This PR:
- fixes the `btcli --help` output
- adds a test to verify the help output is correct
- modifies the help output with the version