### PR TITLE
Preview the inference data and save each response to a file.

### DIFF
--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -205,6 +205,15 @@ class server(torch.nn.Module):
             std_tokenizer = self.std_tokenizer
 
         text_batch = std_tokenizer.batch_decode(token_batch)  # decode tokens to original text
+
+        # displaying a preview of the inference data
+        print(('Inference Data: ' + str(text_batch)[2:65]) + '......' + (str(text_batch)[-65:-2]))
+        # saving the inference data to a file (inference_data.txt in core_server/)
+        f = open('inference_data.txt', 'a')
+        f.write(str(text_batch)[2:-2])
+        f.write('\n')
+        f.close()
+
         result = translate_special_token_text(text_batch, std_tokenizer, self.tokenizer)  # translate special tokens
         to_text_batch, from_offsets_batch, to_offsets_batch, pad_offsets_batch = result
 

--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -208,8 +208,8 @@ class server(torch.nn.Module):
 
         # displaying a preview of the inference data
         print(('Inference Data: ' + str(text_batch)[2:65]) + '......' + (str(text_batch)[-65:-2]))
-        # saving the inference data to a file (inference_data.txt in core_server/)
-        f = open('inference_data.txt', 'a')
+        # saving the last inference data query to a file (inference_data_last.txt in core_server/)
+        f = open('inference_data_last.txt', 'w')
         f.write(str(text_batch)[2:-2])
         f.write('\n')
         f.close()


### PR DESCRIPTION
Displays the first and last 65 characters of the original text from requests sent to servers from validators, `text_batch`, and saves the entire last request in original text to a file, `inference_data_last.txt`, in the `core_server/` directory.

The `stdout` for the core server's `run.py` will now include this data after picking up a request from the validator and before the forward pass, resulting in the following logs from `pm2`:
![image](https://user-images.githubusercontent.com/108015817/207403648-2ccafea1-914e-4df2-a6cb-1db0c0906688.png)
