### PR TITLE
[fix] [ci] modify cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             python -m venv env/
             . env/bin/activate
             python -m pip install --upgrade pip
-            pip install '.'
+            pip install '.[dev]'
 
       - save_cache:
           name: Save cached venv
@@ -41,7 +41,7 @@ jobs:
           name: Install Bittensor
           command: |
             . env/bin/activate
-            pip install -e '.'
+            pip install -e '.[dev]'
 
       - run:
           name: Instantiate Mock Wallet & Protos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - restore_cache:
           name: Restore cached venv
           keys:
-            - v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements/prod.txt" }}
+            - v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements/prod.txt" }}-{{ checksum "requirements/dev.txt" }}
             - v1-pypi-py<< parameters.python-version >>
 
       - run:
@@ -35,7 +35,7 @@ jobs:
           name: Save cached venv
           paths:
             - "env/"
-          key: v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements/prod.txt" }}
+          key: v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements/prod.txt" }}-{{ checksum "requirements/dev.txt" }}
 
       - run:
           name: Install Bittensor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - restore_cache:
           name: Restore cached venv
           keys:
-            - v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements/prod.txt" }}-{{ checksum "requirements/dev.txt" }}
+            - v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements/prod.txt" }}+{{ checksum "requirements/dev.txt" }}
             - v1-pypi-py<< parameters.python-version >>
 
       - run:
@@ -35,7 +35,7 @@ jobs:
           name: Save cached venv
           paths:
             - "env/"
-          key: v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements/prod.txt" }}-{{ checksum "requirements/dev.txt" }}
+          key: v1-pypi-py<< parameters.python-version >>-{{ checksum "requirements/prod.txt" }}+{{ checksum "requirements/dev.txt" }}
 
       - run:
           name: Install Bittensor


### PR DESCRIPTION
This PR adds `requirements/dev.txt` to the venv cache key
This should make the venv re-run when there are changes in **either** `prod.txt` or `dev.txt`