### PR TITLE
[Hotfix] Synapse security update (nobunaga)

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -23,7 +23,7 @@ import nest_asyncio
 nest_asyncio.apply()
 
 # Bittensor code and protocol version.
-__version__ = '3.4.2'
+__version__ = '3.4.3'
 version_split = __version__.split(".")
 __version_as_int__ = (100 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/bittensor/_synapse/text_causallmnext_impl.py
+++ b/bittensor/_synapse/text_causallmnext_impl.py
@@ -123,6 +123,10 @@ class TextCausalLMNext(Synapse):
                              f"[>={forward_request_tensor.shape[0]} x (2 x {self.topk} + 1)], "
                              f"got: {forward_response_tensor.size(0)} for synapse: {self}")
 
+        atol = 1e-6  # absolute tolerance
+        if (forward_response_tensor < -atol).any():
+            raise ValueError("forward_response_tensor values below tolerance.")
+
     def check_backward_request_gradient(self, forward_request_tensor, backward_request_gradient):
         # forward_request_tensor: [batch_size, sequence_len]
         # backward_request_gradient: [batch_size, (topk + 1), max_len]

--- a/bittensor/utils/tokenizer_utils.py
+++ b/bittensor/utils/tokenizer_utils.py
@@ -875,7 +875,7 @@ def unravel_topk_token_phrases(compact_topk: torch.Tensor, topk: int, ignore_ind
                                                      f'{batch_size} * ({topk} + 1) != {len(prob_idx)}'  # decoding irregularity otherwise
 
     probs = torch.clamp(compact_topk[prob_idx], 0, 1)  # [batch_size * (topk + 1)] ensure probabilities within [0, 1]
-    probs_sum = probs.reshape(batch_size, topk + 1).sum(dim=1)  # [batch_size, (topk + 1)]
+    probs_sum = probs.reshape(batch_size, topk + 1).sum(dim=1)  # [batch_size]
     assert torch.all((-atol < probs_sum) & (probs_sum < 1 + atol)), f'unravel_topk_token_phrases(): probs_sum not in [0, 1]'
 
     # Obtain phrase lengths and maximum phrase length


### PR DESCRIPTION
### [Hotfix] Synapse security update (nobunaga)

**Catch precision errors in synapse forward responses**

Response serialization/deserialization can introduce precision errors that may cause probability sums to exceed permissible boundaries. Now checks to see if precision errors are within established absolute tolerance (atol = 1e-6 currently).