### PR TITLE
Restore from json

### DIFF
--- a/bittensor/_cli/commands/wallets.py
+++ b/bittensor/_cli/commands/wallets.py
@@ -18,13 +18,29 @@
 
 import argparse
 import bittensor
+import os
+import sys
 from rich.prompt import Prompt
+from typing import Optional
 
 class RegenColdkeyCommand:
     def run ( cli ):
         r""" Creates a new coldkey under this wallet."""
         wallet = bittensor.wallet(config = cli.config)
-        wallet.regenerate_coldkey( mnemonic = cli.config.mnemonic, seed = cli.config.seed, use_password = cli.config.use_password, overwrite = cli.config.overwrite_coldkey )
+
+        json_str: Optional[str] = None
+        json_password: Optional[str] = None
+        if cli.config.get('json'):
+            file_name: str = cli.config.get('json')
+            if not os.path.exists(file_name) or not os.path.isfile(file_name):
+                raise ValueError('File {} does not exist'.format(file_name))
+            with open(cli.config.get('json'), 'r') as f:
+                json_str = f.read()
+            
+            # Password can be "", assume if None
+            json_password = cli.config.get('json_password', "")
+
+        wallet.regenerate_coldkey( mnemonic = cli.config.mnemonic, seed = cli.config.seed, json = (json_str, json_password), use_password = cli.config.use_password, overwrite = cli.config.overwrite_coldkey )
    
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
@@ -56,6 +72,18 @@ class RegenColdkeyCommand:
             required=False,  
             default=None,
             help='Seed hex string used to regen your key i.e. 0x1234...'
