### PR TITLE
[BIT-598] Validator debug response table

### DIFF
--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1444,9 +1444,14 @@ def response_table(batch_predictions: List, stats: Dict, sort_col: str, console_
         return
     batch_perm = torch.randperm(batch_size)  # avoid restricting observation to predictable subsets
 
-    columns = [column for column in neuron_stats_columns if column[1] in ['uid', 'loss_nxt', 'synergy_nxt']]
+    columns = [c[:] for c in neuron_stats_columns if c[1] in ['uid', 'shapley_values_nxt', 'loss_nxt', 'synergy_nxt']]
+    # === Sort rows ===
     sort = sorted([(uid, s[sort_col]) for uid, s in stats.items() if sort_col in s],
                   reverse=True, key=lambda _row: _row[1])
+    col_keys = [c[1] for c in columns]
+    if sort_col in col_keys:
+        sort_idx = col_keys.index(sort_col)  # sort column with key of sort_col
+        columns[sort_idx][0] += '\u2193'  # ↓ downwards arrow (sort)
 
     for i, (uid, val) in enumerate(sort):
         if i % task_repeat == 0:

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1436,7 +1436,7 @@ def response_predictions(uids: torch.Tensor, query_responses: List[List[torch.Fl
                 phrase = topk_tokens[i]
                 phrase = phrase[phrase >= 0]
                 preds[f'phrase{i}'] = repr(std_tokenizer.decode(phrase))
-                preds[f'prob{i}'] = topk_probs[i]
+                preds[f'prob{i}'] = topk_probs[i].item()
 
             predictions[uid] = preds
 

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1233,7 +1233,8 @@ def textcausallmnext(uids: torch.Tensor, query_responses: List[List[torch.FloatT
     logger.info(f'{str(synapse)} \t| Shapley synergy values <dim>[{time.time() - synergy_start_time:.3g}s]</dim>')
 
     if logging:
-        context, answer, predictions = response_predictions(uids, query_responses, return_ops, inputs, batch_size, index_s)
+        context, answer, predictions = response_predictions(uids, query_responses, return_ops,
+                                                            inputs, validation_len, batch_size, index_s)
         response_table(predictions, context, answer, stats,
                        sort_col='shapley_values_nxt', console_width=console_width, index_s=index_s)
 

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1410,7 +1410,7 @@ def format_predictions(uids: torch.Tensor, query_responses: List[List[torch.Floa
         context = repr(std_tokenizer.decode(context))[1:-1][-30:]  # strip '' and truncate
         answer = repr(std_tokenizer.decode(answer))[1:-1][:15]  # strip '' and truncate
 
-        task = f"[bold]{context}[/bold]{answer}"
+        task = f"[bold reverse]{context}[/bold reverse]{answer}"
 
         predictions = {}
         for index, uid in enumerate(uids.tolist()):

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1233,7 +1233,7 @@ def textcausallmnext(uids: torch.Tensor, query_responses: List[List[torch.FloatT
     logger.info(f'{str(synapse)} \t| Shapley synergy values <dim>[{time.time() - synergy_start_time:.3g}s]</dim>')
 
     if logging:
-        batch_item, predictions = response_predictions(uids, query_responses, batch_size, index_s)
+        batch_item, predictions = response_predictions(uids, query_responses, return_ops, batch_size, index_s)
         response_table(predictions, inputs[batch_item], validation_len, stats,
                        sort_col='shapley_values_nxt', console_width=console_width, index_s=index_s)
 

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1410,7 +1410,7 @@ def format_predictions(uids: torch.Tensor, query_responses: List[List[torch.Floa
         context = repr(std_tokenizer.decode(context))[1:-1][-30:]  # strip '' and truncate
         answer = repr(std_tokenizer.decode(answer))[1:-1][:15]  # strip '' and truncate
 
-        task = f"[bold reverse]{context}[/bold reverse]{answer}"
+        task = f"[reverse]{context}[/reverse][bold]{answer}[/bold]"
 
         predictions = {}
         for index, uid in enumerate(uids.tolist()):
@@ -1425,7 +1425,7 @@ def format_predictions(uids: torch.Tensor, query_responses: List[List[torch.Floa
                     phrase = phrase[phrase >= 0]
                     phrase_str = repr(std_tokenizer.decode(phrase))[:15]  # escape and truncate
                     prob = f'{topk_probs[i]:.3f}'
-                    prob = prob[1:] if prob[0] == '0' else prob
+                    prob = prob[1:] if prob[0] == '0' else prob[:-1]
                     preds += f"[green]{prob}[/green]: {phrase_str} "
 
                 predictions[uid] = preds[:-1]  # strip trailing space
@@ -1450,7 +1450,7 @@ def response_table(batch_predictions: List, stats: Dict, sort_col: str, console_
             # === Response table ===
             table = Table(width=console_width, box=None)
             if i == 0:
-                table.title = f'[white] Response sample [/white]'
+                table.title = f'[white] Query responses [/white]'
 
             for col, _, _, stl in columns:  # [Column_name, key_name, format_string, rich_style]
                 table.add_column(col, style=stl, justify='right')
@@ -1471,7 +1471,7 @@ def response_table(batch_predictions: List, stats: Dict, sort_col: str, console_
             print(table)
 
     if (len(sort) - 1) % task_repeat != task_repeat - 1:
-        table.caption = f'[white]context[/white]prediction'
+        table.caption = f'[white]context[/white][bold]prediction[/bold]'
         print(table)
     print()
 

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1468,6 +1468,8 @@ def response_table(batch_predictions: List, stats: Dict, sort_col: str, console_
         table.add_row(*row)
 
         if i % task_repeat == task_repeat - 1:
+            if i == len(sort) - 1:
+                table.caption = f'[white]context[/white][bold]prediction[/bold]'
             print(table)
 
     if (len(sort) - 1) % task_repeat != task_repeat - 1:

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1416,6 +1416,7 @@ def format_predictions(uids: torch.Tensor, query_responses: List[List[torch.Floa
 
         predictions = {}
         for index, uid in enumerate(uids.tolist()):
+            print('uid', uid, 'index', index, 'index_s', index_s, len(return_ops), end='; ')
             if return_ops[index][index_s] == bittensor.proto.ReturnCode.Success:
                 topk_tensor = query_responses[index][index_s]  # [batch_size, (topk + 1), max_len] (prob_k) + floor_prob
                 topk_tokens = topk_tensor[batch_item, :-1, 1:].int()  # [batch_size, topk, max_len - 1] Phrase tokens with ignore_index token for padding.
@@ -1429,7 +1430,7 @@ def format_predictions(uids: torch.Tensor, query_responses: List[List[torch.Floa
                     preds += f"[[white]{topk_probs[i]:.3f}[/white]: {phrase_str} "
 
                 predictions[uid] = preds[:-1]  # strip trailing space
-
+        print()
         batch_predictions += [(task, predictions)]
 
     return batch_predictions

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1480,7 +1480,8 @@ def response_table(batch_predictions: List, stats: Dict, sort_col: str, console_
             table.caption = f'[bold]{len(sort)}[/bold]/{len(stats)} (respond/topk) | ' \
                             f'[bold]{tasks_per_server}[/bold] tasks per server | ' \
                             f'repeat tasks over [bold]{task_repeat}[/bold] servers ' \
-                            f'\[{batch_size}]'
+                            f'[white]\[{math.ceil(1. * len(sort) / task_repeat) * tasks_per_server}/' \
+                            f'{batch_size} batch tasks][/white]'
 
         # === Row addition ===
         row = [txt.format(stats[uid][key]) for _, key, txt, _ in columns]

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1448,20 +1448,18 @@ def response_table(predictions: Dict, context: str, answer: str, stats: Dict,
 
     # Query response table columns
     #   [Column_name, key_name, format_string, rich_style]  # description
-    phrase_columns = sum([[['p', f'prob{i}', '{:.4f}', 'grey30'],  # probability of top prediction
+    phrase_columns = sum([[['p', f'prob{i}', '{:.4f}', 'magenta'],  # probability of top prediction
                            ['pred', f'phrase{i}', '{}', ''],  # phrase string prediction
                            ] for i in range(number_of_predictions)], [])
     columns = [column for column in neuron_stats_columns if column[1] in ['uid', 'loss_nxt', 'synergy_nxt']]
-    print('phrase_columns', phrase_columns)
+
     sort = sorted([(uid, s[sort_col]) for uid, s in stats.items() if sort_col in s],
                   reverse=True, key=lambda _row: _row[1])
 
     rows = []
     for uid, val in sort:
-        print(uid, predictions[uid])
         row = [txt.format(stats[uid][key]) for _, key, txt, _ in columns]
         row += [txt.format(predictions[uid][key]) for _, key, txt, _ in phrase_columns]
-        print(row)
         rows += [row]
 
     # === Response table ===

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1477,9 +1477,10 @@ def response_table(batch_predictions: List, stats: Dict, sort_col: str, console_
 
         # === Last table section ===
         if i == len(sort) - 1:
-            table.caption = f'[bold]{len([s for s in stats.values() if len(s)])}[/bold]/{len(stats)} (respond/topk) | ' \
+            table.caption = f'[bold]{len(sort)}[/bold]/{len(stats)} (respond/topk) | ' \
                             f'[bold]{tasks_per_server}[/bold] tasks per server | ' \
-                            f'repeat tasks over [bold]{task_repeat}[/bold] servers'
+                            f'repeat tasks over [bold]{task_repeat}[/bold] servers ' \
+                            f'\[{batch_size}]'
 
         # === Row addition ===
         row = [txt.format(stats[uid][key]) for _, key, txt, _ in columns]
@@ -1576,10 +1577,10 @@ def stats_table(stats, sort_col, console_width, title, caption, mark_uids=None):
 def synapse_table(name, stats, sort_col, console_width, start_time):
     r""" Prints the evaluation of the neuron responses to the validator request
     """
-
     stats_table(stats, sort_col, console_width,
                 f'[white] \[{name}] responses [/white] | Validator forward',  # title
-                f'[bold]{len([s for s in stats.values() if len(s)])}[/bold]/{len(stats)} (respond/topk) | '
+                f'[bold]{len([s for s in stats.values() if len(s) and sort_col in s])}[/bold]/'
+                f'{len(stats)} (respond/topk) | '
                 f'[bold]Synapse[/bold] | [white]\[{time.time() - start_time:.3g}s][/white]'  # caption
                 )
 

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1452,7 +1452,7 @@ def response_table(batch_predictions: List, stats: Dict, sort_col: str, console_
 
         row = [txt.format(stats[uid][key]) for _, key, txt, _ in columns]
         for j in range(tasks_per_server):
-            batch_item = batch_size % ((i // task_repeat) * tasks_per_server + j)  # do not exceed batch_size, repeat task over servers
+            batch_item = ((i // task_repeat) * tasks_per_server + j) % batch_size  # repeat task over servers, do not exceed batch_size
             task, predictions = batch_predictions[batch_perm[batch_item]]
 
             if i % task_repeat == 0:

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1452,7 +1452,7 @@ def response_table(predictions: Dict, context: str, answer: str, stats: Dict,
                            ['pred', f'phrase{i}', '{}', ''],  # phrase string prediction
                            ] for i in range(number_of_predictions)], [])
     columns = [column for column in neuron_stats_columns if column[1] in ['uid', 'loss_nxt', 'synergy_nxt']]
-
+    print('phrase_columns', phrase_columns)
     sort = sorted([(uid, s[sort_col]) for uid, s in stats.items() if sort_col in s],
                   reverse=True, key=lambda _row: _row[1])
 
@@ -1461,6 +1461,7 @@ def response_table(predictions: Dict, context: str, answer: str, stats: Dict,
         print(uid, predictions[uid])
         row = [txt.format(stats[uid][key]) for _, key, txt, _ in columns]
         row += [txt.format(predictions[uid][key]) for _, key, txt, _ in phrase_columns]
+        print(row)
         rows += [row]
 
     # === Response table ===

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1178,7 +1178,6 @@ def textcausallmnext(uids: torch.Tensor, query_responses: List[List[torch.FloatT
                 Statistics per endpoint for this batch.
     """
 
-    batch_size = inputs.shape[0]
     inputs_nxt = inputs[..., -validation_len:]  # input validation with next token target phrase [batch_size, val_len]
 
     def _base_params(_stats, query_response):
@@ -1233,8 +1232,7 @@ def textcausallmnext(uids: torch.Tensor, query_responses: List[List[torch.FloatT
     logger.info(f'{str(synapse)} \t| Shapley synergy values <dim>[{time.time() - synergy_start_time:.3g}s]</dim>')
 
     if logging:
-        batch_predictions = format_predictions(uids, query_responses, return_ops,
-                                               inputs, validation_len, batch_size, index_s)
+        batch_predictions = format_predictions(uids, query_responses, return_ops, inputs, validation_len, index_s)
         response_table(batch_predictions, stats, sort_col='shapley_values_nxt', console_width=console_width)
 
         # === Synergy table ===
@@ -1416,7 +1414,6 @@ def format_predictions(uids: torch.Tensor, query_responses: List[List[torch.Floa
 
         predictions = {}
         for index, uid in enumerate(uids.tolist()):
-            print('uid', uid, 'index', index, 'index_s', index_s, len(return_ops), end='; ')
             if return_ops[index][index_s] == bittensor.proto.ReturnCode.Success:
                 topk_tensor = query_responses[index][index_s]  # [batch_size, (topk + 1), max_len] (prob_k) + floor_prob
                 topk_tokens = topk_tensor[batch_item, :-1, 1:].int()  # [batch_size, topk, max_len - 1] Phrase tokens with ignore_index token for padding.
@@ -1430,7 +1427,7 @@ def format_predictions(uids: torch.Tensor, query_responses: List[List[torch.Floa
                     preds += f"[[white]{topk_probs[i]:.3f}[/white]: {phrase_str} "
 
                 predictions[uid] = preds[:-1]  # strip trailing space
-        print()
+
         batch_predictions += [(task, predictions)]
 
     return batch_predictions

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1424,7 +1424,9 @@ def format_predictions(uids: torch.Tensor, query_responses: List[List[torch.Floa
                     phrase = topk_tokens[i]
                     phrase = phrase[phrase >= 0]
                     phrase_str = repr(std_tokenizer.decode(phrase))[:15]  # escape and truncate
-                    preds += f"[[white]{topk_probs[i]:.3f}[/white]: {phrase_str} "
+                    prob = f'{topk_probs[i]:.3f}'
+                    prob = prob[1:] if prob[0] == '0' else prob
+                    preds += f"[green]{prob}[/green]: {phrase_str} "
 
                 predictions[uid] = preds[:-1]  # strip trailing space
 
@@ -1447,6 +1449,9 @@ def response_table(batch_predictions: List, stats: Dict, sort_col: str, console_
         if i % task_repeat == 0:
             # === Response table ===
             table = Table(width=console_width, box=None)
+            if i == 0:
+                table.title = f'[white] Response sample [/white]'
+
             for col, _, _, stl in columns:  # [Column_name, key_name, format_string, rich_style]
                 table.add_column(col, style=stl, justify='right')
 
@@ -1456,7 +1461,7 @@ def response_table(batch_predictions: List, stats: Dict, sort_col: str, console_
             task, predictions = batch_predictions[batch_perm[batch_item]]
 
             if i % task_repeat == 0:
-                table.add_column(task, style='', justify='left')
+                table.add_column(task, header_style='not bold', style='', justify='left')
 
             row += [predictions[uid]]
 
@@ -1465,6 +1470,9 @@ def response_table(batch_predictions: List, stats: Dict, sort_col: str, console_
         if i % task_repeat == task_repeat - 1:
             print(table)
 
+    if (len(sort) - 1) % task_repeat != task_repeat - 1:
+        table.caption = f'[white]context[/white]prediction'
+        print(table)
     print()
 
 


### PR DESCRIPTION
### [BIT-598] Validator debug response table

Adds an additional debug table to `core_validator... --logging.debug` that samples query tasks and server responses, formats it compactly, and displays the topk predicted phrases with probabilities.

The intended use of this table is to monitor and confirm proper query handling by displaying actual response content. This can also help to detect response anomalies that can help identify various new code/system/network errors that may have been introduced.

Apart from a task selection the table also includes overall step statistics for responsive servers.

Rich MarkupError exceptions are infrequently caught and handled when special characters in the task representation corrupt added markup.

<img width="1062" alt="Screenshot 2022-11-18 at 12 32 39" src="https://user-images.githubusercontent.com/93473497/202682218-b185608e-0645-4858-9135-f9d422a97f05.png">

<img width="1056" alt="Screenshot 2022-11-18 at 12 39 22" src="https://user-images.githubusercontent.com/93473497/202684555-cf5a0cf0-25fe-45de-acde-8f6851ae8d66.png">


[BIT-598]: https://opentensor.atlassian.net/browse/BIT-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