### PR TITLE
Bit 583 memory optimization v4

### DIFF
--- a/bittensor/_dendrite/__init__.py
+++ b/bittensor/_dendrite/__init__.py
@@ -181,7 +181,7 @@ class dendrite:
         assert 'timeout' in config.dendrite
         assert 'requires_grad' in config.dendrite
         assert config.dendrite.max_worker_threads > 0, 'max_worker_threads must be larger than 0'
-        assert config.dendrite.max_active_receptors > 0, 'max_active_receptors must be larger than 0'
+        assert config.dendrite.max_active_receptors >= 0, 'max_active_receptors must be larger or eq to 0'
         bittensor.wallet.check_config( config )
 
     @classmethod

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -144,7 +144,7 @@ class neuron:
         self.wallet = bittensor.wallet ( config = self.config ) if wallet == None else wallet
         self.subtensor = bittensor.subtensor ( config = self.config ) if subtensor == None else subtensor
         self.metagraph = bittensor.metagraph ( config = self.config, subtensor = self.subtensor ) if metagraph == None else metagraph
-        self.dendrite = bittensor.dendrite ( config = self.config, wallet = self.wallet, max_active_receptors = 1 ) if dendrite == None else dendrite # Dendrite should not store receptor in validator.
+        self.dendrite = bittensor.dendrite ( config = self.config, wallet = self.wallet, max_active_receptors = 0 ) if dendrite == None else dendrite # Dendrite should not store receptor in validator.
         self.device = torch.device ( device = self.config.neuron.device )    
         self.nucleus = nucleus ( config = self.config, device = self.device, subtensor = self.subtensor ).to( self.device )
         self.dataset = (bittensor.dataset(config=self.config, batch_size=self.subtensor.validator_batch_size,

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -144,7 +144,7 @@ class neuron:
         self.wallet = bittensor.wallet ( config = self.config ) if wallet == None else wallet
         self.subtensor = bittensor.subtensor ( config = self.config ) if subtensor == None else subtensor
         self.metagraph = bittensor.metagraph ( config = self.config, subtensor = self.subtensor ) if metagraph == None else metagraph
-        self.dendrite = bittensor.dendrite ( config = self.config, wallet = self.wallet ) if dendrite == None else dendrite
+        self.dendrite = bittensor.dendrite ( config = self.config, wallet = self.wallet, max_active_receptors = 1 ) if dendrite == None else dendrite # Dendrite should not store receptor in validator.
         self.device = torch.device ( device = self.config.neuron.device )    
         self.nucleus = nucleus ( config = self.config, device = self.device, subtensor = self.subtensor ).to( self.device )
         self.dataset = (bittensor.dataset(config=self.config, batch_size=self.subtensor.validator_batch_size,


### PR DESCRIPTION
- Changing max_active_receptors from 2000 (default) to strictly 0. Meaning that the dendrite would not store any receptor for the validator. Note that it would not affect the working/efficiency of the validator due to the uid permutation approach.

**(1) Core validator with stored receptor**
![image](https://user-images.githubusercontent.com/49876827/192866420-bd1c8c08-31a9-4ea3-abf7-df35eba0f180.png)

**(2) Core validator that dose not store receptor**
![image](https://user-images.githubusercontent.com/49876827/192866612-77e54f27-68b6-4704-b6c1-96b08c90f73f.png)

**(3) Core validator that dose not store receptor with separated receptor forward**
![image](https://user-images.githubusercontent.com/49876827/192866905-1bd01ce7-23d0-4b88-a484-9da03eea2644.png)

Note that for (2) and (3) there is a difference in the increment of memory, with slope 0.05 VS slope 0.013 (stated at the very right hand side of the pic).
Although the increment with (3) is significantly smaller, I am not confident that the fix from (3) can account for all of the memory leak, so I would like to leave it until there is strong enough evidence. 