### PR TITLE
[Fix] pin wandb lower

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ wheel
 codecov
 tqdm
 qqdm
-wandb>=0.11.1
+wandb>=0.11.1,<0.13.4
 ansible_vault>=2.1
 substrate-interface==1.2.4
 markupsafe==2.0.1


### PR DESCRIPTION
Version `0.13.4` of wandb causes an error that isn't present in `0.13.3` so I'm pinning it
