### PR TITLE
[GH-1052] - Fix prompts when default same as flag

### DIFF
--- a/bittensor/_cli/commands/delegates.py
+++ b/bittensor/_cli/commands/delegates.py
@@ -101,10 +101,10 @@ class DelegateStakeCommand:
 
     @staticmethod   
     def check_config( config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -163,7 +163,7 @@ class ListDelegatesCommand:
 
     @staticmethod   
     def check_config( config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
 
@@ -215,14 +215,14 @@ class NominateCommand:
 
     @staticmethod   
     def check_config( config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt and not config.wallet.get('all_hotkeys') and not config.wallet.get('hotkeys'):
+        if not config.is_set('wallet.hotkey') and not config.no_prompt and not config.wallet.get('all_hotkeys') and not config.wallet.get('hotkeys'):
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 

--- a/bittensor/_cli/commands/inspect.py
+++ b/bittensor/_cli/commands/inspect.py
@@ -131,16 +131,16 @@ class InspectCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         check_netuid_set( config, subtensor = bittensor.subtensor( config = config ),allow_none = True )
 
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if not config.is_set('wallet.hotkey') and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name (optional)", default = None)
             config.wallet.hotkey = hotkey
 

--- a/bittensor/_cli/commands/metagraph.py
+++ b/bittensor/_cli/commands/metagraph.py
@@ -100,7 +100,7 @@ class MetagraphCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
         check_netuid_set( config, subtensor = bittensor.subtensor( config = config ) )
 

--- a/bittensor/_cli/commands/misc.py
+++ b/bittensor/_cli/commands/misc.py
@@ -136,7 +136,7 @@ class ListSubnetsCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
     @staticmethod

--- a/bittensor/_cli/commands/overview.py
+++ b/bittensor/_cli/commands/overview.py
@@ -287,10 +287,10 @@ class OverviewCommand:
 
     @staticmethod   
     def check_config( config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt and not config.all:
+        if not config.is_set('wallet.name') and not config.no_prompt and not config.all:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 

--- a/bittensor/_cli/commands/query.py
+++ b/bittensor/_cli/commands/query.py
@@ -45,11 +45,11 @@ class QueryCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if not config.is_set('wallet.hotkey') and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
                   

--- a/bittensor/_cli/commands/register.py
+++ b/bittensor/_cli/commands/register.py
@@ -81,16 +81,16 @@ class RegisterCommand:
 
     @staticmethod   
     def check_config( config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         check_netuid_set( config, subtensor = bittensor.subtensor( config = config ) )
 
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if not config.is_set('wallet.hotkey') and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 

--- a/bittensor/_cli/commands/run.py
+++ b/bittensor/_cli/commands/run.py
@@ -84,17 +84,17 @@ class RunCommand:
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
         # Check network.
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
         
         check_netuid_set( config, subtensor = bittensor.subtensor( config = config ) )
 
-        if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
         # Check hotkey.
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if not config.is_set('wallet.hotkey') and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 

--- a/bittensor/_cli/commands/stake.py
+++ b/bittensor/_cli/commands/stake.py
@@ -122,14 +122,14 @@ class StakeCommand:
 
     @classmethod   
     def check_config( cls, config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt and not config.wallet.get('all_hotkeys') and not config.wallet.get('hotkeys'):
+        if not config.is_set('wallet.hotkey') and not config.no_prompt and not config.wallet.get('all_hotkeys') and not config.wallet.get('hotkeys'):
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
                     

--- a/bittensor/_cli/commands/transfer.py
+++ b/bittensor/_cli/commands/transfer.py
@@ -33,10 +33,10 @@ class TransferCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 

--- a/bittensor/_cli/commands/unstake.py
+++ b/bittensor/_cli/commands/unstake.py
@@ -28,14 +28,14 @@ class UnStakeCommand:
 
     @classmethod   
     def check_config( cls, config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
         
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt and not config.wallet.get('all_hotkeys') and not config.wallet.get('hotkeys'):
+        if not config.is_set('wallet.hotkey') and not config.no_prompt and not config.wallet.get('all_hotkeys') and not config.wallet.get('hotkeys'):
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
                     

--- a/bittensor/_cli/commands/wallets.py
+++ b/bittensor/_cli/commands/wallets.py
@@ -28,7 +28,7 @@ class RegenColdkeyCommand:
    
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
         if config.mnemonic == None and config.seed == None:
@@ -94,7 +94,7 @@ class RegenColdkeypubCommand:
     
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
         if config.ss58_address == None and config.public_key_hex == None:
@@ -156,11 +156,11 @@ class RegenHotkeyCommand:
     
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if not config.is_set('wallet.hotkey') and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
         
@@ -230,11 +230,11 @@ class NewHotkeyCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if not config.is_set('wallet.hotkey') and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 
@@ -285,7 +285,7 @@ class NewColdkeyCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 

--- a/bittensor/_cli/commands/weights.py
+++ b/bittensor/_cli/commands/weights.py
@@ -63,12 +63,12 @@ class WeightsCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         check_netuid_set( config, subtensor = bittensor.subtensor( config = config ) )
 
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             if not Confirm.ask("Show all weights?"):
                 wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
                 config.wallet.name = str(wallet_name)
@@ -126,16 +126,16 @@ class SetWeightsCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         check_netuid_set( config, subtensor = bittensor.subtensor( config = config ) )
 
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if not config.is_set('wallet.hotkey') and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 

--- a/bittensor/_config/__init__.py
+++ b/bittensor/_config/__init__.py
@@ -22,11 +22,12 @@ Create and init the config class, which manages the config of different bittenso
 import os
 import sys
 from argparse import ArgumentParser, Namespace
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 import bittensor
 import yaml
 from loguru import logger
+import pandas as pd
 
 from . import config_impl
 
@@ -115,7 +116,45 @@ class config:
             if len(keys) == 1:
                 head[keys[0]] = arg_val
 
+        # Get defaults for this config
+        is_set_map = cls.__fill_is_set_list__(_config, bittensor.defaults)
+
+        _config['__is_set'] = is_set_map
+
+        _config.__fill_with_defaults__(is_set_map, bittensor.defaults)
+
         return _config
+
+    @staticmethod
+    def __fill_is_set_list__(_config: 'bittensor.Config', defaults: 'bittensor.Config') -> Dict[str, bool]:
+        """Creates an is_set map
+        Args:
+            _config (bittensor.Config):
+                Config to generate is_set mapping.
+            defaults (bittensor.Config):
+                The bittensor defaults
+        Returns:
+            is_set_map (Dict[str, bool]):
+                A map from flattened param name to whether this param was set in a flag.
+        """
+        is_set_map = {}
+        config_d = _config.__dict__
+        # Only defaults we are concerned with
+        defaults_filtered = {}
+        for key in config_d.keys():
+            if key in defaults.keys():
+                defaults_filtered[key] = getattr(defaults, key)
+
+        flat_config = pd.json_normalize(config_d, sep='.').to_dict('records')[0]
+        flat_defaults = pd.json_normalize(defaults_filtered, sep='.').to_dict('records')[0]
+        for key, _ in flat_defaults.items():
+            if key in flat_config:
+                is_set_map[key] = True
+            else:
+                is_set_map[key] = False
+        
+        return is_set_map
+
 
     @staticmethod
     def __parse_args__( args: List[str], parser: ArgumentParser = None, strict: bool = False) -> Namespace:
@@ -151,4 +190,3 @@ class config:
         bittensor.dataset.add_args( parser )
         bittensor.prometheus.add_args( parser )
         return bittensor.config( parser )
-

--- a/bittensor/_config/config_impl.py
+++ b/bittensor/_config/config_impl.py
@@ -64,7 +64,8 @@ class Config ( Munch ):
             prometheus_info = Info('config', 'Config Values')
             # Make copy, remove __is_set map
             config_copy = copy.deepcopy(self)
-            del config_copy.__is_set
+
+            del config_copy['__is_set']
 
             config_info = json_normalize(json.loads(json.dumps(config_copy)), sep='.').to_dict(orient='records')[0]
             formatted_info = {}

--- a/bittensor/_config/config_impl.py
+++ b/bittensor/_config/config_impl.py
@@ -23,13 +23,17 @@ import yaml
 import json
 from munch import Munch
 from prometheus_client import Info
-from pandas.io.json import json_normalize
+from pandas import json_normalize
+from typing import Dict
+import copy
 import bittensor
 
 class Config ( Munch ):
     """
     Implementation of the config class, which manages the config of different bittensor modules.
     """
+    __is_set: Dict[str, bool]
+
     def __init__(self, loaded_config = None ):
         super().__init__()
         if loaded_config:
@@ -58,7 +62,11 @@ class Config ( Munch ):
         """
         try:
             prometheus_info = Info('config', 'Config Values')
-            config_info = json_normalize(json.loads(json.dumps(self)), sep='.').to_dict(orient='records')[0]
+            # Make copy, remove __is_set map
+            config_copy = copy.deepcopy(self)
+            del config_copy.__is_set
+
+            config_info = json_normalize(json.loads(json.dumps(config_copy)), sep='.').to_dict(orient='records')[0]
             formatted_info = {}
             for key in config_info:
                 config_info[key] = str(config_info[key])
@@ -68,6 +76,38 @@ class Config ( Munch ):
             # The user called this function twice in the same session.
             # TODO(const): need a way of distinguishing the various config items.
             bittensor.__console__.print("The config has already been added to prometheus.", highlight=True)
+
+    def is_set(self, param_name: str) -> bool:
+        """
+        Returns a boolean indicating whether the parameter has been set or is still the default.
+        """
+        if param_name not in self.get('__is_set'):
+            return False
+        else:
+            return self.get('__is_set')[param_name]
+
+    def __fill_with_defaults__(self, is_set_map: Dict[str, bool], defaults: 'Config') -> None:
+        """
+        Recursively fills the config with the default values using is_set_map
+        """
+        defaults_filtered = {}
+        for key in self.keys():
+            if key in defaults.keys():
+                defaults_filtered[key] = getattr(defaults, key)
+
+        flat_defaults = json_normalize(defaults_filtered, sep='.').to_dict('records')[0]
+        for key, val in flat_defaults.items():
+            if key not in is_set_map:
+                continue
+            elif not is_set_map[key]:
+                # If the key is not set, set it to the default value
+                # Loop through flattened key to get leaf
+                a = self
+                keys = key.split('.')
+                for key_ in keys[:-1]:
+                    a = a[key_]
+                # Set leaf to default value
+                a[keys[-1]] = val
 
     def to_defaults(self):
         try: 

--- a/bittensor/_subtensor/__init__.py
+++ b/bittensor/_subtensor/__init__.py
@@ -140,7 +140,7 @@ class subtensor:
     def add_args(cls, parser: argparse.ArgumentParser, prefix: str = None ):
         prefix_str = '' if prefix == None else prefix + '.'
         try:
-            parser.add_argument('--' + prefix_str + 'subtensor.network', default = bittensor.defaults.subtensor.network, type=str,
+            parser.add_argument('--' + prefix_str + 'subtensor.network', default = argparse.SUPPRESS, type=str,
                                 help='''The subtensor network flag. The likely choices are:
                                         -- finney (staging network)
                                         -- nakamoto (master network)

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -109,8 +109,8 @@ class wallet:
         """
         prefix_str = '' if prefix == None else prefix + '.'
         try:
-            parser.add_argument('--' + prefix_str + 'wallet.name', required=False, default=bittensor.defaults.wallet.name, help='''The name of the wallet to unlock for running bittensor (name mock is reserved for mocking this wallet)''')
-            parser.add_argument('--' + prefix_str + 'wallet.hotkey', required=False, default=bittensor.defaults.wallet.hotkey, help='''The name of wallet's hotkey.''')
+            parser.add_argument('--' + prefix_str + 'wallet.name', required=False, default=argparse.SUPPRESS, help='''The name of the wallet to unlock for running bittensor (name mock is reserved for mocking this wallet)''')
+            parser.add_argument('--' + prefix_str + 'wallet.hotkey', required=False, default=argparse.SUPPRESS, help='''The name of wallet's hotkey.''')
             parser.add_argument('--' + prefix_str + 'wallet.path', required=False, default=bittensor.defaults.wallet.path, help='''The path to your bittensor wallets''')
             parser.add_argument('--' + prefix_str + 'wallet._mock', action='store_true', default=bittensor.defaults.wallet._mock, help='To turn on wallet mocking for testing purposes.')
             


### PR DESCRIPTION
This PR adds a map `Config.__is_set` to the `Config` class.  
This map is from the flattened parameter name (e.g. `config.subtensor.network` -> `config.__is_set["subtensor.network"]`) to a boolean value indicating if the value has been set in a flag (or not).  

This map is created from the defaults set in `bittensor.defaults` on creation of the config, from the parser. Any args that use `default=argparse.SUPPRESS` will be set to `False` in the map unless they are set as a flag. 

Then, the config will be filled with the default values for these flags, avoiding a breaking change to the config class.  

You can then check if any of these args are set using `config.is_set('subtensor.network')`.  

The result, is we don't require prompting the user for values that are set, even if the arg is equal to the default. i.e. `btcli --subtensor.network finney` will not prompt for network again. 

Closes #1052 