### PR TITLE
Adds no_private command to cli and wallet

### DIFF
--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -324,6 +324,13 @@ class cli:
             help='Seed hex string used to regen your key i.e. 0x1234...'
         )
         regen_coldkey_parser.add_argument(
+            '--no_private', 
+            dest='no_private', 
+            action='store_true', 
+            help='''If set, the command only creates the coldkeypub.txt keyfile and not the encrypted coldkey (useful for running on insecure servers)''',
+            default=False,
+        )
+        regen_coldkey_parser.add_argument(
             '--use_password', 
             dest='use_password', 
             action='store_true', 
@@ -438,6 +445,13 @@ class cli:
             action='store_true', 
             help='''Set true to protect the generated bittensor key with a password.''',
             default=True,
+        )
+        new_coldkey_parser.add_argument(
+            '--no_private', 
+            dest='no_private', 
+            action='store_true', 
+            help='''If set, the command only creates the coldkeypub.txt keyfile and not the encrypted coldkey (useful for running on insecure servers)''',
+            default=False,
         )
         new_coldkey_parser.add_argument(
             '--no_password', 
@@ -861,6 +875,9 @@ class cli:
         if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
+        if config.no_private and not config.no_prompt:
+            if not Confirm.ask("Only generate the public key (coldkeypub.txt)?"):
+                sys.exit()
 
     def check_new_hotkey_config( config: 'bittensor.Config' ):
         if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
@@ -887,6 +904,9 @@ class cli:
         if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
+        if config.no_private and not config.no_prompt:
+            if not Confirm.ask("Only generate public key (coldkeypub.txt)?"):
+                sys.exit()
         if config.mnemonic == None and config.seed == None:
             prompt_answer = Prompt.ask("Enter mnemonic or seed")
             print(prompt_answer)

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -90,7 +90,7 @@ class CLI:
         r""" Creates a new coldkey under this wallet.
         """
         wallet = bittensor.wallet(config = self.config)
-        wallet.create_new_coldkey( n_words = self.config.n_words, use_password = self.config.use_password, overwrite = self.config.overwrite_coldkey)   
+        wallet.create_new_coldkey( n_words = self.config.n_words, use_password = self.config.use_password, overwrite = self.config.overwrite_coldkey, no_private = self.config.no_private)   
 
     def create_new_hotkey ( self ):
         r""" Creates a new hotke under this wallet.
@@ -102,7 +102,7 @@ class CLI:
         r""" Creates a new coldkey under this wallet.
         """
         wallet = bittensor.wallet(config = self.config)
-        wallet.regenerate_coldkey( mnemonic = self.config.mnemonic, seed = self.config.seed, use_password = self.config.use_password, overwrite = self.config.overwrite_coldkey )
+        wallet.regenerate_coldkey( mnemonic = self.config.mnemonic, seed = self.config.seed, use_password = self.config.use_password, overwrite = self.config.overwrite_coldkey, no_private = self.config.no_private)
 
     def regen_coldkeypub ( self ):
         r""" Creates a new coldkeypub under this wallet.

--- a/tests/integration_tests/test_wallet.py
+++ b/tests/integration_tests/test_wallet.py
@@ -37,8 +37,10 @@ def init_wallet():
     return the_wallet
 
 def check_keys_exists(the_wallet = None, coldkey_exists = True, hotkey_exists = True, coldkeypub_exists = True):
+
     if coldkey_exists:
         # --- test file and key exists
+        assert the_wallet.has_coldkey
         assert os.path.isfile(the_wallet.coldkey_file.path)
         assert the_wallet._coldkey != None
         # --- test _load_key()
@@ -48,6 +50,7 @@ def check_keys_exists(the_wallet = None, coldkey_exists = True, hotkey_exists = 
 
     if hotkey_exists:
         # --- test file and key exists
+        assert the_wallet.has_hotkey
         assert os.path.isfile(the_wallet.hotkey_file.path)
         assert the_wallet._hotkey != None
         # --- test _load_key()
@@ -57,6 +60,7 @@ def check_keys_exists(the_wallet = None, coldkey_exists = True, hotkey_exists = 
 
     if coldkeypub_exists:
         # --- test file and key exists
+        assert the_wallet.has_coldkeypub
         assert os.path.isfile(the_wallet.coldkeypub_file.path)
         # --- test _load_key()
         the_wallet._coldkeypub = None
@@ -77,6 +81,20 @@ def test_create_keys():
     the_wallet.new_coldkey( use_password=False, overwrite = True )
     the_wallet.new_hotkey( use_password=False, overwrite = True )
     check_keys_exists(the_wallet)
+
+def test_create_coldkeys_no_private():
+    the_wallet = init_wallet()
+    the_wallet.create_new_coldkey( use_password=False, overwrite = True, no_private=True )
+    assert not the_wallet.has_hotkey
+    assert not the_wallet.has_coldkey
+    assert the_wallet.has_coldkeypub
+
+def test_regenerate_coldkeys_no_private():
+    the_wallet = init_wallet()
+    the_wallet.regenerate_coldkey( mnemonic = "solve arrive guilt syrup dust sea used phone flock vital narrow endorse".split(),  use_password=False, overwrite = True, no_private=True )
+    assert not the_wallet.has_hotkey
+    assert not the_wallet.has_coldkey
+    assert the_wallet.has_coldkeypub
     
 def test_wallet_uri():
     the_wallet = init_wallet()
@@ -197,6 +215,9 @@ def test_wallet_mock_from_name():
 
 def test_wallet_mock_from_func():
     wallet = bittensor.wallet.mock()
+    assert wallet.has_coldkey
+    assert wallet.has_coldkeypub
+    assert wallet.has_hotkey
     assert wallet.hotkey_file.exists_on_device()
     assert wallet.coldkey_file.exists_on_device()
     assert wallet.coldkeypub_file.exists_on_device()

--- a/tests/unit_tests/bittensor_tests/test_wallet.py
+++ b/tests/unit_tests/bittensor_tests/test_wallet.py
@@ -64,3 +64,4 @@ class TestWallet(unittest.TestCase):
         with pytest.raises(ValueError):
             # Must provide either public_key or ss58_address
             self.mock_wallet.regenerate_coldkeypub(ss58_address=None, public_key=None)
+


### PR DESCRIPTION
User can now specify that they only want to regenerate the coldkeypub.txt file during regeneration or on the creation of the coldkey. This helps the user keep private information off of potentially insecure servers.

btcli regen_coldkey --no_private

btcli new_coldkey --no_private
