### PR TITLE
update torch version to 1.13.1 and docker to py3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,9 @@ RUN bash -c "source $HOME/.nvm/nvm.sh && \
     # install pm2
     npm install --location=global pm2"
 
-RUN mkdir -p /root/.bittensor/
-COPY . /root/.bittensor/
-RUN cd /root/.bittensor/ && python3 -m pip install .
+RUN mkdir -p /root/.bittensor/bittensor
+COPY . /root/.bittensor/bittensor
+RUN cd /root/.bittensor/bittensor && python3 -m pip install .
 
 # Increase ulimit to 1,000,000
 RUN prlimit --pid=$PPID --nofile=1000000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM pytorch/pytorch:1.12.0-cuda11.3-cudnn8-devel
+FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-devel
 
 LABEL bittensor.image.authors="bittensor.com" \
 	bittensor.image.vendor="Bittensor" \
@@ -9,8 +9,8 @@ LABEL bittensor.image.authors="bittensor.com" \
 	bittensor.image.revision="${VCS_REF}" \
 	bittensor.image.created="${BUILD_DATE}" \
 	bittensor.image.documentation="https://app.gitbook.com/@opentensor/s/bittensor/"
-LABEL bittensor.dependencies.versions.torch="1.12.0"
-LABEL bittensor.dependencies.versions.cuda="11.3"
+LABEL bittensor.dependencies.versions.torch="1.13.1"
+LABEL bittensor.dependencies.versions.cuda="11.6"
 ARG DEBIAN_FRONTEND=noninteractive
 
 #nvidia key migration

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM pytorch/pytorch:1.13.0-cuda11.6-cudnn8-devel
+FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-devel
 
 LABEL bittensor.image.authors="bittensor.com" \
 	bittensor.image.vendor="Bittensor" \
@@ -9,7 +9,7 @@ LABEL bittensor.image.authors="bittensor.com" \
 	bittensor.image.revision="${VCS_REF}" \
 	bittensor.image.created="${BUILD_DATE}" \
 	bittensor.image.documentation="https://app.gitbook.com/@opentensor/s/bittensor/"
-LABEL bittensor.dependencies.versions.torch="1.13.0"
+LABEL bittensor.dependencies.versions.torch="1.13.1"
 LABEL bittensor.dependencies.versions.cuda="11.6"
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-devel
+FROM pytorch/pytorch:1.13.0-cuda11.6-cudnn8-devel
 
 LABEL bittensor.image.authors="bittensor.com" \
 	bittensor.image.vendor="Bittensor" \
@@ -9,7 +9,7 @@ LABEL bittensor.image.authors="bittensor.com" \
 	bittensor.image.revision="${VCS_REF}" \
 	bittensor.image.created="${BUILD_DATE}" \
 	bittensor.image.documentation="https://app.gitbook.com/@opentensor/s/bittensor/"
-LABEL bittensor.dependencies.versions.torch="1.13.1"
+LABEL bittensor.dependencies.versions.torch="1.13.0"
 LABEL bittensor.dependencies.versions.cuda="11.6"
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -34,7 +34,7 @@ requests==2.25.0
 scalecodec>=1.0.35,<1.1.0
 sentencepiece==0.1.97
 termcolor==2.1.1
-torch==1.12
+torch==1.13.1
 transformers==4.20.1
 numpy==1.21.6
 wheel==0.37.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -34,7 +34,7 @@ requests==2.25.0
 scalecodec>=1.0.35,<1.1.0
 sentencepiece==0.1.97
 termcolor==2.1.1
-torch==1.13.0
+torch==1.13.1
 transformers==4.20.1
 numpy==1.21.6
 wheel==0.37.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -34,7 +34,7 @@ requests==2.25.0
 scalecodec>=1.2,<1.3
 sentencepiece==0.1.97
 termcolor==2.1.1
-torch==1.13.1
+torch==1.13.0
 transformers==4.20.1
 numpy==1.21.6
 wheel==0.37.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -34,7 +34,7 @@ requests==2.25.0
 scalecodec>=1.2,<1.3
 sentencepiece==0.1.97
 termcolor==2.1.1
-torch==1.13.0
+torch==1.13.1
 transformers==4.20.1
 numpy==1.21.6
 wheel==0.37.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -31,7 +31,7 @@ pyyaml==6.0
 rich==12.5.1
 retry==0.9.2
 requests==2.25.0
-scalecodec>=1.0.35,<1.1.0
+scalecodec>=1.2,<1.3
 sentencepiece==0.1.97
 termcolor==2.1.1
 torch==1.13.1
@@ -42,5 +42,5 @@ tqdm==4.64.1
 qqdm==0.0.7
 wandb>=0.11.1,<0.13.4
 ansible_vault>=2.1
-substrate-interface==1.2.4
+substrate-interface==1.5.0
 markupsafe==2.0.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -34,7 +34,7 @@ requests==2.25.0
 scalecodec>=1.0.35,<1.1.0
 sentencepiece==0.1.97
 termcolor==2.1.1
-torch==1.13.1
+torch==1.13.0
 transformers==4.20.1
 numpy==1.21.6
 wheel==0.37.1


### PR DESCRIPTION
this PR changes the base docker image to pytorch 1.13.1
This image has python 3.10.8 as well, which was needed as the images for previous pytorch versions only have py <3.8    
See: https://github.com/pytorch/pytorch/issues/73714#issuecomment-1423557777