### PR TITLE
addons to receptor_pool

### DIFF
--- a/bittensor/_receptor/receptor_pool_impl.py
+++ b/bittensor/_receptor/receptor_pool_impl.py
@@ -280,11 +280,7 @@ class ReceptorPool ( torch.nn.Module ):
         # resolve output type as either a tuple or a dictionary
 
         if return_type in ['tuple', tuple]:
-            return_result =  tuple(results_dict['outputs'], 
-                    results_dict['codes'], 
-                    results_dict['times'])
-
-            return return_result
+            return results_dict['outputs'], results_dict['codes'], results_dict['times']
         elif return_type in ['dict', dict]:
             return results_dict
 

--- a/bittensor/_receptor/receptor_pool_impl.py
+++ b/bittensor/_receptor/receptor_pool_impl.py
@@ -120,7 +120,7 @@ class ReceptorPool ( torch.nn.Module ):
             timeout: int,
             min_success:int = None, 
             return_success_only:bool=False, 
-            return_type:str = 'dict',
+            return_type:str = 'tuple',
             max_workers:int=None,
             graph:'bittensor.Metagraph'=None,
             graph_features:List[str]=['stake', 'ranks', 'trust', 'consensus', 'incentive', 'emission', 'dividends'],

--- a/bittensor/_receptor/receptor_pool_impl.py
+++ b/bittensor/_receptor/receptor_pool_impl.py
@@ -280,12 +280,11 @@ class ReceptorPool ( torch.nn.Module ):
         # resolve output type as either a tuple or a dictionary
 
         if return_type in ['tuple', tuple]:
-            return_result =  [results_dict['outputs'], 
+            return_result =  tuple(results_dict['outputs'], 
                     results_dict['codes'], 
-                    results_dict['times'],
-                    results_dict['uids']]
+                    results_dict['times'])
 
-            return tuple(return_result)
+            return return_result
         elif return_type in ['dict', dict]:
             return results_dict
 


### PR DESCRIPTION
Following changes that is backwards compatible

- use executor.submit to asynchronously send and process requests. This allows you to create generators (next PR ;) ) and return the first N to succeed
- min_success parameter which indicates the number of successful (or fraction if it is 0<x<len(endpoints)). This means that as we submit the endpoints, we only wait for the first {min_success} to respond
- return_type: the return type allows users to return the final result as a tuple or a dictionary. This was due to the lack of readability of using tuples. 
- graph features are included into the return object, and the user can also specify which features they want to include with {graph features}