### PR TITLE
Fixes issue with --neuron.no_set_weights

### DIFF
--- a/bittensor/_neuron/text/core_server/run.py
+++ b/bittensor/_neuron/text/core_server/run.py
@@ -457,10 +457,10 @@ def serve(
         if current_block - last_set_block > blocks_per_set_weights:
             bittensor.__console__.print('[green]Current Status:[/green]', {**wandb_data, **local_data})
             metagraph.sync()
+            last_set_block = current_block
             if not config.neuron.no_set_weights:
                 try: 
                     bittensor.__console__.print('[green]Current Status:[/green]', {**wandb_data, **local_data})
-                    last_set_block = current_block
                     # Set self weights to maintain activity.
                     # --- query the chain for the most current number of peers on the network
                     chain_weights = torch.zeros(subtensor.n)


### PR DESCRIPTION
This PR addresses #1019   

Currently, the metagraph sync is executed every time the if-statement on line 457 evaluates as true.   
` if current_block - last_set_block > blocks_per_set_weights:`  
However, `last_set_block` is never updated when `config.neuron.no_set_weights` is true.  
This PR moves `last_set_block = current_block` outside the check for `no_set_weights`, fixing the bug