### PR TITLE
Fix/neuron netuid arg

### DIFF
--- a/bittensor/_neuron/text/core_server/__init__.py
+++ b/bittensor/_neuron/text/core_server/__init__.py
@@ -100,11 +100,7 @@ class neuron:
         config.neuron.causallm = causallm if causallm != None else config.neuron.causallm
         config.neuron.causallmnext = causallmnext if causallmnext is not None else config.neuron.causallmnext
         config.neuron.seq2seq = seq2seq if seq2seq != None else config.neuron.seq2seq
-        config.neuron.netuid = netuid if netuid != None else config.neuron.netuid
-        # Try config.netuid as well
-        if config.neuron.netuid == None:
-            if config.get('netuid') != None:
-                config.neuron.netuid = config.get('netuid')
+        config.netuid = netuid if netuid != None else config.netuid
 
         self.check_config( config )
         bittensor.logging (
@@ -125,9 +121,9 @@ class neuron:
         self.axon = axon
         self.metagraph = metagraph
 
-        if self.config.neuron.netuid == None:
+        if self.config.netuid == None:
             subtensor = bittensor.subtensor(config = config) if subtensor == None else subtensor
-            self.config.neuron.netuid = subtensor.get_subnets()[0]
+            self.config.netuid = subtensor.get_subnets()[0]
         
         self.model = server(config = self.config)
 

--- a/bittensor/_neuron/text/core_server/nucleus_impl.py
+++ b/bittensor/_neuron/text/core_server/nucleus_impl.py
@@ -576,7 +576,6 @@ class server(torch.nn.Module):
         parser.add_argument('--neuron.disable_blacklist', action='store_true', help='Turns off blacklisting', default=False)
         parser.add_argument('--neuron.disable_priority', action='store_true', help='Turns off priority threadpool', default=False)
         parser.add_argument('--neuron.num_remote_loss', type=int, help='Number of past remote loss to keep in stat.', default=20)
-        parser.add_argument('--neuron.netuid', type=int , help='Subnet uid on finney', default=None)
 
         # Synapse Arguements
         parser.add_argument('--neuron.lasthidden', action='store_false', help='To turn off last hidden synapse', default=True)
@@ -588,6 +587,8 @@ class server(torch.nn.Module):
         parser.add_argument('--neuron.causallmnext_stake', type=float, help='the amount of stake to run causallmnext synapse', default=0)
         parser.add_argument('--neuron.seq2seq_stake',  type = float, help='the amount of stake to run seq2seq synapse',default=0)
 
+        # Netuid Arg
+        parser.add_argument('--netuid', type=int , help='Subnet netuid', default=0)
 
         bittensor.wallet.add_args( parser )
         bittensor.axon.add_args( parser )

--- a/bittensor/_neuron/text/core_server/run.py
+++ b/bittensor/_neuron/text/core_server/run.py
@@ -50,24 +50,22 @@ def serve(
     config.to_defaults()
     model= model.to(model.device)
 
-    config.neuron.netuid = config.netuid
-
     # Create Subtensor connection
     subtensor = bittensor.subtensor(config = config) if subtensor == None else subtensor
 
     # Load/Create our bittensor wallet.
     if wallet == None:
-        wallet = bittensor.wallet( config = config ).create().reregister(subtensor=subtensor, netuid = config.neuron.netuid) 
+        wallet = bittensor.wallet( config = config ).create().reregister(subtensor=subtensor, netuid = config.netuid) 
     else:
-        wallet.reregister(subtensor=subtensor, netuid = config.neuron.netuid)
+        wallet.reregister(subtensor=subtensor, netuid = config.netuid)
 
     # Load/Sync/Save our metagraph.
     if metagraph == None:
         metagraph = bittensor.metagraph ( 
-            netuid = config.neuron.netuid,
+            netuid = config.netuid,
         )
     
-    metagraph.load().sync(netuid= config.neuron.netuid).save()
+    metagraph.load().sync(netuid= config.netuid).save()
 
     # Create our optimizer.
     optimizer = torch.optim.SGD(
@@ -88,7 +86,7 @@ def serve(
     prometheus_info.info ({
         'type': "core_server",
         'uid': str(metagraph.hotkeys.index( wallet.hotkey.ss58_address )),
-        'netuid': config.neuron.netuid,
+        'netuid': config.netuid,
         'network': config.subtensor.network,
         'coldkey': str(wallet.coldkeypub.ss58_address),
         'hotkey': str(wallet.hotkey.ss58_address),
@@ -327,7 +325,7 @@ def serve(
         axon = bittensor.axon(
             config = config,
             wallet = wallet,
-            netuid = config.neuron.netuid,
+            netuid = config.netuid,
             synapse_checks=synapse_check,
             synapse_last_hidden = forward_hidden_state if model.config.neuron.lasthidden else None,
             synapse_causal_lm = forward_casual_lm if model.config.neuron.causallm else None,
@@ -359,13 +357,13 @@ def serve(
         )
 
     last_set_block = subtensor.get_current_block()
-    blocks_per_set_weights = subtensor.validator_epoch_length(config.neuron.netuid) if config.neuron.blocks_per_set_weights == -1 else config.neuron.blocks_per_set_weights
+    blocks_per_set_weights = subtensor.validator_epoch_length(config.netuid) if config.neuron.blocks_per_set_weights == -1 else config.neuron.blocks_per_set_weights
 
     # --- Run Forever.
     while True:
         iteration = 0
         local_data = {}
-        nn = subtensor.get_neuron_for_pubkey_and_subnet(wallet.hotkey.ss58_address, netuid = config.neuron.netuid)
+        nn = subtensor.get_neuron_for_pubkey_and_subnet(wallet.hotkey.ss58_address, netuid = config.netuid)
         uid = metagraph.hotkeys.index( wallet.hotkey.ss58_address )
         current_block = subtensor.get_current_block()
         end_block = current_block + config.neuron.blocks_per_epoch
@@ -458,18 +456,18 @@ def serve(
 
         if current_block - last_set_block > blocks_per_set_weights:
             bittensor.__console__.print('[green]Current Status:[/green]', {**wandb_data, **local_data})
-            metagraph.sync(netuid=config.neuron.netuid)
+            metagraph.sync(netuid=config.netuid)
             last_set_block = current_block
             if not config.neuron.no_set_weights:
                 try: 
                     bittensor.__console__.print('[green]Current Status:[/green]', {**wandb_data, **local_data})
                     # Set self weights to maintain activity.
                     # --- query the chain for the most current number of peers on the network
-                    chain_weights = torch.zeros(subtensor.subnetwork_n( netuid = config.neuron.netuid ))
+                    chain_weights = torch.zeros(subtensor.subnetwork_n( netuid = config.netuid ))
                     chain_weights [ uid ] = 1 
                     did_set = subtensor.set_weights(
-                        netuid = config.neuron.netuid,
-                        uids=torch.arange(0,subtensor.subnetwork_n( netuid = config.neuron.netuid )),
+                        netuid = config.netuid,
+                        uids=torch.arange(0,subtensor.subnetwork_n( netuid = config.netuid )),
                         weights = chain_weights,
                         wait_for_inclusion = False,
                         wallet = wallet,

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -98,15 +98,11 @@ class neuron:
         if config == None: config = neuron.config()
         
         # === Set up subtensor and netuid === 
-        config.neuron.netuid = netuid if netuid != None else config.neuron.netuid
-        # Try config.netuid as well
-        if config.neuron.netuid == None:
-            if config.get('netuid') != None:
-                config.neuron.netuid = config.get('netuid')
+        config.netuid = netuid if netuid != None else config.netuid
 
         subtensor = bittensor.subtensor ( config = config ) if subtensor == None else subtensor
-        if config.neuron.netuid == None:
-            config.neuron.netuid = subtensor.get_subnets()[0]
+        if config.netuid == None:
+            config.netuid = subtensor.get_subnets()[0]
 
         # === Config check === 
         self.config = config
@@ -142,11 +138,11 @@ class neuron:
         self.subtensor = bittensor.subtensor ( config = self.config ) if subtensor == None else subtensor
         self.metagraph = bittensor.metagraph ( config = self.config ) if metagraph == None else metagraph
         self.dendrite = bittensor.dendrite ( config = self.config, wallet = self.wallet, max_active_receptors = 0 ) if dendrite == None else dendrite # Dendrite should not store receptor in validator.
-        self.axon = bittensor.axon ( netuid=self.config.neuron.netuid, config = self.config, wallet = self.wallet ) if axon == None else axon
+        self.axon = bittensor.axon ( netuid=self.config.netuid, config = self.config, wallet = self.wallet ) if axon == None else axon
         self.device = torch.device ( device = self.config.neuron.device )    
         self.nucleus = nucleus ( config = self.config, device = self.device, subtensor = self.subtensor, vlogger = self.vlogger ).to( self.device )
-        self.dataset = (bittensor.dataset(config=self.config, batch_size=self.subtensor.validator_batch_size(self.config.neuron.netuid),
-                                          block_size=self.subtensor.validator_sequence_length(self.config.neuron.netuid) + self.config.neuron.validation_len + self.config.neuron.prune_len)
+        self.dataset = (bittensor.dataset(config=self.config, batch_size=self.subtensor.validator_batch_size(self.config.netuid),
+                                          block_size=self.subtensor.validator_sequence_length(self.config.netuid) + self.config.neuron.validation_len + self.config.neuron.prune_len)
                         if dataset is None else dataset)
         self.optimizer = torch.optim.SGD(
             self.nucleus.parameters(), lr=self.config.neuron.learning_rate, momentum=self.config.neuron.momentum
@@ -223,7 +219,7 @@ class neuron:
         
         # Netuid Arg
         parser.add_argument('--netuid', type=int , help='Subnet netuid', default=0)
-            
+
         bittensor.wallet.add_args( parser )
         bittensor.dendrite.add_args( parser )
         bittensor.subtensor.add_args( parser )
@@ -262,12 +258,12 @@ class neuron:
         # Connects wallet to network. 
         self.wallet.create()
         # NOTE: This registration step should likely be solved offline first.
-        self.wallet.reregister( subtensor = self.subtensor, netuid=self.config.neuron.netuid )
+        self.wallet.reregister( subtensor = self.subtensor, netuid=self.config.netuid )
 
         # === UID ===
         # Get our uid from the chain. 
         # At this point we should have a uid because we are already registered.
-        self.uid = self.wallet.get_uid( subtensor = self.subtensor, netuid=self.config.neuron.netuid )    
+        self.uid = self.wallet.get_uid( subtensor = self.subtensor, netuid=self.config.netuid )    
 
         # === Monitoring ===
         # Optionally set up wandb logging.
@@ -369,16 +365,16 @@ class neuron:
         # === Get params for epoch ===
         # Pulling the latest chain parameters.
         current_block = self.subtensor.block
-        batch_size = self.subtensor.validator_batch_size(netuid=self.config.neuron.netuid)
-        sequence_length = self.subtensor.validator_sequence_length(netuid=self.config.neuron.netuid)
+        batch_size = self.subtensor.validator_batch_size(netuid=self.config.netuid)
+        sequence_length = self.subtensor.validator_sequence_length(netuid=self.config.netuid)
         validation_len = self.config.neuron.validation_len  # Number of tokens to holdout for phrase validation beyond sequence context
         prune_len = self.config.neuron.prune_len  # Number of tokens to holdout for phrase validation beyond sequence context
-        min_allowed_weights = self.subtensor.min_allowed_weights(netuid=self.config.neuron.netuid)
-        max_weight_limit = self.subtensor.max_weight_limit(netuid=self.config.neuron.netuid)
-        blocks_per_epoch = self.subtensor.validator_epoch_length(netuid=self.config.neuron.netuid) if self.config.neuron.blocks_per_epoch == -1 else self.config.neuron.blocks_per_epoch
-        epochs_until_reset = self.subtensor.validator_epochs_per_reset(netuid=self.config.neuron.netuid) if self.config.neuron.epochs_until_reset == -1 else self.config.neuron.epochs_until_reset
-        self.config.nucleus.scaling_law_power = self.subtensor.scaling_law_power(netuid=self.config.neuron.netuid)
-        self.config.nucleus.synergy_scaling_law_power = self.subtensor.synergy_scaling_law_power(netuid=self.config.neuron.netuid)
+        min_allowed_weights = self.subtensor.min_allowed_weights(netuid=self.config.netuid)
+        max_weight_limit = self.subtensor.max_weight_limit(netuid=self.config.netuid)
+        blocks_per_epoch = self.subtensor.validator_epoch_length(netuid=self.config.netuid) if self.config.neuron.blocks_per_epoch == -1 else self.config.neuron.blocks_per_epoch
+        epochs_until_reset = self.subtensor.validator_epochs_per_reset(netuid=self.config.netuid) if self.config.neuron.epochs_until_reset == -1 else self.config.neuron.epochs_until_reset
+        self.config.nucleus.scaling_law_power = self.subtensor.scaling_law_power(netuid=self.config.netuid)
+        self.config.nucleus.synergy_scaling_law_power = self.subtensor.synergy_scaling_law_power(netuid=self.config.netuid)
 
         # === Update dataset size ===
         if (batch_size != self.dataset.batch_size) or (sequence_length + validation_len + prune_len != self.dataset.block_size):
@@ -546,7 +542,7 @@ class neuron:
         self.subtensor.set_weights(
             uids=sample_uids.detach().to('cpu'),
             weights=sample_weights.detach().to('cpu'),
-            netuid = self.config.neuron.netuid,
+            netuid = self.config.netuid,
             wallet=self.wallet,
             version_key=bittensor.__version_as_int__, # TODO: correct?
             wait_for_finalization=self.config.neuron.wait_for_finalization,
@@ -596,7 +592,7 @@ class neuron:
         r""" Syncing metagraph together with other metagraph-size related objects
         """
         old_hotkeys = self.neuron_hotkeys + [] if self.neuron_hotkeys else self.metagraph.hotkeys
-        self.metagraph.sync(netuid=self.config.neuron.netuid)
+        self.metagraph.sync(netuid=self.config.netuid)
         self.neuron_hotkeys = self.metagraph.hotkeys
 
         changed_hotkeys = []
@@ -703,8 +699,8 @@ class neuron:
 
         weight_key = self.weight_key + '!'  # use zeroing key to penalize non-responsive neurons
 
-        min_allowed_weights = self.subtensor.min_allowed_weights(netuid=self.config.neuron.netuid)
-        max_weight_limit = self.subtensor.max_weight_limit(netuid=self.config.neuron.netuid)
+        min_allowed_weights = self.subtensor.min_allowed_weights(netuid=self.config.netuid)
+        max_weight_limit = self.subtensor.max_weight_limit(netuid=self.config.netuid)
 
         # === Populate neuron weights ===
         neuron_weights = torch.zeros_like(self.metagraph.S)  # allow unevaluated UIDs for min_allowed_weights
@@ -722,7 +718,7 @@ class neuron:
 
         # === Exclude lowest quantile from weight setting ===
         max_exclude = (len(sample_weights) - min_allowed_weights) / len(sample_weights)  # max excludable weight quantile
-        quantile = self.subtensor.validator_exclude_quantile(netuid=self.config.neuron.netuid) if self.config.neuron.exclude_quantile == -1 else self.config.neuron.exclude_quantile 
+        quantile = self.subtensor.validator_exclude_quantile(netuid=self.config.netuid) if self.config.neuron.exclude_quantile == -1 else self.config.neuron.exclude_quantile 
         if 0 < max_exclude:
             exclude_quantile = min([quantile , max_exclude])  # reduce quantile to meet min_allowed_weights
             lowest_quantile = sample_weights.quantile(exclude_quantile)  # find lowest quantile threshold
@@ -747,11 +743,11 @@ class nucleus( torch.nn.Module ):
         super(nucleus, self).__init__()
         self.config = config
         self.vlogger = vlogger
-        self.config.nucleus.scaling_law_power = subtensor.scaling_law_power(netuid=self.config.neuron.netuid) if self.config.nucleus.scaling_law_power == -1 else self.config.nucleus.scaling_law_power
-        self.config.nucleus.synergy_scaling_law_power = subtensor.synergy_scaling_law_power(netuid=self.config.neuron.netuid) if self.config.nucleus.synergy_scaling_law_power == -1 else self.config.nucleus.synergy_scaling_law_power
+        self.config.nucleus.scaling_law_power = subtensor.scaling_law_power(netuid=self.config.netuid) if self.config.nucleus.scaling_law_power == -1 else self.config.nucleus.scaling_law_power
+        self.config.nucleus.synergy_scaling_law_power = subtensor.synergy_scaling_law_power(netuid=self.config.netuid) if self.config.nucleus.synergy_scaling_law_power == -1 else self.config.nucleus.synergy_scaling_law_power
 
         self.device = device
-        self.max_n = subtensor.max_n(netuid=self.config.neuron.netuid)
+        self.max_n = subtensor.max_n(netuid=self.config.netuid)
         self.permute_uids = []  # iterable of next UIDs to query, reset to permuted UIDs when empty
 
         tokenizer = bittensor.tokenizer()

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -214,13 +214,16 @@ class neuron:
         parser.add_argument('--neuron.forward_num', type=int, help='''How much forward request before a backward call.''', default=3)
         parser.add_argument('--neuron.validation_synapse', type=str, help='''Synapse used for validation.''', default='TextCausalLMNext', choices = ['TextCausalLMNext', 'TextCausalLM'])
         parser.add_argument('--neuron.exclude_quantile', type=float, help='Exclude the lowest quantile from weight setting. (default value: -1, pulling from subtensor directly)', default=-1)
-        parser.add_argument('--neuron.netuid', type=int , help='Subnet uid on finney', default=None)
 
     @classmethod
     def config ( cls ):
         parser = argparse.ArgumentParser()    
         cls.add_args( parser )
-        nucleus.add_args( parser )        
+        nucleus.add_args( parser )    
+        
+        # Netuid Arg
+        parser.add_argument('--netuid', type=int , help='Subnet netuid', default=0)
+            
         bittensor.wallet.add_args( parser )
         bittensor.dendrite.add_args( parser )
         bittensor.subtensor.add_args( parser )

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -243,7 +243,8 @@ class neuron:
         if getattr(self, 'dataset', None) is not None:
             self.dataset.close()
         
-        self.dendrite.__del__()
+        if getattr(self, 'dendrite', None) is not None:
+            self.dendrite.__del__()
 
     def __exit__ ( self, exc_type, exc_value, exc_traceback ):
         r""" Close down neuron.

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -244,7 +244,9 @@ class neuron:
                 f'{self.config.wallet.hotkey}:[bold]{self.wallet.hotkey.ss58_address[:7]}[/bold])')
 
     def __del__(self):
-        self.dataset.close()
+        if getattr(self, 'dataset', None) is not None:
+            self.dataset.close()
+        
         self.dendrite.__del__()
 
     def __exit__ ( self, exc_type, exc_value, exc_traceback ):


### PR DESCRIPTION
This PR changes `--neuron.netuid` to `--netuid` instead, to be the same as other btcli commands  

This PR also adds a check for the `dendrite` and `dataset` attributes in `core_validator.__del__`, so there is are no errors on early exit.  