### PR TITLE
fix help overview, fix tests, change to --config.strict and --config

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -142,5 +142,5 @@ wallet.add_defaults( defaults )
 dataset.add_defaults( defaults )
 wandb.add_defaults( defaults )
 logging.add_defaults( defaults )
-
+config.add_defaults( defaults )
 from substrateinterface import Keypair as Keypair

--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -111,7 +111,7 @@ class cli:
             type=str,
             help='''Sort the hotkeys in the specified ordering. (ascending/asc or descending/desc/reverse)'''
         )
-        
+        bittensor.config.add_args( overview_parser )        
         bittensor.wallet.add_args( overview_parser )
         bittensor.subtensor.add_args( overview_parser )
         
@@ -142,7 +142,7 @@ class cli:
             default='None', 
             help='''Synapses available through bittensor.synapse'''
         )
-        
+        bittensor.config.add_args( run_parser )        
         bittensor.subtensor.add_args( run_parser )
         bittensor.wallet.add_args( run_parser )
 
@@ -158,6 +158,7 @@ class cli:
             default=False,
         )
         bittensor.subtensor.add_args( metagraph_parser )
+        bittensor.config.add_args( metagraph_parser )        
 
 
         help_parser = cmd_parsers.add_parser(
@@ -184,6 +185,8 @@ class cli:
             help='''Set true to skip prompt from update.''',
             default=False,
         )
+        bittensor.config.add_args( update_parser )        
+
 
         inspect_parser = cmd_parsers.add_parser(
             'inspect', 
@@ -198,6 +201,7 @@ class cli:
         )
         bittensor.wallet.add_args( inspect_parser )
         bittensor.subtensor.add_args( inspect_parser )
+        bittensor.config.add_args( inspect_parser )        
 
         query_parser = cmd_parsers.add_parser(
             'query', 
@@ -222,6 +226,7 @@ class cli:
         bittensor.subtensor.add_args( query_parser )
         bittensor.dendrite.add_args( query_parser )
         bittensor.logging.add_args( query_parser )
+        bittensor.config.add_args( query_parser )        
 
         weights_parser = cmd_parsers.add_parser(
             'weights', 
@@ -236,6 +241,7 @@ class cli:
         )
         bittensor.wallet.add_args( weights_parser )
         bittensor.subtensor.add_args( weights_parser )
+        bittensor.config.add_args( weights_parser )        
 
         set_weights_parser = cmd_parsers.add_parser(
             'set_weights', 
@@ -252,6 +258,7 @@ class cli:
         set_weights_parser.add_argument ("--weights", type=float, required=False, nargs='*', action='store', help="Weights to set.")
         bittensor.wallet.add_args( set_weights_parser )
         bittensor.subtensor.add_args( set_weights_parser )
+        bittensor.config.add_args( set_weights_parser )        
 
         list_parser = cmd_parsers.add_parser(
             'list', 
@@ -265,6 +272,7 @@ class cli:
             default=False,
         )
         bittensor.wallet.add_args( list_parser )
+        bittensor.config.add_args( list_parser )        
 
         transfer_parser = cmd_parsers.add_parser(
             'transfer', 
@@ -344,6 +352,7 @@ class cli:
             help='''Overwrite the old coldkey with the newly generated coldkey'''
         )
         bittensor.wallet.add_args( regen_coldkey_parser )
+        bittensor.config.add_args( regen_coldkey_parser )        
 
 
         regen_coldkeypub_parser.add_argument(
@@ -379,6 +388,7 @@ class cli:
             help='''Overwrite the old coldkeypub file with the newly generated coldkeypub'''
         )
         bittensor.wallet.add_args( regen_coldkeypub_parser )
+        bittensor.config.add_args( regen_coldkeypub_parser )        
 
 
         # Fill arguments for the regen hotkey command.
@@ -416,6 +426,7 @@ class cli:
             help='''Overwrite the old hotkey with the newly generated hotkey'''
         )
         bittensor.wallet.add_args( regen_hotkey_parser )
+        bittensor.config.add_args( regen_hotkey_parser )        
 
 
         # Fill arguments for the new coldkey command.
@@ -452,8 +463,8 @@ class cli:
             default=False,
             help='''Overwrite the old coldkey with the newly generated coldkey'''
         )
-        
         bittensor.wallet.add_args( new_coldkey_parser )
+        bittensor.config.add_args( new_coldkey_parser )        
 
 
         # Fill arguments for the new hotkey command.
@@ -491,6 +502,7 @@ class cli:
             help='''Overwrite the old hotkey with the newly generated hotkey'''
         )
         bittensor.wallet.add_args( new_hotkey_parser )
+        bittensor.config.add_args( new_hotkey_parser )        
 
 
         # Fill arguments for unstake command. 
@@ -525,6 +537,7 @@ class cli:
 
         bittensor.wallet.add_args( unstake_parser )
         bittensor.subtensor.add_args( unstake_parser )
+        bittensor.config.add_args( unstake_parser )        
 
 
         # Fill arguments for stake command.
@@ -564,6 +577,7 @@ class cli:
         
         bittensor.wallet.add_args( stake_parser )
         bittensor.subtensor.add_args( stake_parser )