+        )
+        regen_coldkey_parser.add_argument(
+            "--json",
+            required=False,
+            default=None,
+            help='''Path to a json file containing the encrypted key backup. (e.g. from PolkadotJS)'''
+        )
+        regen_coldkey_parser.add_argument(
+            "--json_password",
+            required=False,
+            default=None,
+            help='''Password to decrypt the json file.'''
         )
         regen_coldkey_parser.add_argument(
             '--use_password', 
@@ -152,7 +180,20 @@ class RegenHotkeyCommand:
     def run ( cli ):
         r""" Creates a new coldkey under this wallet."""
         wallet = bittensor.wallet(config = cli.config)
-        wallet.regenerate_hotkey( mnemonic = cli.config.mnemonic, seed=cli.config.seed, use_password = cli.config.use_password, overwrite = cli.config.overwrite_hotkey)
+
+        json_str: Optional[str] = None
+        json_password: Optional[str] = None
+        if cli.config.get('json'):
+            file_name: str = cli.config.get('json')
+            if not os.path.exists(file_name) or not os.path.isfile(file_name):
+                raise ValueError('File {} does not exist'.format(file_name))
+            with open(cli.config.get('json'), 'r') as f:
+                json_str = f.read()
+            
+            # Password can be "", assume if None
+            json_password = cli.config.get('json_password', "")
+
+        wallet.regenerate_hotkey( mnemonic = cli.config.mnemonic, seed=cli.config.seed, json = (json_str, json_password), use_password = cli.config.use_password, overwrite = cli.config.overwrite_hotkey)
     
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
@@ -189,6 +230,18 @@ class RegenHotkeyCommand:
             required=False,  
             default=None,
             help='Seed hex string used to regen your key i.e. 0x1234...'
+        )
+        regen_hotkey_parser.add_argument(
+            "--json",
+            required=False,
+            default=None,
+            help='''Path to a json file containing the encrypted key backup. (e.g. from PolkadotJS)'''
+        )
+        regen_hotkey_parser.add_argument(
+            "--json_password",
+            required=False,
+            default=None,
+            help='''Password to decrypt the json file.'''
         )
         regen_hotkey_parser.add_argument(
             '--use_password', 

--- a/bittensor/_cli/commands/wallets.py
+++ b/bittensor/_cli/commands/wallets.py
@@ -47,12 +47,18 @@ class RegenColdkeyCommand:
         if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
-        if config.mnemonic == None and config.seed == None:
-            prompt_answer = Prompt.ask("Enter mnemonic or seed")
+        
+        if config.mnemonic == None and config.seed == None and config.json == None:
+            prompt_answer = Prompt.ask("Enter mnemonic, seed, or json file location")
             if prompt_answer.startswith("0x"):
                 config.seed = prompt_answer
-            else:
+            elif len(prompt_answer.split(" ")) > 1:
                 config.mnemonic = prompt_answer
+            else:
+                config.json = prompt_answer
+
+        if config.json and config.json_password == None:
+            config.json_password = Prompt.ask("Enter json backup password", password=True)
     
     @staticmethod
     def add_args( parser: argparse.ArgumentParser ):
@@ -205,12 +211,17 @@ class RegenHotkeyCommand:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
         
-        if config.mnemonic == None and config.seed == None:
-            prompt_answer = Prompt.ask("Enter mnemonic or seed")
+        if config.mnemonic == None and config.seed == None and config.json == None:
+            prompt_answer = Prompt.ask("Enter mnemonic, seed, or json file location")
             if prompt_answer.startswith("0x"):
                 config.seed = prompt_answer
-            else:
+            elif len(prompt_answer.split(" ")) > 1:
                 config.mnemonic = prompt_answer
+            else:
+                config.json = prompt_answer
+
+        if config.json and config.json_password == None:
+            config.json_password = Prompt.ask("Enter json backup password", password=True)
 
     @staticmethod
     def add_args( parser: argparse.ArgumentParser ):

--- a/bittensor/_wallet/wallet_impl.py
+++ b/bittensor/_wallet/wallet_impl.py
@@ -20,7 +20,7 @@
 import os
 import sys
 from types import SimpleNamespace
-from typing import Optional, Union, List, Tuple, Dict
+from typing import Optional, Union, List, Tuple, Dict, overload
 
 import bittensor
 from bittensor.utils import is_valid_bittensor_address_or_public_key
@@ -672,23 +672,6 @@ class Wallet():
         self.set_hotkey( keypair, encrypt=use_password, overwrite = overwrite)
         return self
 
-    def regen_coldkey( self, mnemonic: Optional[Union[list, str]]=None, seed: Optional[str]=None, use_password: bool = True,  overwrite:bool = False) -> 'Wallet':
-        """ Regenerates the coldkey from passed mnemonic, encrypts it with the user's password and save the file
-            Args:
-                mnemonic: (Union[list, str], optional):
-                    Key mnemonic as list of words or string space separated words.
-                seed: (str, optional):
-                    Seed as hex string.
-                use_password (bool, optional):
-                    Is the created key password protected.
-                overwrite (bool, optional): 
-                    Will this operation overwrite the coldkey under the same path <wallet path>/<wallet name>/coldkey
-            Returns:
-                wallet (bittensor.Wallet):
-                    this object with newly created coldkey.
-        """
-        self.regenerate_coldkey(mnemonic, seed, use_password, overwrite)
-
     def regenerate_coldkeypub( self, ss58_address: Optional[str] = None, public_key: Optional[Union[str, bytes]] = None, overwrite: bool = False ) -> 'Wallet':
         """ Regenerates the coldkeypub from passed ss58_address or public_key and saves the file
                Requires either ss58_address or public_key to be passed.
@@ -724,13 +707,39 @@ class Wallet():
     # Short name for regenerate_coldkeypub
     regen_coldkeypub = regenerate_coldkeypub
 
+    @overload
     def regenerate_coldkey(
             self,
             mnemonic: Optional[Union[list, str]] = None,
+            use_password: bool = True,
+            overwrite: bool = False
+        ) -> 'Wallet':
+        ...
+
+    @overload
+    def regenerate_coldkey(
+            self,
             seed: Optional[str] = None,
+            use_password: bool = True,
+            overwrite: bool = False
+        ) -> 'Wallet':
+        ...
+
+    @overload
+    def regenerate_coldkey(
+            self,
             json: Optional[Tuple[Union[str, Dict], str]] = None,
             use_password: bool = True,
             overwrite: bool = False
+        ) -> 'Wallet':
+        ...
+
+
+    def regenerate_coldkey(
+            self,
+            use_password: bool = True,
+            overwrite: bool = False,
+            **kwargs
         ) -> 'Wallet':
         """ Regenerates the coldkey from passed mnemonic, seed, or json encrypts it with the user's password and saves the file
             Args:
@@ -750,6 +759,14 @@ class Wallet():
 
             Note: uses priority order: mnemonic > seed > json
         """
+        if len(kwargs) == 0:
+            raise ValueError("Must pass either mnemonic, seed, or json")
+        
+        # Get from kwargs
+        mnemonic = kwargs.get('mnemonic', None)
+        seed = kwargs.get('seed', None)
+        json = kwargs.get('json', None)
+        
         if mnemonic is None and seed is None and json is None:
             raise ValueError("Must pass either mnemonic, seed, or json")
         if mnemonic is not None:
@@ -772,30 +789,41 @@ class Wallet():
         self.set_coldkeypub( keypair, overwrite = overwrite)
         return self 
 
-    def regen_hotkey( self, mnemonic: Optional[Union[list, str]], seed: Optional[str] = None, use_password: bool = True, overwrite:bool = False) -> 'Wallet':
-        """ Regenerates the hotkey from passed mnemonic, encrypts it with the user's password and save the file
-            Args:
-                mnemonic: (Union[list, str], optional):
-                    Key mnemonic as list of words or string space separated words.
-                seed: (str, optional):
-                    Seed as hex string.
-                use_password (bool, optional):
-                    Is the created key password protected.
-                overwrite (bool, optional): 
-                    Will this operation overwrite the hotkey under the same path <wallet path>/<wallet name>/hotkeys/<hotkey>
-            Returns:
-                wallet (bittensor.Wallet):
-                    this object with newly created hotkey.
-        """
-        self.regenerate_hotkey(mnemonic, seed, use_password, overwrite)
+    # Short name for regenerate_coldkey
+    regen_coldkey = regenerate_coldkey
 
+    @overload
     def regenerate_hotkey(
             self,
             mnemonic: Optional[Union[list, str]] = None,
+            use_password: bool = True,
+            overwrite: bool = False
+        ) -> 'Wallet':
+        ...
+
+    @overload
+    def regenerate_hotkey(
+            self,
             seed: Optional[str] = None,
+            use_password: bool = True,
+            overwrite: bool = False
+        ) -> 'Wallet':
+        ...
+
+    @overload
+    def regenerate_hotkey(
+            self,
             json: Optional[Tuple[Union[str, Dict], str]] = None,
             use_password: bool = True,
             overwrite: bool = False
+        ) -> 'Wallet':
+        ...
+
+    def regenerate_hotkey(
+            self,
+            use_password: bool = True,
+            overwrite: bool = False,
+            **kwargs
         ) -> 'Wallet':
         """ Regenerates the hotkey from passed mnemonic, encrypts it with the user's password and save the file
             Args:
@@ -813,6 +841,14 @@ class Wallet():
                 wallet (bittensor.Wallet):
                     this object with newly created hotkey.
         """
+        if len(kwargs) == 0:
+            raise ValueError("Must pass either mnemonic, seed, or json")
+        
+        # Get from kwargs
+        mnemonic = kwargs.get('mnemonic', None)
+        seed = kwargs.get('seed', None)
+        json = kwargs.get('json', None)
+
         if mnemonic is None and seed is None and json is None:
             raise ValueError("Must pass either mnemonic, seed, or json")
         if mnemonic is not None:
@@ -834,3 +870,6 @@ class Wallet():
         
         self.set_hotkey( keypair, encrypt=use_password, overwrite = overwrite)
         return self 
+    
+    # Short name for regenerate_hotkey
+    regen_hotkey = regenerate_hotkey

--- a/bittensor/_wallet/wallet_impl.py
+++ b/bittensor/_wallet/wallet_impl.py
@@ -20,7 +20,7 @@
 import os
 import sys
 from types import SimpleNamespace
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Tuple, Dict
 
 import bittensor
 from bittensor.utils import is_valid_bittensor_address_or_public_key
@@ -724,13 +724,22 @@ class Wallet():
     # Short name for regenerate_coldkeypub
     regen_coldkeypub = regenerate_coldkeypub
 
-    def regenerate_coldkey( self, mnemonic: Optional[Union[list, str]] = None, seed: Optional[str] = None, use_password: bool = True,  overwrite:bool = False) -> 'Wallet':
-        """ Regenerates the coldkey from passed mnemonic, encrypts it with the user's password and save the file
+    def regenerate_coldkey(
+            self,
+            mnemonic: Optional[Union[list, str]] = None,
+            seed: Optional[str] = None,
+            json: Optional[Tuple[Union[str, Dict], str]] = None,
+            use_password: bool = True,
+            overwrite: bool = False
+        ) -> 'Wallet':
+        """ Regenerates the coldkey from passed mnemonic, seed, or json encrypts it with the user's password and saves the file
             Args:
                 mnemonic: (Union[list, str], optional):
                     Key mnemonic as list of words or string space separated words.
                 seed: (str, optional):
                     Seed as hex string.
+                json: (Tuple[Union[str, Dict], str], optional):
+                    Restore from encrypted JSON backup as (json_data: Union[str, Dict], passphrase: str)
                 use_password (bool, optional):
                     Is the created key password protected.
                 overwrite (bool, optional): 
@@ -738,18 +747,26 @@ class Wallet():
             Returns:
                 wallet (bittensor.Wallet):
                     this object with newly created coldkey.
+
+            Note: uses priority order: mnemonic > seed > json
         """
-        if mnemonic is None and seed is None:
-            raise ValueError("Must pass either mnemonic or seed")
+        if mnemonic is None and seed is None and json is None:
+            raise ValueError("Must pass either mnemonic, seed, or json")
         if mnemonic is not None:
             if isinstance( mnemonic, str): mnemonic = mnemonic.split()
             if len(mnemonic) not in [12,15,18,21,24]:
                 raise ValueError("Mnemonic has invalid size. This should be 12,15,18,21 or 24 words")
-            keypair = Keypair.create_from_mnemonic(" ".join(mnemonic))   
+            keypair = Keypair.create_from_mnemonic(" ".join(mnemonic), ss58_format=bittensor.__ss58_format__ )
             display_mnemonic_msg( keypair, "coldkey" )
+        elif seed is not None:
+            keypair = Keypair.create_from_seed(seed, ss58_format=bittensor.__ss58_format__ )
         else:
-            # seed is not None
-            keypair = Keypair.create_from_seed(seed)
+            # json is not None
+            if not isinstance(json, tuple) or len(json) != 2 or not isinstance(json[0], (str, dict)) or not isinstance(json[1], str):
+                raise ValueError("json must be a tuple of (json_data: str | Dict, passphrase: str)")
+
+            json_data, passphrase = json
+            keypair = Keypair.create_from_encrypted_json( json_data, passphrase, ss58_format=bittensor.__ss58_format__ )
             
         self.set_coldkey( keypair, encrypt = use_password, overwrite = overwrite)
         self.set_coldkeypub( keypair, overwrite = overwrite)
@@ -772,13 +789,22 @@ class Wallet():
         """
         self.regenerate_hotkey(mnemonic, seed, use_password, overwrite)
 
-    def regenerate_hotkey( self, mnemonic: Optional[Union[list, str]] = None, seed: Optional[str] = None, use_password: bool = True, overwrite:bool = False) -> 'Wallet':
+    def regenerate_hotkey(
+            self,
+            mnemonic: Optional[Union[list, str]] = None,
+            seed: Optional[str] = None,
+            json: Optional[Tuple[Union[str, Dict], str]] = None,
+            use_password: bool = True,
+            overwrite: bool = False
+        ) -> 'Wallet':
         """ Regenerates the hotkey from passed mnemonic, encrypts it with the user's password and save the file
             Args:
                 mnemonic: (Union[list, str], optional):
                     Key mnemonic as list of words or string space separated words.
                 seed: (str, optional):
                     Seed as hex string.
+                json: (Tuple[Union[str, Dict], str], optional):
+                    Restore from encrypted JSON backup as (json_data: Union[str, Dict], passphrase: str)
                 use_password (bool, optional):
                     Is the created key password protected.
                 overwrite (bool, optional): 
@@ -787,17 +813,24 @@ class Wallet():
                 wallet (bittensor.Wallet):
                     this object with newly created hotkey.
         """
-        if mnemonic is None and seed is None:
-            raise ValueError("Must pass either mnemonic or seed")
+        if mnemonic is None and seed is None and json is None:
+            raise ValueError("Must pass either mnemonic, seed, or json")
         if mnemonic is not None:
             if isinstance( mnemonic, str): mnemonic = mnemonic.split()
             if len(mnemonic) not in [12,15,18,21,24]:
                 raise ValueError("Mnemonic has invalid size. This should be 12,15,18,21 or 24 words")
-            keypair = Keypair.create_from_mnemonic(" ".join(mnemonic))
-            display_mnemonic_msg( keypair, "hotkey" )
+            keypair = Keypair.create_from_mnemonic(" ".join(mnemonic), ss58_format=bittensor.__ss58_format__ )
+            display_mnemonic_msg( keypair, "coldkey" )
+        elif seed is not None:
+            keypair = Keypair.create_from_seed(seed, ss58_format=bittensor.__ss58_format__ )
         else:
-            # seed is not None
-            keypair = Keypair.create_from_seed(seed)
+            # json is not None
+            if not isinstance(json, tuple) or len(json) != 2 or not isinstance(json[0], (str, dict)) or not isinstance(json[1], str):
+                raise ValueError("json must be a tuple of (json_data: str | Dict, passphrase: str)")
+
+            json_data, passphrase = json
+            keypair = Keypair.create_from_encrypted_json( json_data, passphrase, ss58_format=bittensor.__ss58_format__ )
+
         
         self.set_hotkey( keypair, encrypt=use_password, overwrite = overwrite)
         return self 


### PR DESCRIPTION
Updating pysubstrate gave us the ability to restore keys from encrypted json backups.  
These are the same format as output by PolkadotJS explorer, etc.  

Usage: `btcli regen_coldkey --wallet.name taotip --json ~/Downloads/wallet-export.json`   
<img width="956" alt="Screenshot 2023-02-09 at 7 23 35 PM" src="https://user-images.githubusercontent.com/24501463/217969351-5c7e6ac7-58ca-459c-8205-b6be8a4870f5.png">  