### PR TITLE
[Fix] change bellagene entrypoint string

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -61,8 +61,8 @@ __nakamoto_entrypoint__ = "AtreusLB-2c6154f73e6429a9.elb.us-east-2.amazonaws.com
 
 __nobunaga_entrypoint__ = "staging.nobunaga.opentensor.ai:9944"
 
-
-__bellagene_entrypoint__ = "parachain.opentensor.ai:443"
+# Needs to use wss://
+__bellagene_entrypoint__ = "wss://parachain.opentensor.ai:443"
 
 
 __local_entrypoint__ = "127.0.0.1:9944"

--- a/bittensor/_subtensor/__init__.py
+++ b/bittensor/_subtensor/__init__.py
@@ -132,13 +132,10 @@ class subtensor:
             config.subtensor.network = bittensor.defaults.subtensor.network
         
         # make sure it's wss:// or ws://
-        # If it's bellagene (parachain testnet) then it has to be wss
+        # by default, add ws:// if neither are present
         endpoint_url: str = config.subtensor.chain_endpoint
         if endpoint_url[0:6] != "wss://" and endpoint_url[0:5] != "ws://":
-            if config.subtensor.network == "bellagene":
-                endpoint_url = "wss://{}".format(endpoint_url)
-            else:
-                endpoint_url = "ws://{}".format(endpoint_url)
+            endpoint_url = "ws://{}".format(endpoint_url)
         
         substrate = SubstrateInterface(
             ss58_format = bittensor.__ss58_format__,


### PR DESCRIPTION
The subtensor factory used to check if the network was `"bellagene"` to specially prepend `wss://` to the constant chain endpoint url.   

Instead, I think it's much better to add the `wss://` to the entrypoint url constant, as this removes the need to have this check at all.