### PR TITLE
[BIT-599] Validator weight setting improvements

### DIFF
--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1428,10 +1428,7 @@ def format_predictions(uids: torch.Tensor, query_responses: List[List[torch.Floa
                     phrase = topk_tokens[i]
                     phrase = phrase[phrase >= 0]  # strip negative ignore_index = -100
                     phrase_str = repr(std_tokenizer.decode(phrase))[:15]  # decode, escape and truncate
-
-                    prob = f'{topk_probs[i]:.3f}'
-                    prob = prob[1:] if prob[0] == '0' else prob[:-1]  # remove obvious leading 0
-
+                    prob = f'{topk_probs[i]:.3f}'.lstrip('0')
                     topk_predictions += f"[green]{prob}[/green]: {phrase_str} "
 
                 predictions[uid] = topk_predictions[:-1]  # strip trailing space
@@ -1511,12 +1508,12 @@ def synergy_table(stats, syn_loss_diff, sort_col, console_width):
     columns = [uid_col] + [[f'{s[0]}', '', '{:.2f}', ''] for s in sort]
     rows = [[uid_col[2].format(s[0])] +
             [('[bright_cyan]{:.2f}[/bright_cyan]' if t == s else
-              '[magenta]{:.2f}[/magenta]' if syn_loss_diff[s[0]][t[0]] > 0 else
+              '[magenta]{:.2f}[/magenta]'.lstrip('0') if syn_loss_diff[s[0]][t[0]] > 0 else
               '[dim]{:.0f}[/dim]').format(syn_loss_diff[s[0]][t[0]]) for t in sort] for s in sort]
 
     # === Synergy table ===
     table = Table(width=console_width, box=None)
-    table.title = f'[white] Synergy [/white]'
+    table.title = f'[white] Synergy table [/white] | Pairwise synergy'
     table.caption = f'loss decrease'
 
     for col, _, _, stl in columns:  # [Column_name, key_name, format_string, rich_style]

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1508,8 +1508,8 @@ def synergy_table(stats, syn_loss_diff, sort_col, console_width):
     columns = [uid_col] + [[f'{s[0]}', '', '{:.2f}', ''] for s in sort]
     rows = [[uid_col[2].format(s[0])] +
             [('[bright_cyan]{:.2f}[/bright_cyan]' if t == s else
-              '[magenta]{:.3f}[/magenta]'.lstrip('0') if syn_loss_diff[s[0]][t[0]] > 0 else
-              '[dim]{:.0f}[/dim]').format(syn_loss_diff[s[0]][t[0]]) for t in sort] for s in sort]
+              '[magenta]{:.3f}[/magenta]' if syn_loss_diff[s[0]][t[0]] > 0 else
+              '[dim]{:.0f}[/dim]').format(syn_loss_diff[s[0]][t[0]]).replace('0.', '.') for t in sort] for s in sort]
 
     # === Synergy table ===
     table = Table(width=console_width, box=None)

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -627,11 +627,11 @@ class neuron:
         # === Reset neuron stats if uid got replaced
         for uid, old_hotkey in enumerate(old_hotkeys):
             if old_hotkey != self.neuron_hotkeys[uid]:
+                block = self.subtensor.block
                 self.neuron_register.setdefault(uid, {})  # [uid] -> dict() of blocks
-                self.neuron_register[uid][self.subtensor.block] = {'new_hotkey': self.neuron_hotkeys[uid],
-                                                                   'old_hotkey': old_hotkey}
+                self.neuron_register[uid][block] = {'new_hotkey': self.neuron_hotkeys[uid], 'old_hotkey': old_hotkey}
                 if uid in self.neuron_stats:
-                    self.neuron_register[uid][self.subtensor.block]['old_stats'] = self.neuron_stats[uid]
+                    self.neuron_register[uid][block]['old_stats'] = self.neuron_stats[uid]
                     del self.neuron_stats[uid]
                     changed_hotkeys += [uid]
 

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -622,7 +622,7 @@ class neuron:
         self.neuron_hotkeys = self.metagraph.hotkeys
 
         assert len(old_hotkeys) == len(self.neuron_hotkeys), 'metagraph hotkeys length do not match'
