### PR TITLE
[fix] fixes unstake with max-stake flag

### DIFF
--- a/bittensor/utils/balance.py
+++ b/bittensor/utils/balance.py
@@ -68,6 +68,9 @@ class Balance:
         return self.__str__()
 
     def __eq__(self, other: Union[int, float, "Balance"]):
+        if other is None:
+            return False
+            
         if hasattr(other, "rao"):
             return self.rao == other.rao
         else:

--- a/tests/unit_tests/bittensor_tests/test_balance.py
+++ b/tests/unit_tests/bittensor_tests/test_balance.py
@@ -327,3 +327,12 @@ class TestBalance(unittest.TestCase):
         assert isinstance(quot_, Balance)
         assert CLOSE_IN_VALUE(quot_.rao, 5) == rao2_ // rao_   
 
+    @given(balance=valid_tao_numbers_strategy)
+    def test_balance_not_eq_none(self, balance: Union[int, float]):
+        balance_ = Balance(balance)
+        assert not balance_ == None
+
+    @given(balance=valid_tao_numbers_strategy)
+    def test_balance_neq_none(self, balance: Union[int, float]):
+        balance_ = Balance(balance)
+        assert balance_ != None


### PR DESCRIPTION
The balance class equality didn't support `Balance == None`, this PR adds a catch for this and returns False.
This fixes an error on `unstake_multiple` with a `wallet.max_stake` flag set