### PR TITLE
Bit 614 gptneox compatibility check

### DIFF
--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -476,7 +476,7 @@ class server(torch.nn.Module):
         """
         if hasattr(model_output, 'hidden_states') and model_output.hidden_states[-1].isnan().sum() > 0:
             raise ValueError("Got nan value from model last hidden state. If you are using cuda, try setting --neuron.autocast to False.")
-        
+
         if model_output.logits.isnan().sum() > 0:
             raise ValueError("Got nan value from model logit. If you are using cuda, try setting --neuron.autocast to False.")
 

--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -555,7 +555,7 @@ class server(torch.nn.Module):
         parser.add_argument('--neuron.padding', action='store_false', help='To pad out final dimensions',default=True)
         parser.add_argument('--neuron.interpolate', action='store_false', help='To interpolate between sentence length',default=True)
         parser.add_argument('--neuron.inter_degree', type=str, help='Interpolate algorithm (nearest | linear | bilinear | bicubic | trilinear | area)', default='nearest')
-        parser.add_argument('--neuron.autocast',  type=bool, help='(experimental) autocasts the model to float16. Must require cuda', default=False)
+        parser.add_argument('--neuron.autocast',  action='store_true', help='(experimental) autocasts the model to float16. Must require cuda', default=False)
         parser.add_argument('--neuron.local_train', action='store_true', help='''If true, allow local training''', default=False)
         parser.add_argument('--neuron.remote_train', action='store_true', help='''If true, allow remote training''', default=False)
         parser.add_argument('--neuron.finetune.all', action='store_true', help='Finetune your whole model instead of only on the last (few) layers', default=False)

--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -478,7 +478,7 @@ class server(torch.nn.Module):
             raise ValueError("Got nan value from model last hidden state. If you are using cuda, try setting --neuron.autocast to False.")
         
         if model_output.logits.isnan().sum() > 0:
-            raise ValueError("Got nan value from model logit. If you are using cuda, try setting --neuron.autocast to False.")
+            raise ValueError("Got nan value from model logits. If you are using cuda, try setting --neuron.autocast to False.")
 
         return True
 

--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -475,10 +475,10 @@ class server(torch.nn.Module):
                     True if the model_output is valid.
         """
         if hasattr(model_output, 'hidden_states') and model_output.hidden_states[-1].isnan().sum() > 0:
-            raise ValueError("Got nan value from model last hidden state. If you are using cuda, try setting --neuron.autocast to False.")
+            raise ValueError("Got nan value from model last hidden state. If you are using cuda with autocast, try remove setting --neuron.autocast.")
 
         if model_output.logits.isnan().sum() > 0:
-            raise ValueError("Got nan value from model logits. If you are using cuda, try setting --neuron.autocast to False.")
+            raise ValueError("Got nan value from model logits. If you are using cuda with autocast, try remove setting --neuron.autocast.")
 
         return True
 

--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -462,7 +462,7 @@ class server(torch.nn.Module):
         with torch.no_grad():
             return _forward()  # no gradients
 
