### PR TITLE
Support arbitrary gRPC request metadata order

### DIFF
--- a/bittensor/_axon/__init__.py
+++ b/bittensor/_axon/__init__.py
@@ -339,39 +339,39 @@ class axon:
         forward_callback([sample_input], synapses, hotkey='')
 
 class AuthInterceptor(grpc.ServerInterceptor):
-    """ Creates a new server interceptor that authenticates incoming messages from passed arguments.
-    """
-    def __init__(self, key:str = 'Bittensor',blacklist:List = []):
-        r""" Creates a new server interceptor that authenticates incoming messages from passed arguments.
+    """Creates a new server interceptor that authenticates incoming messages from passed arguments."""
+
+    def __init__(self, key: str = "Bittensor", blacklist: List = []):
+        r"""Creates a new server interceptor that authenticates incoming messages from passed arguments.
         Args:
             key (str, `optional`):
                  key for authentication header in the metadata (default= Bittensor)
-            black_list (Fucntion, `optional`): 
+            black_list (Fucntion, `optional`):
                 black list function that prevents certain pubkeys from sending messages
         """
         super().__init__()
-        self._valid_metadata = ('rpc-auth-header', key)
+        self._valid_metadata = ("rpc-auth-header", key)
         self.nounce_dic = {}
-        self.message = 'Invalid key'
+        self.message = "Invalid key"
         self.blacklist = blacklist
+
         def deny(_, context):
             context.abort(grpc.StatusCode.UNAUTHENTICATED, self.message)
 
         self._deny = grpc.unary_unary_rpc_method_handler(deny)
 
     def intercept_service(self, continuation, handler_call_details):
-        r""" Authentication between bittensor nodes. Intercepts messages and checks them
-        """
+        r"""Authentication between bittensor nodes. Intercepts messages and checks them"""
         meta = handler_call_details.invocation_metadata
 
-        try: 
-            #version checking
+        try:
+            # version checking
             self.version_checking(meta)
 
-            #signature checking
+            # signature checking
             self.signature_checking(meta)
 
-            #blacklist checking
+            # blacklist checking
             self.black_list_checking(meta)
 
             return continuation(handler_call_details)
@@ -380,10 +380,9 @@ class AuthInterceptor(grpc.ServerInterceptor):
             self.message = str(e)
             return self._deny
 
-    def vertification(self,meta):
-        r"""vertification of signature in metadata. Uses the pubkey and nounce
-        """
-        variable_length_messages = meta[1].value.split('bitxx')
+    def vertification(self, meta):
+        r"""vertification of signature in metadata. Uses the pubkey and nounce"""
+        variable_length_messages = meta[1].value.split("bitxx")
         nounce = int(variable_length_messages[0])
         pubkey = variable_length_messages[1]
         message = variable_length_messages[2]
@@ -392,48 +391,49 @@ class AuthInterceptor(grpc.ServerInterceptor):
 
         # Unique key that specifies the endpoint.
         endpoint_key = str(pubkey) + str(unique_receptor_uid)
-        
-        #checking the time of creation, compared to previous messages
-        if endpoint_key in self.nounce_dic.keys():
-            prev_data_time = self.nounce_dic[ endpoint_key ]
-            if nounce - prev_data_time > -10:
-                self.nounce_dic[ endpoint_key ] = nounce
 
-                #decrypting the message and verify that message is correct
-                verification = _keypair.verify( str(nounce) + str(pubkey) + str(unique_receptor_uid), message)
+        # checking the time of creation, compared to previous messages
+        if endpoint_key in self.nounce_dic.keys():
+            prev_data_time = self.nounce_dic[endpoint_key]
+            if nounce - prev_data_time > -10:
+                self.nounce_dic[endpoint_key] = nounce
+
+                # decrypting the message and verify that message is correct
+                verification = _keypair.verify(
+                    str(nounce) + str(pubkey) + str(unique_receptor_uid), message
+                )
             else:
                 verification = False
         else:
-            self.nounce_dic[ endpoint_key ] = nounce
-            verification = _keypair.verify( str( nounce ) + str(pubkey) + str(unique_receptor_uid), message)
+            self.nounce_dic[endpoint_key] = nounce
+            verification = _keypair.verify(
+                str(nounce) + str(pubkey) + str(unique_receptor_uid), message
+            )
 
         return verification
 
-    def signature_checking(self,meta):
-        r""" Calls the vertification of the signature and raises an error if failed
-        """
+    def signature_checking(self, meta):
+        r"""Calls the vertification of the signature and raises an error if failed"""
         if self.vertification(meta):
             pass
         else:
-            raise Exception('Incorrect Signature')
+            raise Exception("Incorrect Signature")
 
-    def version_checking(self,meta):
-        r""" Checks the header and version in the metadata
-        """
+    def version_checking(self, meta):
+        r"""Checks the header and version in the metadata"""
         if meta[0] == self._valid_metadata:
             pass
         else:
-            raise Exception('Incorrect Metadata format')
+            raise Exception("Incorrect Metadata format")
 
-    def black_list_checking(self,meta):
-        r"""Tries to call to blacklist function in the miner and checks if it should blacklist the pubkey 
-        """
-        variable_length_messages = meta[1].value.split('bitxx')
+    def black_list_checking(self, meta):
+        r"""Tries to call to blacklist function in the miner and checks if it should blacklist the pubkey"""
+        variable_length_messages = meta[1].value.split("bitxx")
         pubkey = variable_length_messages[1]
-        
+
         if self.blacklist == None:
             pass
-        elif self.blacklist(pubkey,int(meta[3].value)):
-            raise Exception('Black listed')
+        elif self.blacklist(pubkey, int(meta[3].value)):
+            raise Exception("Black listed")
         else:
             pass

--- a/bittensor/_receptor/receptor_impl.py
+++ b/bittensor/_receptor/receptor_impl.py
@@ -664,7 +664,7 @@ class Receptor(nn.Module):
                     ('rpc-auth-header','Bittensor'),
                     ('bittensor-signature',self.sign()),
                     ('bittensor-version',str(bittensor.__version_as_int__)),
-                    ('request_type', str(bittensor.proto.RequestType.FORWARD)),
+                    ('request_type', str(bittensor.proto.RequestType.BACKWARD)),
                 ))
             asyncio_future.cancel()
 


### PR DESCRIPTION
#### Summary

This PR fixes the gRPC server interceptor logic such that it can handle any metadata order. gRPC request metadata is a set of key values - it has no order. So depending on the fact that the order of the sender is equivalent in the receiver is not correct.

gRPC metadata is sent over as HTTP headers, and the order of HTTP headers may be changed by intermediary proxies. 

#### Changes

- Format the `AuthInterceptor` using `black`.
- Use the invocation metadata as a dictionary, not a list of key-value pairs.
- Do not trust the user provided `request_type` and use the gRPC method instead.
- Fix `request_type` provided for backward calls.

#### Testing

Tested locally by proxying the axon traffic using Traefik.