### PR TITLE
Remove locals from cli and bittensor common

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -16,6 +16,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 from rich.console import Console
+from rich.traceback import install
 from prometheus_client import Info
 
 # Bittensor code and protocol version.
@@ -26,6 +27,10 @@ __version_as_int__ = (100 * int(version_split[0])) + (10 * int(version_split[1])
 # Rich console.
 __console__ = Console()
 __use_console__ = True
+
+# Remove overdue locals in debug training.
+install(show_locals=False)
+
 def turn_console_off():
     from io import StringIO
     __use_console__ = False

--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -32,6 +32,10 @@ from . import cli_impl
 
 console = bittensor.__console__
 
+# Remove incredibly large tracebacks.
+from rich.traceback import install
+install(show_locals=False)
+
 class cli:
     """
     Create and init the CLI class, which handles the coldkey, hotkey and tao transfer 


### PR DESCRIPTION
Adding install(show_locals=False) to cli/__init__.py and bittensor/__init__.py

This stops the error messages from becoming incredibly large.
