### PR TITLE
[BIT-572] Exclude lowest quantile from weight setting

### DIFF
--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -630,8 +630,8 @@ class neuron:
         sample_weights = neuron_weights[:weights_to_set]  # slice to weights_to_set
 
         # === Exclude lowest quantile from weight setting ===
-        if min_allowed_weights <= len(sample_weights):
-            max_exclude = (len(sample_weights) - min_allowed_weights) / len(sample_weights)  # max excludable weights
+        max_exclude = (len(sample_weights) - min_allowed_weights) / len(sample_weights)  # max excludable weights
+        if 0 < max_exclude:
             exclude_quantile = min([self.config.neuron.exclude_quantile, max_exclude])  # reduce quantile to meet min_allowed_weights
             lowest_quantile = sample_weights.quantile(exclude_quantile)  # find lowest quantile threshold
             sample_uids = sample_uids[lowest_quantile <= sample_weights]  # exclude uids with weights below quantile

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -630,11 +630,12 @@ class neuron:
         sample_weights = neuron_weights[:weights_to_set]  # slice to weights_to_set
 
         # === Exclude lowest quantile from weight setting ===
-        max_exclude = (len(sample_weights) - min_allowed_weights) / len(sample_weights)  # max excludable weights
-        exclude_quantile = min([self.config.neuron.exclude_quantile, max_exclude])  # reduce quantile to meet min_allowed_weights
-        lowest_quantile = sample_weights.quantile(exclude_quantile)  # find lowest quantile threshold
-        sample_uids = sample_uids[lowest_quantile <= sample_weights]  # exclude uids with weights below quantile
-        sample_weights = sample_weights[lowest_quantile <= sample_weights]  # exclude weights below quantile
+        if min_allowed_weights <= len(sample_weights):
+            max_exclude = (len(sample_weights) - min_allowed_weights) / len(sample_weights)  # max excludable weights
+            exclude_quantile = min([self.config.neuron.exclude_quantile, max_exclude])  # reduce quantile to meet min_allowed_weights
+            lowest_quantile = sample_weights.quantile(exclude_quantile)  # find lowest quantile threshold
+            sample_uids = sample_uids[lowest_quantile <= sample_weights]  # exclude uids with weights below quantile
+            sample_weights = sample_weights[lowest_quantile <= sample_weights]  # exclude weights below quantile
 
         # === Normalize and apply max_allowed_ratio ===
         sample_weights = bittensor.utils.weight_utils.normalize_max_multiple(x=sample_weights,

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -629,17 +629,25 @@ class neuron:
         sample_uids = preferred_uids[:weights_to_set]  # slice to weights_to_set
         sample_weights = neuron_weights[:weights_to_set]  # slice to weights_to_set
 
+        logger.info(f'{len(sample_weights)} Shapley values | min:{sample_weights.min()} max:{sample_weights.max()}')
+
         # === Exclude lowest quantile from weight setting ===
-        max_exclude = (len(sample_weights) - min_allowed_weights) / len(sample_weights)  # max excludable weights
+        max_exclude = (len(sample_weights) - min_allowed_weights) / len(sample_weights)  # max excludable weight quantile
         if 0 < max_exclude:
             exclude_quantile = min([self.config.neuron.exclude_quantile, max_exclude])  # reduce quantile to meet min_allowed_weights
             lowest_quantile = sample_weights.quantile(exclude_quantile)  # find lowest quantile threshold
             sample_uids = sample_uids[lowest_quantile <= sample_weights]  # exclude uids with weights below quantile
             sample_weights = sample_weights[lowest_quantile <= sample_weights]  # exclude weights below quantile
 
+            logger.info(f'Exclude {exclude_quantile} quantile ({lowest_quantile}) | '
+                        f'{len(sample_weights)} Shapley values | min:{sample_weights.min()} max:{sample_weights.max()}')
+
         # === Normalize and apply max_allowed_ratio ===
         sample_weights = bittensor.utils.weight_utils.normalize_max_multiple(x=sample_weights,
                                                                              multiple=max_allowed_ratio)
+        logger.info(f'{len(sample_weights)} normalize_max_multiple | '
+                    f'min:{sample_weights.min()} max:{sample_weights.max()}')
+
         return sample_uids, sample_weights
 
     def weights_table(self, sample_uids, sample_weights, include_uids=None, num_rows: int = None):


### PR DESCRIPTION
### [BIT-572] Exclude lowest quantile from weight setting

Exclude lowest quantile from weight setting in validator

Intended to pair with normalize_max_multiple to reduce sensitivity to bottom outliers by excluding the lowest quantile, effectively setting their weight to zero.

Quantile of 10% chosen in added neuron parameter: `exclude_quantile`:
`parser.add_argument('--neuron.exclude_quantile', type=float, help='Exclude the lowest quantile from weight setting.', default=0.1)`

[BIT-572]: https://opentensor.atlassian.net/browse/BIT-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