### PR TITLE
fix btcli list with wallet.path

### DIFF
--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -477,7 +477,7 @@ class CLI:
                 coldkeypub_str = '?'
 
             wallet_tree = root.add("\n[bold white]{} ({})".format(w_name, coldkeypub_str))
-            hotkeys_path = self.config.wallet.path + w_name + '/hotkeys'
+            hotkeys_path = os.path.join(self.config.wallet.path, w_name, 'hotkeys')
             try:
                 hotkeys = next(os.walk(os.path.expanduser(hotkeys_path)))
                 if len( hotkeys ) > 1:


### PR DESCRIPTION
This PR fixes a bug with `btcli list` when `wallet.path` ends in a '/'  
The expected behaviour is that the output is the same as when `wallet.path` does not end in `/`  
This is fixed by using `os.path.join` instead of a manual joining.   

See:
<img width="662" alt="Screenshot 2023-01-02 at 11 59 45 AM" src="https://user-images.githubusercontent.com/24501463/210260724-59caca0d-de2f-4664-81d6-e5a996ee9e56.png">