+        bittensor.config.add_args( stake_parser )        
 
 
         # Fill arguments for transfer
@@ -588,6 +602,7 @@ class cli:
         )
         bittensor.wallet.add_args( transfer_parser )
         bittensor.subtensor.add_args( transfer_parser )
+        bittensor.config.add_args( transfer_parser )        
 
 
         # Fill arguments for transfer
@@ -601,6 +616,7 @@ class cli:
 
         bittensor.wallet.add_args( register_parser )
         bittensor.subtensor.add_args( register_parser )
+        bittensor.config.add_args( register_parser )        
 
         # Fill run parser.
         run_parser.add_argument(

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -126,7 +126,7 @@ class CLI:
         for uid in self.config.uids:
             neuron = subtensor.neuron_for_uid( uid )
             endpoint = bittensor.endpoint.from_neuron( neuron )
-            _, c, t = dendrite.forward_text( endpoints = endpoint, inputs = 'hello world')
+            _, c, t = dendrite.format_text_inputs( endpoints = endpoint, inputs = 'hello world')
             latency = "{}".format(t.tolist()[0]) if c.tolist()[0] == 1 else 'N/A'
             bittensor.__console__.print("\tUid: [bold white]{}[/bold white]\n\tLatency: [bold white]{}[/bold white]\n\tCode: [bold {}]{}[/bold {}]\n\n".format(uid, latency, bittensor.utils.codes.code_to_loguru_color( c.item() ), bittensor.utils.codes.code_to_string( c.item() ), bittensor.utils.codes.code_to_loguru_color( c.item() )), highlight=True)
             stats[uid] = latency

--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -512,8 +512,7 @@ class server(torch.nn.Module):
     @staticmethod
     def config ():
         parser = argparse.ArgumentParser()
-        parser.add_argument('--config', type=str, help='If set, defaults are overridden by passed file.')
-
+        
         # ML model arguements
         parser.add_argument('--neuron.learning_rate', type=float, help='Training initial learning rate.', default=0.01)
         parser.add_argument('--neuron.momentum', type=float, help='optimizer momentum.', default=0.8)
@@ -563,5 +562,6 @@ class server(torch.nn.Module):
         bittensor.prioritythreadpool.add_args( parser )
         bittensor.dataset.add_args( parser )
         bittensor.metagraph.add_args( parser )
+        bittensor.config.add_args( parser )        
         return bittensor.config( parser )
     

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -188,6 +188,7 @@ class neuron:
         bittensor.dataset.check_config( config )
         bittensor.dendrite.check_config( config )
         bittensor.wandb.check_config( config )
+        bittensor.config.check_config( config )        
         full_path = os.path.expanduser('{}/{}/{}/{}'.format( config.logging.logging_dir, config.wallet.name, config.wallet.hotkey, config.neuron.name ))
         config.neuron.full_path = os.path.expanduser(full_path)
         config.using_wandb = config.wandb.api_key != 'default'
@@ -223,7 +224,8 @@ class neuron:
         bittensor.metagraph.add_args( parser )
         bittensor.logging.add_args( parser )
         bittensor.dataset.add_args( parser )
-        bittensor.wandb.add_args(parser)
+        bittensor.wandb.add_args( parser )
+        bittensor.config.add_args( parser )        
         return bittensor.config( parser )
 
     def __repr__(self) -> str:
@@ -235,14 +237,15 @@ class neuron:
                 f'{self.config.wallet.hotkey}:[bold]{self.wallet.hotkey.ss58_address[:7]}[/bold])')
 
     def __del__(self):
-        self.__exit__()
+        try:
+            self.dataset.close()
+            self.dendrite.__del__()
+        except: pass
 
     def __exit__ ( self, exc_type, exc_value, exc_traceback ):
         r""" Close down neuron.
         """
         print(exc_type, exc_value, exc_traceback)