-        assert self.metagraph.S == len(self.neuron_hotkeys), 'metagraph hotkeys do not match metagraph size'
+        assert self.metagraph.n == len(self.neuron_hotkeys), 'metagraph hotkeys do not match metagraph size'
 
         changed_hotkeys = []
         # === Reset neuron stats if uid got replaced

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -235,6 +235,7 @@ class neuron:
         parser.add_argument('--neuron.print_neuron_stats', action='store_true', help='If True, print neuron_stats and exit.', default=False)
         parser.add_argument('--neuron.restart', action='store_true', help='If True, reset neuron_stats and validate anew.', default=False)
         parser.add_argument('--neuron.restart_on_failure',  action='store_true', help='''Restart neuron on unknown error.''', default=True )
+        parser.add_argument('--neuron.metagraph_cached', action='store_true', help='''Use metagraph.sync(cached=True).''', default=False)
         parser.add_argument('--neuron._mock', action='store_true', help='To turn on neuron mocking for testing purposes.', default=False )
         parser.add_argument('--neuron.wait_for_finalization', action='store_true', help='''when setting weights the miner waits for trnasaction finalization.''', default=False)
         parser.add_argument('--neuron.forward_num', type=int, help='''How much forward request before a backward call.''', default=3)
@@ -616,7 +617,7 @@ class neuron:
         r""" Syncing metagraph together with other metagraph-size related objects
         """
         old_hotkeys = self.neuron_hotkeys + [] if self.neuron_hotkeys else self.metagraph.hotkeys
-        self.metagraph.sync(cached=False)
+        self.metagraph.sync(cached=self.config.neuron.metagraph_cached)
         self.neuron_hotkeys = self.metagraph.hotkeys
 
         assert len(old_hotkeys) == len(self.neuron_hotkeys), 'metagraph hotkeys length do not match'

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -617,7 +617,7 @@ class neuron:
         r""" Syncing metagraph together with other metagraph-size related objects
         """
         old_hotkeys = self.neuron_hotkeys + [] if self.neuron_hotkeys else self.metagraph.hotkeys
-        self.metagraph.sync(cached=self.config.neuron.metagraph_cached)
+        self.metagraph.sync(cached=self.config.neuron.metagraph_cached or self.subtensor.network != 'local')
         self.neuron_hotkeys = self.metagraph.hotkeys
 
         assert len(old_hotkeys) == len(self.neuron_hotkeys), 'metagraph hotkeys length do not match'

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -616,7 +616,7 @@ class neuron:
         r""" Syncing metagraph together with other metagraph-size related objects
         """
         old_hotkeys = self.neuron_hotkeys + [] if self.neuron_hotkeys else self.metagraph.hotkeys
-        self.metagraph.sync()
+        self.metagraph.sync(cached=False)
         self.neuron_hotkeys = self.metagraph.hotkeys
 
         assert len(old_hotkeys) == len(self.neuron_hotkeys), 'metagraph hotkeys length do not match'

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -422,8 +422,6 @@ class neuron:
         # This gives us a consistent network wide timer.
         # Here we run until blocks_per_epochs have progressed.
 
-        self.nucleus.permute_uids = []  # clear nucleus permutation before epoch
-
         epoch_steps = 0
         epoch_responsive_uids = set()
         epoch_queried_uids = set()

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -432,16 +432,16 @@ class neuron:
 
         # normal epoch duration is blocks_per_epoch if all UIDs have been queried
         # try to query each UID at least once - assumes nucleus samples without replacement
-        # but keep minimum epoch duration at blocks_per_epoch * 12 sec block_period
+        # but keep minimum epoch duration at blocks_per_epoch * block_period
         # in case of subtensor outage causing invalid block readings to prevent fast repeated weight setting
         start_block = self.subtensor.block
         while (self.subtensor.block < start_block + blocks_per_epoch or
-               time.time() - epoch_start_time < blocks_per_epoch * 12):
+               time.time() - epoch_start_time < blocks_per_epoch * bittensor.__blocktime__):
 
             logger.info(f'Run epoch {self.epoch} (step {epoch_steps}) while '
                         f'({self.subtensor.block} < {start_block + blocks_per_epoch} '
                         f'= {start_block} + {blocks_per_epoch}) or '
-                        f'({time.time() - epoch_start_time:.2f} < {blocks_per_epoch * 12})')
+                        f'({time.time() - epoch_start_time:.2f} < {blocks_per_epoch * bittensor.__blocktime__})')
 
             start_time = time.time()
 
