### PR TITLE
[feature] add --seed option to regen_hotkey

### DIFF
--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -395,6 +395,12 @@ class cli:
             help='Mnemonic used to regen your key i.e. horse cart dog ...'
         )
         regen_hotkey_parser.add_argument(
+            "--seed", 
+            required=False,  
+            default=None,
+            help='Seed hex string used to regen your key i.e. 0x1234...'
+        )
+        regen_hotkey_parser.add_argument(
             '--use_password', 
             dest='use_password', 
             action='store_true', 
@@ -891,8 +897,12 @@ class cli:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
         
-        if config.mnemonic == None:
-            config.mnemonic = Prompt.ask("Enter mnemonic")
+        if config.mnemonic == None and config.seed == None:
+            prompt_answer = Prompt.ask("Enter mnemonic or seed")
+            if prompt_answer.startswith("0x"):
+                config.seed = prompt_answer
+            else:
+                config.mnemonic = prompt_answer
 
     def check_regen_coldkey_config( config: 'bittensor.Config' ):
         if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
@@ -900,7 +910,6 @@ class cli:
             config.wallet.name = str(wallet_name)
         if config.mnemonic == None and config.seed == None:
             prompt_answer = Prompt.ask("Enter mnemonic or seed")
-            print(prompt_answer)
             if prompt_answer.startswith("0x"):
                 config.seed = prompt_answer
             else:

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -114,7 +114,7 @@ class CLI:
         r""" Creates a new coldkey under this wallet.
         """
         wallet = bittensor.wallet(config = self.config)
-        wallet.regenerate_hotkey( mnemonic = self.config.mnemonic, use_password = self.config.use_password, overwrite = self.config.overwrite_hotkey)
+        wallet.regenerate_hotkey( mnemonic = self.config.mnemonic, seed=self.config.seed, use_password = self.config.use_password, overwrite = self.config.overwrite_hotkey)
 
     def query ( self ):
         r""" Query an endpoint and get query time.

--- a/bittensor/_wallet/wallet_impl.py
+++ b/bittensor/_wallet/wallet_impl.py
@@ -669,7 +669,7 @@ class Wallet():
     # Short name for regenerate_coldkeypub
     regen_coldkeypub = regenerate_coldkeypub
 
-    def regenerate_coldkey( self, mnemonic: Optional[Union[list, str]]=None, seed: Optional[str]=None, use_password: bool = True,  overwrite:bool = False) -> 'Wallet':
+    def regenerate_coldkey( self, mnemonic: Optional[Union[list, str]] = None, seed: Optional[str] = None, use_password: bool = True,  overwrite:bool = False) -> 'Wallet':
         """ Regenerates the coldkey from passed mnemonic, encrypts it with the user's password and save the file
             Args:
                 mnemonic: (Union[list, str], optional):
@@ -700,11 +700,13 @@ class Wallet():
         self.set_coldkeypub( keypair, overwrite = overwrite)
         return self 
 
-    def regen_hotkey( self, mnemonic: Union[list, str], seed: str, use_password: bool = True, overwrite:bool = False) -> 'Wallet':
+    def regen_hotkey( self, mnemonic: Optional[Union[list, str]], seed: Optional[str], use_password: bool = True, overwrite:bool = False) -> 'Wallet':
         """ Regenerates the hotkey from passed mnemonic, encrypts it with the user's password and save the file
             Args:
                 mnemonic: (Union[list, str], optional):
                     Key mnemonic as list of words or string space separated words.
+                seed: (str, optional):
+                    Seed as hex string.
                 use_password (bool, optional):
                     Is the created key password protected.
                 overwrite (bool, optional): 
@@ -715,11 +717,13 @@ class Wallet():
         """
         self.regenerate_hotkey(mnemonic, seed, use_password, overwrite)
 
-    def regenerate_hotkey( self, mnemonic: Union[list, str], seed: str, use_password: bool = True, overwrite:bool = False) -> 'Wallet':
+    def regenerate_hotkey( self, mnemonic: Optional[Union[list, str]] = None, seed: Optional[str] = None, use_password: bool = True, overwrite:bool = False) -> 'Wallet':
         """ Regenerates the hotkey from passed mnemonic, encrypts it with the user's password and save the file
             Args:
                 mnemonic: (Union[list, str], optional):
                     Key mnemonic as list of words or string space separated words.
+                seed: (str, optional):
+                    Seed as hex string.
                 use_password (bool, optional):
                     Is the created key password protected.
                 overwrite (bool, optional): 

--- a/bittensor/_wallet/wallet_impl.py
+++ b/bittensor/_wallet/wallet_impl.py
@@ -700,7 +700,7 @@ class Wallet():
         self.set_coldkeypub( keypair, overwrite = overwrite)
         return self 
 
-    def regen_hotkey( self, mnemonic: Union[list, str], use_password: bool = True, overwrite:bool = False) -> 'Wallet':
+    def regen_hotkey( self, mnemonic: Union[list, str], seed: str, use_password: bool = True, overwrite:bool = False) -> 'Wallet':
         """ Regenerates the hotkey from passed mnemonic, encrypts it with the user's password and save the file
             Args:
                 mnemonic: (Union[list, str], optional):
@@ -713,9 +713,9 @@ class Wallet():
                 wallet (bittensor.Wallet):
                     this object with newly created hotkey.
         """
-        self.regenerate_hotkey(mnemonic, use_password, overwrite)
+        self.regenerate_hotkey(mnemonic, seed, use_password, overwrite)
 
-    def regenerate_hotkey( self, mnemonic: Union[list, str], use_password: bool = True, overwrite:bool = False) -> 'Wallet':
+    def regenerate_hotkey( self, mnemonic: Union[list, str], seed: str, use_password: bool = True, overwrite:bool = False) -> 'Wallet':
         """ Regenerates the hotkey from passed mnemonic, encrypts it with the user's password and save the file
             Args:
                 mnemonic: (Union[list, str], optional):
@@ -728,10 +728,17 @@ class Wallet():
                 wallet (bittensor.Wallet):
                     this object with newly created hotkey.
         """
-        if isinstance( mnemonic, str): mnemonic = mnemonic.split()
-        if len(mnemonic) not in [12,15,18,21,24]:
-            raise ValueError("Mnemonic has invalid size. This should be 12,15,18,21 or 24 words")
-        keypair = Keypair.create_from_mnemonic(" ".join(mnemonic))
-        display_mnemonic_msg( keypair, "hotkey" )
+        if mnemonic is None and seed is None:
+            raise ValueError("Must pass either mnemonic or seed")
+        if mnemonic is not None:
+            if isinstance( mnemonic, str): mnemonic = mnemonic.split()
+            if len(mnemonic) not in [12,15,18,21,24]:
+                raise ValueError("Mnemonic has invalid size. This should be 12,15,18,21 or 24 words")
+            keypair = Keypair.create_from_mnemonic(" ".join(mnemonic))
+            display_mnemonic_msg( keypair, "hotkey" )
+        else:
+            # seed is not None
+            keypair = Keypair.create_from_seed(seed)
+        
         self.set_hotkey( keypair, encrypt=use_password, overwrite = overwrite)
         return self 

--- a/bittensor/_wallet/wallet_impl.py
+++ b/bittensor/_wallet/wallet_impl.py
@@ -700,7 +700,7 @@ class Wallet():
         self.set_coldkeypub( keypair, overwrite = overwrite)
         return self 
 
-    def regen_hotkey( self, mnemonic: Optional[Union[list, str]], seed: Optional[str], use_password: bool = True, overwrite:bool = False) -> 'Wallet':
+    def regen_hotkey( self, mnemonic: Optional[Union[list, str]], seed: Optional[str] = None, use_password: bool = True, overwrite:bool = False) -> 'Wallet':
         """ Regenerates the hotkey from passed mnemonic, encrypts it with the user's password and save the file
             Args:
                 mnemonic: (Union[list, str], optional):

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -1185,6 +1185,7 @@ class TestCli(unittest.TestCase):
         config.subtensor._mock = True
         config.model = "core_server"
         config.mnemonic = "faculty decade seven jelly gospel axis next radio grain radio remain gentle"
+        config.seed = None
         config.n_words = 12
         config.use_password = False
         config.no_prompt = True

--- a/tests/unit_tests/bittensor_tests/test_wallet.py
+++ b/tests/unit_tests/bittensor_tests/test_wallet.py
@@ -64,3 +64,33 @@ class TestWallet(unittest.TestCase):
         with pytest.raises(ValueError):
             # Must provide either public_key or ss58_address
             self.mock_wallet.regenerate_coldkeypub(ss58_address=None, public_key=None)
+
+    def test_regen_coldkey_from_hex_seed_str(self):
+        ss58_addr = "5D5cwd8DX6ij7nouVcoxDuWtJfiR1BnzCkiBVTt7DU8ft5Ta"
+        seed_str = "0x659c024d5be809000d0d93fe378cfde020846150b01c49a201fc2a02041f7636"
+        with patch.object(self.mock_wallet, 'set_coldkey') as mock_set_coldkey:
+            self.mock_wallet.regenerate_coldkey(seed=seed_str)
+
+            mock_set_coldkey.assert_called_once()
+            keypair: bittensor.Keypair = mock_set_coldkey.call_args_list[0][0][0]
+            self.assertEqual(keypair.seed_hex, seed_str)
+            self.assertEqual(keypair.ss58_address, ss58_addr) # Check that the ss58 address is correct
+
+        seed_str_bad = "0x659c024d5be809000d0d93fe378cfde020846150b01c49a201fc2a02041f763" # 1 character short
+        with pytest.raises(ValueError):
+            self.mock_wallet.regenerate_coldkey(seed=seed_str_bad)
+
+    def test_regen_hotkey_from_hex_seed_str(self):
+        ss58_addr = "5D5cwd8DX6ij7nouVcoxDuWtJfiR1BnzCkiBVTt7DU8ft5Ta"
+        seed_str = "0x659c024d5be809000d0d93fe378cfde020846150b01c49a201fc2a02041f7636"
+        with patch.object(self.mock_wallet, 'set_hotkey') as mock_set_hotkey:
+            self.mock_wallet.regenerate_hotkey(seed=seed_str)
+
+            mock_set_hotkey.assert_called_once()
+            keypair: bittensor.Keypair = mock_set_hotkey.call_args_list[0][0][0]
+            self.assertEqual(keypair.seed_hex, seed_str)
+            self.assertEqual(keypair.ss58_address, ss58_addr) # Check that the ss58 address is correct
+
+        seed_str_bad = "0x659c024d5be809000d0d93fe378cfde020846150b01c49a201fc2a02041f763" # 1 character short
+        with pytest.raises(ValueError):
+            self.mock_wallet.regenerate_hotkey(seed=seed_str_bad)


### PR DESCRIPTION
This PR adds the functionality to regenerate a hotkey using a private seed, in-place of a mnemonic.  
i.e.  

    btcli regen_hotkey --seed 0x659c024d5be809000d0d93fe378cfde020846150b01c49a201fc2a02041f7636
will regen a hotkey with the ss58 address:  

    5D5cwd8DX6ij7nouVcoxDuWtJfiR1BnzCkiBVTt7DU8ft5Ta

This PR also adds unit tests for regenerating both the hotkey and coldkey using a seed, in this way.