### PR TITLE
Fix is_registered call

### DIFF
--- a/bittensor/_wallet/wallet_impl.py
+++ b/bittensor/_wallet/wallet_impl.py
@@ -175,7 +175,8 @@ class Wallet():
                     Is the wallet registered on the chain.
         """
         if subtensor == None: subtensor = bittensor.subtensor()
-        return subtensor.is_hotkey_registered( self.hotkey.ss58_address, netuid = netuid )
+        if netuid == None: return subtensor.is_hotkey_registered_any( self.hotkey.ss58_address )
+        return subtensor.is_hotkey_registered_on_subnet( self.hotkey.ss58_address, netuid = netuid )
 
     def get_neuron ( self, netuid: int, subtensor: Optional['bittensor.Subtensor'] = None ) -> Optional['bittensor.NeuronInfo'] :
         """ Returns this wallet's neuron information from subtensor.


### PR DESCRIPTION
This PR fixes the call to `wallet.is_registered( netuid = None )` when netuid is None and there are not active subnets.

e.g.
```
import bittensor
from tqdm import tqdm
sub = bittensor.subtensor( chain_endpoint = "wss://collator-06.rinzler01.parachain.opentensor.ai:443" )
wallet = bittensor.wallet( name = 'test', hotkey = 'test')
wallet.create( coldkey_use_password = False, hotkey_use_password = False )
wallet.is_registered( subtensor = sub )

>>> False
```