### PR TITLE
Remove Py 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ workflows:
       - build-and-test:
           matrix:
             parameters:
-              python-version: ["3.7.14", "3.8.14", "3.9.13", "3.10.6"]
+              python-version: ["3.8.14", "3.9.13", "3.10.6"]
       - unit-tests-all-python-versions:
           requires:
             - build-and-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machi
 RUN apt update && apt upgrade -y
 # Install bittensor
 ## Install dependencies
-RUN apt install -y curl sudo nano git htop netcat wget unzip python3-dev python3-pip tmux apt-utils cmake build-essential
+RUN apt install -y curl sudo nano git htop netcat wget unzip tmux apt-utils cmake build-essential
 ## Upgrade pip
 RUN pip3 install --upgrade pip
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(
 
         # Pick your license as you wish
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     include_package_data=True,
     author_email='',
     license='MIT',
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=requirements,
     extras_require={
         'dev': extra_requirements_dev,

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
 
         # Pick your license as you wish
         'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
This PR ups the python requirements to py3.8+, therefore removing support for python3.7.  

This comes up as per: https://devguide.python.org/versions/  python 3.7 is being deprecated shortly this year.  