-        self.dataset.close()
-        self.dendrite.__del__()
 
     def __enter__(self):
         r""" Sanity checks and begin validator.

--- a/bittensor/_proto/bittensor.proto
+++ b/bittensor/_proto/bittensor.proto
@@ -29,12 +29,12 @@ message Neuron {
 	int64 uid = 2;
 
 	// Neuron key: [REQUIRED] Ed25519 raw hex encoded public key (the hotkey).
-	// i.e. b'4c598ff31b68eb6c458c2dc51b25367fa213c566088077f46d93156148429d78'
+	// i.e. '4c598ff31b68eb6c458c2dc51b25367fa213c566088077f46d93156148429d78'
 	// SIZE: 256-bits (32-bytes)
 	string hotkey = 3;
 
 	// Neuron key: [REQUIRED] Ed25519 raw hex encoded public key (the coldkey).
-	// i.e. b'4c598ff31b68eb6c458c2dc51b25367fa213c566088077f46d93156148429d78'
+	// i.e. '4c598ff31b68eb6c458c2dc51b25367fa213c566088077f46d93156148429d78'
 	// SIZE: 256-bits (32-bytes)
 	string coldkey = 4;
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ jinja2>=3.0
 fuzzywuzzy==0.18.0
 google-api-python-client>=2.6.0
 python-levenshtein==0.12.1
-grpcio==1.42.0
+grpcio
 grpcio-tools==1.42.0
 hypothesis>=6.47.4
 loguru
@@ -20,7 +20,7 @@ netaddr==0.8.0
 pandas
 psutil
 password_strength==0.0.3.post2
-protobuf==3.15.0
+protobuf
 pycryptodome==3.11.0
 py-sr25519-bindings>=0.1.4,<1
 py-ed25519-bindings>=1.0,<2

--- a/scripts/build_protos.sh
+++ b/scripts/build_protos.sh
@@ -1,1 +1,1 @@
-python3 -m grpc.tools.protoc bittensor/_proto/bittensor.proto  -I. --python_out=. --grpc_python_out=.
+python3.9 -m grpc.tools.protoc bittensor/_proto/bittensor.proto  -I. --python_out=. --grpc_python_out=.

--- a/tests/unit_tests/bittensor_tests/test_config.py
+++ b/tests/unit_tests/bittensor_tests/test_config.py
@@ -44,8 +44,13 @@ def test_strict():
     bittensor.dataset.add_args( parser )
     bittensor.axon.add_args( parser )
     bittensor.wandb.add_args( parser )
-    bittensor.config( parser, strict=False)
-    bittensor.config( parser, strict=True)
+    bittensor.config( parser, strict=False )
+    try:
+        bittensor.config( parser, strict=True )
+        assert False, "This should raise an error because pytest will add its specific arguments which we do not recognize."
+    except:
+        assert True
+
 
 def test_prefix():
     # Test the use of prefixes to instantiate all of the bittensor objects.
@@ -74,53 +79,29 @@ def test_prefix():
     bittensor.wandb.add_args( parser )
     bittensor.wandb.add_args( parser, prefix = 'second' )
 
-    config_non_strict = bittensor.config( parser, strict=False)
-    config_strict = bittensor.config( parser, strict=True)
+    config = bittensor.config( parser, strict=False)
 
-    bittensor.dendrite( config_strict )
-    bittensor.dendrite( config_non_strict )
-    bittensor.dendrite( config_strict.second )
-    bittensor.dendrite( config_non_strict.second )
+    bittensor.dendrite( config )
+    bittensor.dendrite( config.second )
 
-    bittensor.axon( config_strict )
-    bittensor.axon( config_non_strict )
-    bittensor.axon( config_strict.second )
-    bittensor.axon( config_non_strict.second )
+    bittensor.axon( config )
+    bittensor.axon( config.second )
 
-    bittensor.dataset( config_strict )
-    bittensor.dataset( config_non_strict )
-    bittensor.dataset( config_strict.second )
-    bittensor.dataset( config_non_strict.second )
+    bittensor.dataset( config )
+    bittensor.dataset( config.second )
 
-    bittensor.axon( config_strict )
-    bittensor.axon( config_non_strict )
-    bittensor.axon( config_strict.second )
-    bittensor.axon( config_non_strict.second )
+    bittensor.axon( config )
+    bittensor.axon( config.second )
 
-    bittensor.metagraph( config_strict )
-    bittensor.metagraph( config_non_strict )
-    bittensor.metagraph( config_strict.second )
-    bittensor.metagraph( config_non_strict.second )
-
-    bittensor.wallet( config_strict )
-    bittensor.wallet( config_non_strict )
-    bittensor.wallet( config_strict.second )
-    bittensor.wallet( config_non_strict.second )
-
-    bittensor.logging( config_strict )
-    bittensor.logging( config_non_strict )
-    bittensor.logging( config_strict.second )
-    bittensor.logging( config_non_strict.second )
-
-    # This is the only place we call bittensor.wandb() outside of neuron code.
-    # It fails because we don't have a key set up for this.
-    # TODO: Actually test bittensor.wandb
-    #bittensor.wandb( config_strict )
-    #bittensor.wandb( config_non_strict )
-    #bittensor.wandb( config_strict.second )
-    #bittensor.wandb( config_non_strict.second )
-
-
+    bittensor.metagraph( config )
+    bittensor.metagraph( config.second )
+  
+    bittensor.wallet( config )
+    bittensor.wallet( config.second )
+  
+    bittensor.logging( config )
+    bittensor.logging( config.second )
+  
 def construct_config():
     defaults = bittensor.Config()
     bittensor.subtensor.add_defaults( defaults )
@@ -130,7 +111,7 @@ def construct_config():
     bittensor.dataset.add_defaults( defaults )
     bittensor.logging.add_defaults( defaults )
     bittensor.wandb.add_defaults( defaults )
-    
+    bittensor.config.add_defaults( defaults )
     return defaults
 
 def test_to_defaults():


### PR DESCRIPTION
Fixes --help for the btcli

The issue was caused because by bittensor calls a parse_args on import. 
The fix was ensuring bittensor only calls pars_args when a parser has been created by the API.

Features:
-- changes --config to --config.file
-- changes --strict to --config.strict

Updates: 
This will require a documentation change to reflect these new arguments