@@ -619,9 +619,6 @@ class neuron:
         old_hotkeys = self.neuron_hotkeys + [] if self.neuron_hotkeys else self.metagraph.hotkeys
         self.metagraph.sync(cached=self.config.neuron.metagraph_cached or self.subtensor.network != 'local')
         self.neuron_hotkeys = self.metagraph.hotkeys
-
-        assert len(old_hotkeys) == len(self.neuron_hotkeys), 'metagraph hotkeys length do not match'
-        assert self.metagraph.n == len(self.neuron_hotkeys), 'metagraph hotkeys do not match metagraph size'
 
         changed_hotkeys = []
         # === Reset neuron stats if uid got replaced

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -418,8 +418,6 @@ class neuron:
         # Each block length lasts blocks_per_epoch blocks.
         # This gives us a consistent network wide timer.
         # Here we run until blocks_per_epochs have progressed.
-        if self.epoch > 0:  # skip first epoch: already synced at start of run
-            self.metagraph_sync()  # Reset metagraph.
 
         self.nucleus.permute_uids = []  # clear nucleus permutation before epoch
 
@@ -551,9 +549,8 @@ class neuron:
                 self.optimizer.step()
                 self.optimizer.zero_grad()
                 logger.info(f'Model update \t| Optimizer step <dim>[{time.time() - start_time:.3g}s]</dim>')
-                
-        # Iterate epochs.
-        self.epoch += 1
+
+        self.metagraph_sync()  # Reset metagraph.
 
         # === Calculate neuron weights ===
         sample_uids, sample_weights = self.calculate_weights()
@@ -605,6 +602,9 @@ class neuron:
         self.prometheus_gauges.labels("incentive").set( self.metagraph.incentive[self.uid] )
         self.prometheus_gauges.labels("dividends").set( self.metagraph.dividends[self.uid] )
         self.prometheus_gauges.labels("emission").set( self.metagraph.emission[self.uid] )
