### PR TITLE
[hotfix] pin scalecodec lower

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ pyyaml
 rich>=12.5.1
 retry
 requests>=2.25.0
-scalecodec>=1.0.35
+scalecodec>=1.0.35,<1.1.0
 sentencepiece
 termcolor
 torch>=1.11


### PR DESCRIPTION
This PR is a re-open of #1012 that is checked-out from v3.5.0 