-    def model_output_check(model_output: transformers.modeling_outputs.CausalLMOutputWithPast):
+    def model_output_check(self, model_output: transformers.modeling_outputs.CausalLMOutputWithPast):
         """
             Verify the model has been ran correctly with valid output.
 

--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -278,6 +278,7 @@ class server(torch.nn.Module):
                                                     attention_mask=tokens['attention_mask'],
                                                     output_hidden_states=True)
 
+            self.model_output_check(model_output)
         return None, model_output, model_output.logits
     
     def encode_forward(self,inputs,tokenizer=None, model_output = None):
@@ -316,6 +317,7 @@ class server(torch.nn.Module):
                                                     attention_mask=tokens['attention_mask'],
                                                     output_hidden_states=True)
 
+        self.model_output_check(model_output)
         pre_hidden = model_output.hidden_states[-1]
 
         if self.interpolate and sen_len[1] != pre_hidden.size()[1]:
@@ -367,6 +369,7 @@ class server(torch.nn.Module):
                 _model_output = self.pre_model(input_ids=tokens['input_ids'],
                                                 #attention_mask=tokens['attention_mask'],
                                                output_hidden_states=True)
+                self.model_output_check(_model_output)
             pre_logits = _model_output.logits  # [batch_size, sequence_len, self.tokenizer.vocab_len]
 
             probs_std = translate_logits_to_probs_std(pre_logits,
@@ -439,7 +442,7 @@ class server(torch.nn.Module):
                 _model_output = self.pre_model(input_ids=tokens['input_ids'],
                                                attention_mask=tokens['attention_mask'],
                                                output_hidden_states=True)
-
+                self.model_output_check(_model_output)
             # model_output.logits: [batch_size, sequence_len, server_vocab_size]
             last_logits = _model_output.logits[:, -1, :]  # [batch_size] server prediction of continuation, right-aligned
 
@@ -458,6 +461,26 @@ class server(torch.nn.Module):
 
         with torch.no_grad():
             return _forward()  # no gradients
+
+    def model_output_check(model_output: transformers.modeling_outputs.CausalLMOutputWithPast):
+        """
+            Verify the model has been ran correctly with valid output.
+
+            Args:
+                model_output (:obj:`transformers.modeling_outputs.CausalLMOutputWithPast`, required):
+                    The output of transformers AutoModel.
+
+            Returns:
+                check_status (:type: `bool`):
+                    True if the model_output is valid.
+        """
+        if hasattr(model_output, 'hidden_states') and model_output.hidden_states[-1].isnan().sum() > 0:
+            raise ValueError("Got nan value from model last hidden state. If you are using cuda, try setting --neuron.autocast to False.")
+        
+        if model_output.logits.isnan().sum() > 0:
+            raise ValueError("Got nan value from model logit. If you are using cuda, try setting --neuron.autocast to False.")
+
+        return True
 
     def get_loss_fct(self, logits: torch.FloatTensor, labels: torch.LongTensor) -> torch.FloatTensor:
         """

--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -555,7 +555,7 @@ class server(torch.nn.Module):
         parser.add_argument('--neuron.padding', action='store_false', help='To pad out final dimensions',default=True)
         parser.add_argument('--neuron.interpolate', action='store_false', help='To interpolate between sentence length',default=True)
         parser.add_argument('--neuron.inter_degree', type=str, help='Interpolate algorithm (nearest | linear | bilinear | bicubic | trilinear | area)', default='nearest')
-        parser.add_argument('--neuron.autocast',  action='store_true', help='(experimental) autocasts the model to float16. Must require cuda', default=False)
+        parser.add_argument('--neuron.autocast',  type=bool, help='(experimental) autocasts the model to float16. Must require cuda', default=False)
         parser.add_argument('--neuron.local_train', action='store_true', help='''If true, allow local training''', default=False)
         parser.add_argument('--neuron.remote_train', action='store_true', help='''If true, allow remote training''', default=False)
         parser.add_argument('--neuron.finetune.all', action='store_true', help='Finetune your whole model instead of only on the last (few) layers', default=False)

--- a/tests/unit_tests/bittensor_tests/test_neuron.py
+++ b/tests/unit_tests/bittensor_tests/test_neuron.py
@@ -64,6 +64,23 @@ def test_set_fine_tuning_params():
     core_server.config.neuron.finetune.layer_name = None
     assert core_server.set_fine_tuning_params() == (False, None) 
 
+def test_model_output_check():
+    core_server = bittensor._neuron.text.core_server.server(pretrained=False)
+
+    class model_output():
+        def __init__(self, faulty = True):
+            if faulty: 
+                self.hidden_states = [torch.tensor([torch.nan, 2, 3])]
+                self.logits = torch.tensor([torch.nan, 2, 3])
+            else:
+                self.hidden_states = [torch.tensor([1, 2, 3])]
+                self.logits = torch.tensor([1, 2, 3])
+
+    with pytest.raises(ValueError):
+        core_server.model_output_check(model_output())
+
+    assert core_server.model_output_check(model_output(faulty = False))
+
 def test_coreserver_reregister_flag_false_exit():
     config = bittensor.Config()
     config.wallet = bittensor.Config()


### PR DESCRIPTION
Some models (eg. gptneox / pythia / finetuned opt) are not compatible with half precision, and outputing hidden state / logits with nan causing the error message mentioned [here](https://discord.com/channels/799672011265015819/801875196801450045/1059181423388524664)
Which is not an internal bug.


Updated warning message to suggest users to turn off `--neuron.autocast` in case of using half precision  non compatible models
![image](https://user-images.githubusercontent.com/49876827/210612732-64bec1c3-02f1-436f-85f3-2a11f1b1e692.png)
