### PR TITLE
adds --n_keys to new_hotkey command

### DIFF
--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -310,7 +310,7 @@ class cli:
             help='''Creates a new hotkey (for running a miner) under the specified path.'''
         )
          
-        # Fill arguments for the regen coldkey command.
+        # Fill arguments for the regen coldkey new-.
         regen_coldkey_parser.add_argument(
             "--mnemonic", 
             required=False, 
@@ -463,6 +463,13 @@ class cli:
 
 
         # Fill arguments for the new hotkey command.
+        new_hotkey_parser.add_argument(
+            '--n_keys', 
+            type=int, 
+            choices=list(range(1, 25)),
+            default=1, 
+            help='''The number of hotkeys to create under this coldkey. Names are suffixed like so: wallet.hotkey0, wallet.hotkey1, ..., wallet.hotkey(n_keys-1)'''
+        )
         new_hotkey_parser.add_argument(
             '--n_words', 
             type=int, 
@@ -870,6 +877,11 @@ class cli:
         if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
+
+        if config.n_keys != 1 and not config.no_prompt:
+            keynames = [ config.wallet.get('hotkey')+str(i) for i in range(config.n_keys) ]
+            if not Confirm.ask("Create hotkeys: [blue]'{}'[/blue]?".format(keynames)):
+                sys.exit()
 
     def check_regen_hotkey_config( config: 'bittensor.Config' ):
         if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -90,13 +90,22 @@ class CLI:
         r""" Creates a new coldkey under this wallet.
         """
         wallet = bittensor.wallet(config = self.config)
+        bittensor.__console__.print("\n[bold white]Creating coldkey[/bold white]: {}".format(wallet))
         wallet.create_new_coldkey( n_words = self.config.n_words, use_password = self.config.use_password, overwrite = self.config.overwrite_coldkey)   
 
     def create_new_hotkey ( self ):
         r""" Creates a new hotke under this wallet.
         """
-        wallet = bittensor.wallet(config = self.config)
-        wallet.create_new_hotkey( n_words = self.config.n_words, use_password = self.config.use_password, overwrite = self.config.overwrite_hotkey)   
+        if self.config.n_keys == 1:
+            wallet = bittensor.wallet(config = self.config)
+            bittensor.__console__.print("\n[bold white]Creating hotkey[/bold white]: {}".format(wallet))
+            wallet.create_new_hotkey( n_words = self.config.n_words, use_password = self.config.use_password, overwrite = self.config.overwrite_hotkey)   
+        else:
+            keynames = [ self.config.wallet.get('hotkey')+str(i) for i in range(self.config.n_keys) ]
+            for kname in keynames:
+                wallet = bittensor.wallet(config = self.config, hotkey= kname )
+                bittensor.__console__.print("\n[bold white]Creating hotkey[/bold white]: {}".format(wallet))
+                wallet.create_new_hotkey( n_words = self.config.n_words, use_password = self.config.use_password, overwrite = self.config.overwrite_hotkey)   
 
     def regen_coldkey ( self ):
         r""" Creates a new coldkey under this wallet.


### PR DESCRIPTION
Allows the user to specify --n_keys during the new_hotkey command allowing them to create multiple hotkeys at once. 

Example:
btcli new_hotkey --n_keys 10                       
Enter wallet name (default): 
Enter hotkey name (default): 
Create hotkeys: '['default0', 'default1', 'default2', 'default3', 'default4', 'default5', 'default6', 'default7', 'default8', 'default9']'? [y/n]: 