### PR TITLE
Docker Action: dont run tests before docker image push

### DIFF
--- a/.github/workflows/docker_image_push.yml
+++ b/.github/workflows/docker_image_push.yml
@@ -1,7 +1,6 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# This workflow with build and push a Docker image dockerhub on every push to the master branch
 
-name: Pushing Image to Docker
+name: Pushing Latest Release Image to Docker
 
 on: 
   push:
@@ -10,32 +9,10 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest pytest-cov
-
-        pip install -r requirements.txt --use-deprecated=legacy-resolver
-    - name: Build Bittensor
-      run: |
-        python -m pip install -e .
-        ./scripts/create_wallet.sh
-        ./scripts/build_protos.sh
-    - name: Run Unit Tests
-      run: pytest ./tests/unit_tests --cov=. --cov-append --cov-config .coveragerc        
-    - name: Run Integration Tests
-      run: pytest ./tests/integration_tests --cov=. --cov-append --cov-config .coveragerc          
-    - name: Code Coverage
-      run: codecov
     - name: Login to DockerHub
       uses: docker/login-action@v1 
       with:


### PR DESCRIPTION
This PR makes the docker image push action not run tests first, as these should be completed anyway before merge to master occurs