### PR TITLE
Bit 617 dataset excessive data fix

### DIFF
--- a/bittensor/_dataset/__init__.py
+++ b/bittensor/_dataset/__init__.py
@@ -94,7 +94,6 @@ class dataset:
                 max_datasets = config.dataset.max_datasets,
                 no_tokenizer = config.dataset.no_tokenizer,
                 num_batches = config.dataset.num_batches,
-                max_directories = config.dataset.max_directories
             )
         else:
             return dataset_impl.GenesisTextDataset(
@@ -107,7 +106,6 @@ class dataset:
                 max_datasets = config.dataset.max_datasets,
                 no_tokenizer = config.dataset.no_tokenizer,
                 num_batches = config.dataset.num_batches,
-                max_directories = config.dataset.max_directories
             )
 
     @classmethod
@@ -140,7 +138,6 @@ class dataset:
             parser.add_argument('--' + prefix_str + 'dataset.no_tokenizer', action='store_true', help='To return non-tokenized text (EXPERIMENTAL, DO NOT USE)',default=False)
             parser.add_argument('--' + prefix_str + 'dataset.num_batches', type=int, help='The number of data to download each time(measured by the number of batches).', default=bittensor.defaults.dataset.num_batches)
             parser.add_argument('--' + prefix_str + 'dataset._mock', action='store_true', help='To turn on dataset mocking for testing purposes.', default=False)
-            parser.add_argument('--' + prefix_str + 'dataset.max_directories', type=int, help='Maximum number of directories to consider when loading text from IPFS', default=bittensor.defaults.dataset.max_directories)
 
         except argparse.ArgumentError:
             # re-parsing arguments.
@@ -168,7 +165,6 @@ class dataset:
         defaults.dataset.save_dataset = os.getenv('BT_DATASET_SAVE_DATASET') if os.getenv('BT_DATASET_SAVE_DATASET') != None else False
         defaults.dataset.max_datasets = os.getenv('BT_DATASET_MAX_DATASETS') if os.getenv('BT_DATASET_MAX_DATASETS') != None else 3
         defaults.dataset.num_batches = os.getenv('BT_DATASET_NUM_BATCHES') if os.getenv('BT_DATASET_NUM_BATCHES') != None else 500
-        defaults.dataset.max_directories = os.getenv('BT_DATASET_MAX_DIRECTORIES') if os.getenv('BT_DATASET_MAX_DIRECTORIES') != None else 250
 
     @classmethod
     def check_config( cls, config: 'bittensor.Config' ):

--- a/bittensor/_dataset/__init__.py
+++ b/bittensor/_dataset/__init__.py
@@ -164,7 +164,7 @@ class dataset:
         defaults.dataset.data_dir = os.getenv('BT_DATASET_DATADIR') if os.getenv('BT_DATASET_DATADIR') != None else '~/.bittensor/data/'
         defaults.dataset.save_dataset = os.getenv('BT_DATASET_SAVE_DATASET') if os.getenv('BT_DATASET_SAVE_DATASET') != None else False
         defaults.dataset.max_datasets = os.getenv('BT_DATASET_MAX_DATASETS') if os.getenv('BT_DATASET_MAX_DATASETS') != None else 3
-        defaults.dataset.num_batches = os.getenv('BT_DATASET_NUM_BATCHES') if os.getenv('BT_DATASET_NUM_BATCHES') != None else 500
+        defaults.dataset.num_batches = os.getenv('BT_DATASET_NUM_BATCHES') if os.getenv('BT_DATASET_NUM_BATCHES') != None else 100
 
     @classmethod
     def check_config( cls, config: 'bittensor.Config' ):

--- a/bittensor/_dataset/dataset_impl.py
+++ b/bittensor/_dataset/dataset_impl.py
@@ -490,7 +490,7 @@ class GenesisTextDataset( Dataset ):
                                 data_corpus.extend(text_list)
                                 total_dataset_len += len(text_list)
                         
-                        logger.success(f"Loaded from IPFS { round(total_dataset_len / min_data_len * 100) }%".ljust(20) + "<blue>{}</blue>".format([file_meta['Name'] for file_meta in directories[:n_workers]]))
+                        logger.success("Loaded from IPFS".ljust(20) + f"<yellow>{ round(total_dataset_len / min_data_len * 100) }%</yellow>  " + "<blue>{}</blue>".format([file_meta['Name'] for file_meta in directories[:n_workers]]))
                         directories = directories[n_workers:]
 
             else:

--- a/bittensor/_dataset/dataset_impl.py
+++ b/bittensor/_dataset/dataset_impl.py
@@ -106,7 +106,6 @@ class Dataset:
                 response = self.requests_retry_session(session=session).get(address, timeout=timeout)
             elif action == 'post':
                 response = self.requests_retry_session(session=session).post(address, timeout=timeout)
-            logger.success("Loaded from IPFS:".ljust(20) + "<blue>{}</blue>".format(file_meta['Name']))
 
         except Exception as E:
             logger.error(f"Failed to get from IPFS {file_meta['Name']} {E}")
@@ -136,7 +135,6 @@ class GenesisTextDataset( Dataset ):
         max_datasets,
         no_tokenizer, 
         num_batches,
-        max_directories
     ):
         super().__init__()
         self.block_size = block_size
@@ -154,7 +152,6 @@ class GenesisTextDataset( Dataset ):
         self.backup_dataset_cap_size = 5e7 # set 50MB limit per folder
         self.IPFS_fails_max = 10
         self.num_batches = num_batches
-        self.max_directories = max_directories
 
         # Retrieve a random slice of the genesis dataset
         self.data = []
@@ -485,14 +482,16 @@ class GenesisTextDataset( Dataset ):
                         for idx, call_arg in enumerate(directories[:n_workers]):
                             future = executor.submit(self.get_text, call_arg)
                             future_map[future] = call_arg
-
+                        
                         for i, future in enumerate(concurrent.futures.as_completed(future_map)):
                             text = future.result()
-
                             if text is not None:
                                 text_list = text.split()
                                 data_corpus.extend(text_list)
                                 total_dataset_len += len(text_list)
+                        
+                        logger.success(f"Loaded from IPFS { round(total_dataset_len / min_data_len * 100) }%".ljust(20) + "<blue>{}</blue>".format([file_meta['Name'] for file_meta in directories[:n_workers]]))
+                        directories = directories[n_workers:]
 
             else:
                 logger.error("It appears the directory is empty... Restart your miner to try again.")

--- a/bittensor/_dataset/dataset_mock.py
+++ b/bittensor/_dataset/dataset_mock.py
@@ -39,7 +39,6 @@ class MockGenesisTextDataset( dataset_impl.Dataset ):
         max_datasets,
         no_tokenizer,
         num_batches,
-        max_directories
     ):
         super().__init__()
         self.block_size = block_size
@@ -53,7 +52,6 @@ class MockGenesisTextDataset( dataset_impl.Dataset ):
         self.max_datasets = max_datasets
         self.__infinite_dataset_iterator = None
         self.no_tokenizer = no_tokenizer
-        self.max_directories = max_directories
 
         # Retrieve a random slice of the genesis dataset
         self.data = []

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -169,7 +169,7 @@ class neuron:
         self.device = torch.device ( device = self.config.neuron.device )    
         self.nucleus = nucleus ( config = self.config, device = self.device, subtensor = self.subtensor ).to( self.device )
         self.dataset = (bittensor.dataset(config=self.config, batch_size=self.subtensor.validator_batch_size,
-                                          block_size=self.subtensor.validator_sequence_length + self.config.neuron.validation_len)
+                                          block_size=self.subtensor.validator_sequence_length + self.config.neuron.validation_len + self.config.neuron.prune_len)
                         if dataset is None else dataset)
         self.optimizer = torch.optim.SGD(
             self.nucleus.parameters(), lr=self.config.neuron.learning_rate, momentum=self.config.neuron.momentum


### PR DESCRIPTION
- validator has been pulling excessive data in multiple ways, namely always pulling 250 directories where most of the times it should only need <100. 
- default num_batches was unnecessarily high, reduced from 500 -> 100, approximately needing to pull data every 2.5hrs -> 30 mins. 
- removed redundant lines of "Loading from IPFS" into sth like... 
![image](https://user-images.githubusercontent.com/49876827/211058414-b160e9c5-2454-48f3-906a-8eba1f04bd39.png)
- removed max_directories parameter.

  