### PR TITLE
[Fix] only reregister if flag is set

### DIFF
--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -196,7 +196,8 @@ class CLI:
         wallet.coldkeypub
 
         # Check registration
-        self.register()
+        ## Will exit if --wallet.reregister is False
+        wallet.reregister()
 
         # Run miner.
         if self.config.model == 'core_server':

--- a/bittensor/_config/__init__.py
+++ b/bittensor/_config/__init__.py
@@ -70,7 +70,7 @@ class config:
 
         # 1.1 Optionally load defaults if the --config is set.
         try:
-            config_file_path = str(os.getcwd()) + '/' + vars(parser.parse_known_args()[0])['config']
+            config_file_path = str(os.getcwd()) + '/' + vars(parser.parse_known_args(args)[0])['config']
         except Exception as e:
             config_file_path = None
 

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -19,6 +19,7 @@
 
 import argparse
 import copy
+from distutils.util import strtobool
 import os
 
 import bittensor
@@ -114,7 +115,7 @@ class wallet:
             
             parser.add_argument('--' + prefix_str + 'wallet.hotkeys', '--' + prefix_str + 'wallet.exclude_hotkeys', required=False, action='store', default=bittensor.defaults.wallet.hotkeys, type=str, nargs='*', help='''Specify the hotkeys by name. (e.g. hk1 hk2 hk3)''')
             parser.add_argument('--' + prefix_str + 'wallet.all_hotkeys', required=False, action='store_true', default=bittensor.defaults.wallet.all_hotkeys, help='''To specify all hotkeys. Specifying hotkeys will exclude them from this all.''')
-            parser.add_argument('--' + prefix_str + 'wallet.reregister', required=False, action='store', default=bittensor.defaults.wallet.reregister, type=bool, help='''Whether to reregister the wallet if it is not already registered.''')
+            parser.add_argument('--' + prefix_str + 'wallet.reregister', required=False, default=bittensor.defaults.wallet.reregister, type=lambda x: bool(strtobool(x)), help='''Whether to reregister the wallet if it is not already registered.''')
 
         except argparse.ArgumentError as e:
             pass

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -1327,6 +1327,25 @@ class TestCli(unittest.TestCase):
             # This shouldn't raise an error anymore
             cli.run()
 
+    def test_run_reregister_false(self):
+        """
+        Verify that the btcli run command does not reregister a not registered wallet
+            if --wallet.reregister is False
+        """
+        with patch('bittensor.Wallet.is_registered', MagicMock(return_value=False)): # Wallet is not registered
+            with pytest.raises(SystemExit):
+                config = self.config
+                config.wallet.name = "run_testwallet"
+                config.wallet._mock = True
+                config.subtensor.network = "mock"
+                config.subtensor._mock = True
+                config.command = "run"
+                config.wallet.reregister = False # Don't reregister
+                config.no_prompt = True
+
+                cli = bittensor.cli(config)
+                cli.run()
+
 def test_btcli_help():
     """
     Verify the correct help text is output when the --help flag is passed
@@ -1353,6 +1372,7 @@ def test_btcli_help():
     # Verify that cli is printing the help message for 
     assert 'overview' in help_out
     assert 'run' in help_out
+
 
 
 if __name__ == "__main__":

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -1327,25 +1327,6 @@ class TestCli(unittest.TestCase):
             # This shouldn't raise an error anymore
             cli.run()
 
-    def test_run_reregister_false(self):
-        """
-        Verify that the btcli run command does not reregister a not registered wallet
-            if --wallet.reregister is False
-        """
-        with patch('bittensor.Wallet.is_registered', MagicMock(return_value=False)): # Wallet is not registered
-            with pytest.raises(SystemExit):
-                config = self.config
-                config.wallet.name = "run_testwallet"
-                config.wallet._mock = True
-                config.subtensor.network = "mock"
-                config.subtensor._mock = True
-                config.command = "run"
-                config.wallet.reregister = False # Don't reregister
-                config.no_prompt = True
-
-                cli = bittensor.cli(config)
-                cli.run()
-
 def test_btcli_help():
     """
     Verify the correct help text is output when the --help flag is passed
@@ -1373,6 +1354,28 @@ def test_btcli_help():
     assert 'overview' in help_out
     assert 'run' in help_out
 
+class TestCLIUsingArgs(unittest.TestCase):
+    """
+    Test the CLI by passing args directly to the bittensor.cli factory
+    """
+    def test_run_reregister_false(self):
+        """
+        Verify that the btcli run command does not reregister a not registered wallet
+            if --wallet.reregister is False
+        """
+        with patch('bittensor.Wallet.is_registered', MagicMock(return_value=False)): # Wallet is not registered
+            with pytest.raises(SystemExit):
+                cli = bittensor.cli(args=[
+                    'run',
+                    '--wallet.name', 'mock_wallet',
+                    '--wallet.hotkey', 'mock_hotkey',
+                    '--wallet._mock', 'True',
+                    '--subtensor.network', 'mock',
+                    '--subtensor._mock', 'True',
+                    '--no_prompt',
+                    '--wallet.reregister', 'False' # Don't reregister
+                ])
+                cli.run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes a bug where `--wallet.reregister False` was ignored during `btcli run`  
The expected behaviour is to not reregister a wallet that is not registered, and instead exit.  
The current behaviour is to start the registration, regardless, causing the bug.

This PR fixes the bug and adds a test to verify this. 

This PR also fixes a bug with the cli factory where the args where supposed to be passed in to be parsed early in the function as well, see [/bittensor/_config/\_\_init\_\_.py#73](https://github.com/opentensor/bittensor/pull/937/files#diff-7063c608940704d54850544cca95d1bb7ce2540a747e25c86b2a777d53836ddb)