+
+        # Iterate epochs.
+        self.epoch += 1
 
     def metagraph_sync(self):
         r""" Syncing metagraph together with other metagraph-size related objects

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -440,8 +440,9 @@ class neuron:
                time.time() - epoch_start_time < blocks_per_epoch * 12):
 
             logger.info(f'Run epoch {self.epoch} (step {epoch_steps}) while '
-                        f'{self.subtensor.block} < {start_block} + {blocks_per_epoch} or '
-                        f'{time.time() - epoch_start_time} < {blocks_per_epoch * 12}')
+                        f'({self.subtensor.block} < {start_block + blocks_per_epoch} '
+                        f'= {start_block} + {blocks_per_epoch}) or '
+                        f'({time.time() - epoch_start_time:.2f} < {blocks_per_epoch * 12})')
 
             start_time = time.time()
 

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -747,8 +747,7 @@ class neuron:
                     f'sum:{sample_weights.sum().item():.2g} '
                     f'[white] max:[bold]{sample_weights.max().item():.4g}[/bold] / '
                     f'min:[bold]{sample_weights.min().item():.4g}[/bold] [/white] '
-                    f'\[{sample_weights.max().item()}:1] '
-                    f'({max_weight_limit} allowed)',  # caption
+                    f'\[{max_weight_limit:.4g} allowed]',  # caption
                     mark_uids=avail_include_uids)
 
 

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1508,7 +1508,7 @@ def synergy_table(stats, syn_loss_diff, sort_col, console_width):
     columns = [uid_col] + [[f'{s[0]}', '', '{:.2f}', ''] for s in sort]
     rows = [[uid_col[2].format(s[0])] +
             [('[bright_cyan]{:.2f}[/bright_cyan]' if t == s else
-              '[magenta]{:.2f}[/magenta]'.lstrip('0') if syn_loss_diff[s[0]][t[0]] > 0 else
+              '[magenta]{:.3f}[/magenta]'.lstrip('0') if syn_loss_diff[s[0]][t[0]] > 0 else
               '[dim]{:.0f}[/dim]').format(syn_loss_diff[s[0]][t[0]]) for t in sort] for s in sort]
 
     # === Synergy table ===

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -578,8 +578,7 @@ class neuron:
               f'[dim]weights[/dim] sum:{sample_weights.sum().item():.2g} '
               f'[white] max:[bold]{sample_weights.max().item():.4g}[/bold] / '
               f'min:[bold]{sample_weights.min().item():.4g}[/bold] [/white] '
-              f'\[{sample_weights.max().item()}:1] '
-              f'({max_weight_limit} allowed)')
+              f'\[{max_weight_limit:.4g} allowed]')
 
         self.subtensor.set_weights(
             uids=sample_uids.detach().to('cpu'),

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -232,7 +232,6 @@ class neuron:
         parser.add_argument('--neuron.validation_len', type=int, help='Number of tokens to holdout for phrase validation beyond sequence context.', default=8)
         parser.add_argument('--neuron.device', type=str, help='miner default training device cpu/cuda', default=("cuda" if torch.cuda.is_available() else "cpu"))
         parser.add_argument('--neuron.clip_gradients', type=float, help='Implement gradient clipping to avoid exploding loss on smaller architectures.', default=1.0 )
-        parser.add_argument('--neuron.print_neuron_stats', action='store_true', help='If True, print neuron_stats and exit.', default=False)
         parser.add_argument('--neuron.track_hotkey_changes', action='store_true', help='If True, track hotkey changes.', default=False)
         parser.add_argument('--neuron.restart', action='store_true', help='If True, reset neuron_stats and validate anew.', default=False)
         parser.add_argument('--neuron.restart_on_failure',  action='store_true', help='''Restart neuron on unknown error.''', default=True )

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -1428,7 +1428,7 @@ def format_predictions(uids: torch.Tensor, query_responses: List[List[torch.Floa
                     phrase = topk_tokens[i]
                     phrase = phrase[phrase >= 0]  # strip negative ignore_index = -100
                     phrase_str = repr(std_tokenizer.decode(phrase))[:15]  # decode, escape and truncate
-                    prob = f'{topk_probs[i]:.3f}'.lstrip('0')
+                    prob = f'{topk_probs[i]:.3f}'.lstrip('0').replace('1.000', '1.00')
                     topk_predictions += f"[green]{prob}[/green]: {phrase_str} "
 
                 predictions[uid] = topk_predictions[:-1]  # strip trailing space

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -236,7 +236,6 @@ class neuron:
         parser.add_argument('--neuron.track_hotkey_changes', action='store_true', help='If True, track hotkey changes.', default=False)
         parser.add_argument('--neuron.restart', action='store_true', help='If True, reset neuron_stats and validate anew.', default=False)
         parser.add_argument('--neuron.restart_on_failure',  action='store_true', help='''Restart neuron on unknown error.''', default=True )
-        parser.add_argument('--neuron.metagraph_cached', action='store_true', help='''Use metagraph.sync(cached=True).''', default=False)
         parser.add_argument('--neuron._mock', action='store_true', help='To turn on neuron mocking for testing purposes.', default=False )
         parser.add_argument('--neuron.wait_for_finalization', action='store_true', help='''when setting weights the miner waits for trnasaction finalization.''', default=False)
         parser.add_argument('--neuron.forward_num', type=int, help='''How much forward request before a backward call.''', default=3)
@@ -622,7 +621,7 @@ class neuron:
         r""" Syncing metagraph together with other metagraph-size related objects
         """
         old_hotkeys = self.neuron_hotkeys + [] if self.neuron_hotkeys else self.metagraph.hotkeys
-        self.metagraph.sync(cached=self.config.neuron.metagraph_cached or self.subtensor.network != 'local')
+        self.metagraph.sync()
         self.neuron_hotkeys = self.metagraph.hotkeys
 
         changed_hotkeys = []

--- a/bittensor/utils/tokenizer_utils.py
+++ b/bittensor/utils/tokenizer_utils.py
@@ -955,7 +955,7 @@ def phrase_cross_entropy(target_phrases: Union[List[List[int]], torch.Tensor],
     batch_size, topk_p1, max_len = topk_tensor.shape  # [batch_size, (topk + 1), max_len]
     topk = topk_p1 - 1
 
-    topk_tokens = topk_tensor[:, :-1, 1:]  # [batch_size, topk, max_len - 1] Phrase tokens with ignore_index token for padding.
+    topk_tokens = topk_tensor[:, :-1, 1:].int()  # [batch_size, topk, max_len - 1] Phrase tokens with ignore_index token for padding.
     topk_probs = topk_tensor[:, :-1, 0]  # [batch_size, topk] Probabilities for each phrase in topk
     floor_probs = topk_tensor[:, -1, 0]  # [batch_size] Floor probabilities as mean probability for non-topk tokens
 
@@ -973,6 +973,7 @@ def phrase_cross_entropy(target_phrases: Union[List[List[int]], torch.Tensor],
         target_phrase = target_phrases[b]
         if not isinstance(target_phrase, torch.Tensor):
             target_phrase = torch.tensor(target_phrases[b])
+        target_phrase = target_phrase.int()
 
         match = (topk_tokens[b, :, 0] == target_phrase[0].item())  # bool where first tokens match (validation token)
         if match.sum() > 0:

--- a/bittensor/utils/tokenizer_utils.py
+++ b/bittensor/utils/tokenizer_utils.py
@@ -955,7 +955,7 @@ def phrase_cross_entropy(target_phrases: Union[List[List[int]], torch.Tensor],
     batch_size, topk_p1, max_len = topk_tensor.shape  # [batch_size, (topk + 1), max_len]
     topk = topk_p1 - 1
 
-    topk_tokens = topk_tensor[:, :-1, 1:].int()  # [batch_size, topk, max_len - 1] Phrase tokens with ignore_index token for padding.
+    topk_tokens = topk_tensor[:, :-1, 1:].round().int()  # [batch_size, topk, max_len - 1] Phrase tokens with ignore_index token for padding.
     topk_probs = topk_tensor[:, :-1, 0]  # [batch_size, topk] Probabilities for each phrase in topk
     floor_probs = topk_tensor[:, -1, 0]  # [batch_size] Floor probabilities as mean probability for non-topk tokens
 
@@ -973,7 +973,8 @@ def phrase_cross_entropy(target_phrases: Union[List[List[int]], torch.Tensor],
         target_phrase = target_phrases[b]
         if not isinstance(target_phrase, torch.Tensor):
             target_phrase = torch.tensor(target_phrases[b])
-        target_phrase = target_phrase.int()
+        if isinstance(target_phrase, torch.FloatTensor):
+            target_phrase = target_phrase.round().int()
 
         match = (topk_tokens[b, :, 0] == target_phrase[0].item())  # bool where first tokens match (validation token)
         if match.sum() > 0:


### PR DESCRIPTION
### [BIT-599] Validator weight setting improvements
---
### Remove responsive prioritization from validator weight calculation
Weight setting limitation based on responsive prioritization is no longer needed, so has been removed. Part of the original intent of the limitation was a chain storage concern of setting too many weights, but since the network has gained very high > 90% response rate the concern is moot.

The downside of applying the limitation is that validators with longer step size artificially set fewer weights simply because they could not query the network in a single epoch. This introduced a counterproductive weight setting variability across validators.

Responsiveness is scored in any case via a Shapley EMA zero-push penalty, so setting weights on non-responsive nodes still relay an accurate scoring.

---
### Move metagraph_sync just before weight setting
The metagraph is one epoch (~250 blocks) outdated by the time weight setting is done. This means that newly registered keys will have weights set based on the stats of the key just previously registered on the same UID.

Weights will now be set more accurately when the metagraph is updated just before weight setting, which will reset stats of a UID that has changed ownership.

---
### Add metagraph registration tracker to validator
Tracks new hotkey registrations on UIDs, and records statistics of previous hotkey.

[BIT-599]: https://opentensor.atlassian.net/browse/BIT-599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