### PR TITLE
Mark registration threads as daemons

### DIFF
--- a/bittensor/utils/registration.py
+++ b/bittensor/utils/registration.py
@@ -158,7 +158,7 @@ class SolverBase(multiprocessing.Process):
     limit: int
 
     def __init__(self, proc_num, num_proc, update_interval, finished_queue, solution_queue, stopEvent, curr_block, curr_block_num, curr_diff, check_block, limit):
-        multiprocessing.Process.__init__(self)
+        multiprocessing.Process.__init__(self, daemon=True)
         self.proc_num = proc_num
         self.num_proc = num_proc
         self.update_interval = update_interval


### PR DESCRIPTION
#### Summary

This PR marks solver (registration) processes as daemons. This allows the main process to exit when an exception occurs (generally this happens when the `subtensor` is unreachable), instead of hanging indefinitely.

#### Changes

- Mark solver processes as daemons, in order to avoid having them get joined at the end of the program.
  - They are already joined on the 'happy' path, but they should not block program termination if an exception occurs on the main process.