### PR TITLE
Add hyperparams to metagraph

### DIFF
--- a/bittensor/_metagraph/__init__.py
+++ b/bittensor/_metagraph/__init__.py
@@ -115,19 +115,23 @@ class metagraph:
         pass
 
     @staticmethod
-    def from_neurons( network: str, netuid: int, neurons: List['bittensor.NeuronInfo'], block: int ) -> 'bittensor.Metagraph':
+    def from_neurons( network: str, netuid: int, info: 'bittensor.SubnetInfo', neurons: List['bittensor.NeuronInfo'], block: int ) -> 'bittensor.Metagraph':
         r""" Creates a metagraph from a list of neurons.
             Args: 
                 network: (:obj:`str`, required):
                     Name of the network for the metagraph.
                 netuid: (:obj:`int`, required):
                     netuid of the subnet for the metagraph.
+                info: (:obj:`SubnetInfo`, required):
+                    SubnetInfo object for the metagraph, including the subnet's hyperparameters.
                 neurons: (:obj:`List[NeuronInfo]`, required):
                     List of neurons to create metagraph from.
                 block: (:obj:`int`, required):
                     Block number at time of the metagraph.
         """
         metagraph = metagraph_impl.Metagraph( network = network, netuid = netuid )
+        metagraph.info = info
+
         n_total = len(neurons)
 
         # Fill arrays.

--- a/bittensor/_metagraph/metagraph_impl.py
+++ b/bittensor/_metagraph/metagraph_impl.py
@@ -57,6 +57,8 @@ class Metagraph( torch.nn.Module ):
     """
     network: str
     netuid: int
+    neurons: Optional[List[Optional['bittensor.Neurons']]]
+    info: Optional['bittensor.SubnetInfo']
 
     def __init__( self, network: str, netuid: int ):
         r""" Initializes a new Metagraph torch chain interface object.
@@ -91,8 +93,9 @@ class Metagraph( torch.nn.Module ):
         self.uids = torch.nn.Parameter( torch.tensor([], dtype = torch.int64),requires_grad=False )
         self._endpoint_objs = None
         self.neurons = None
+        self.info = None
         return self
-
+    
     @property
     def S(self) -> torch.FloatTensor:
         """ Stake
@@ -273,7 +276,8 @@ class Metagraph( torch.nn.Module ):
             network = self.network
         if netuid == None:
             netuid = self.netuid
-        return self.save_to_path( path = '~/.bittensor/', filename = f"{str(network)}_{str(self.netuid)}.pt")
+        print(f"Saving metagraph to ~/.bittensor/{str(network)}_{str(netuid)}.pt")
+        return self.save_to_path( path = '~/.bittensor/', filename = f"{str(network)}_{str(netuid)}.pt")
 
     def load_from_path(self, path:str ) -> 'Metagraph':
         r""" Loads this metagraph object with state_dict under the specified path.
@@ -324,6 +328,7 @@ class Metagraph( torch.nn.Module ):
         self.bonds = torch.nn.Parameter( state_dict['bonds'], requires_grad=False )
         self.endpoints = torch.nn.Parameter( state_dict['endpoints'], requires_grad=False )
         self._endpoint_objs = None
+        self.info = torch.nn.Parameter( state_dict['info'], requires_grad=False )
         return self
 
     def sync ( self, netuid: int, subtensor: 'bittensor.Subtensor' = None, block: Optional[int] = None ) -> 'Metagraph':

--- a/bittensor/_metagraph/metagraph_impl.py
+++ b/bittensor/_metagraph/metagraph_impl.py
@@ -66,7 +66,15 @@ class Metagraph( torch.nn.Module ):
         super(Metagraph, self).__init__()
         self.network = network
         self.netuid = netuid
+        self._register_state_dict_hook(Metagraph.__info_state_dict_hook__)
         self.clear()
+
+    def __info_state_dict_hook__(self, state_dict, prefix, local_metadata):
+        r""" Hook for state_dict to add info to state_dict. e.g. before saving.
+        """
+        if self.info is not None:
+            state_dict[prefix + 'info'] = self.info.to_parameter_dict()
+        return state_dict
 
     def clear( self ) -> 'Metagraph':
         r""" Erases Metagraph state.
@@ -254,10 +262,13 @@ class Metagraph( torch.nn.Module ):
                 network = self.network
             if netuid == None:
                 netuid = self.netuid
-            metagraph_path = f"~/.bittensor/{str(network)}_{str(self.netuid)}.pt"
+            metagraph_path = f"~/.bittensor/{str(network)}_{str(netuid)}.pt"
             metagraph_path = os.path.expanduser(metagraph_path)
             if os.path.isfile(metagraph_path):
                 self.load_from_path( path = metagraph_path )
+                # Update network and netuid.
+                self.network = network
+                self.netuid = netuid
             else:
                 logger.warning('Did not load metagraph from path: {}, file does not exist. Run metagraph.save() first.', metagraph_path)
         except Exception as e:
@@ -276,7 +287,6 @@ class Metagraph( torch.nn.Module ):
             network = self.network
         if netuid == None:
             netuid = self.netuid
-        print(f"Saving metagraph to ~/.bittensor/{str(network)}_{str(netuid)}.pt")
         return self.save_to_path( path = '~/.bittensor/', filename = f"{str(network)}_{str(netuid)}.pt")
 
     def load_from_path(self, path:str ) -> 'Metagraph':
@@ -287,7 +297,9 @@ class Metagraph( torch.nn.Module ):
         """
         full_path = os.path.expanduser(path)
         metastate = torch.load( full_path )
-        return self.load_from_state_dict( metastate )
+        metagraph = self.load_from_state_dict( metastate )
+        self.__dict__.update(metagraph.__dict__)
+        return self
 
     def save_to_path(self, path:str, filename:str ) -> 'Metagraph':
         r""" Saves this metagraph object's state_dict to the specified path.
@@ -328,7 +340,7 @@ class Metagraph( torch.nn.Module ):
         self.bonds = torch.nn.Parameter( state_dict['bonds'], requires_grad=False )
         self.endpoints = torch.nn.Parameter( state_dict['endpoints'], requires_grad=False )
         self._endpoint_objs = None
-        self.info = torch.nn.Parameter( state_dict['info'], requires_grad=False )
+        self.info = bittensor.SubnetInfo.from_parameter_dict( state_dict['info'] ) if 'info' in state_dict else None
         return self
 
     def sync ( self, netuid: int, subtensor: 'bittensor.Subtensor' = None, block: Optional[int] = None ) -> 'Metagraph':

--- a/bittensor/_neuron/text/core_validator/__init__.py
+++ b/bittensor/_neuron/text/core_validator/__init__.py
@@ -482,7 +482,7 @@ class neuron:
                 # console message - validator identifier status (every 25 validation steps)
                 self.vlogger.print_console_validator_identifier(self.uid, self.wallet, self.dendrite.receptor_pool.external_ip)
                 # console message - validator update status (every 25 validation steps)
-                self.vlogger.print_console_metagraph_status(self.uid, self.metagraph, current_block, start_block, self.subtensor.network)
+                self.vlogger.print_console_metagraph_status(self.uid, self.metagraph, current_block, start_block, self.subtensor.network, self.config.netuid)
                 # save neuron_stats to filesystem
                 self.save()
 

--- a/bittensor/_neuron/text/log_utilities.py
+++ b/bittensor/_neuron/text/log_utilities.py
@@ -371,7 +371,8 @@ class ValidatorLogger:
         metagraph: 'bittensor.Metagraph', 
         current_block: int, 
         start_block: int, 
-        network: str
+        network: str,
+        netuid: int
     ):
         r""" Console print for current validator's metagraph status. 
         """
@@ -381,7 +382,7 @@ class ValidatorLogger:
         f'Updated [yellow]{current_block - metagraph.last_update[uid]}[/yellow] [dim]blocks ago[/dim] | '
         f'Dividends [green not bold]{metagraph.dividends[uid]:.5f}[/green not bold] | '
         f'Stake \u03C4[magenta not bold]{metagraph.stake[uid]:.5f}[/magenta not bold] '
-        f'[dim](retrieved [yellow]{current_block - start_block}[/yellow] blocks ago from {network})[/dim]')
+        f'[dim](retrieved [yellow]{current_block - start_block}[/yellow] blocks ago from {network}:{netuid})[/dim]')
 
     def print_console_query_summary(
         self, 

--- a/bittensor/_subtensor/__init__.py
+++ b/bittensor/_subtensor/__init__.py
@@ -81,7 +81,10 @@ class subtensor:
         # Select using chain_endpoint arg.
         if chain_endpoint != None:
             config.subtensor.chain_endpoint = chain_endpoint
-            config.subtensor.network = network
+            if network != None:
+                config.subtensor.network = network
+            else:
+                config.subtensor.network = config.subtensor.get('network', bittensor.defaults.subtensor.network)
             
         # Select using network arg.
         elif network != None:

--- a/bittensor/_subtensor/chain_data.py
+++ b/bittensor/_subtensor/chain_data.py
@@ -20,6 +20,7 @@ from typing import List, Tuple, Dict
 import bittensor
 from bittensor import Balance
 import scalecodec
+import torch
 
 
 # Constants
@@ -267,7 +268,21 @@ class SubnetInfo:
             blocks_since_epoch = json['blocks_since_last_step'],
             tempo = json['tempo'],
             modality = json['network_modality'],
-            connection_requirements= json['network_connect'],
+            connection_requirements = {
+                str(int(netuid)): int(req) for netuid, req in json['network_connect']
+            },
             emission_value= json['emission_values'],
         )
     
+    def to_parameter_dict( self ) -> 'torch.nn.ParameterDict':
+        r""" Returns a torch tensor of the subnet info.
+        """
+        return torch.nn.ParameterDict( 
+            self.__dict__
+        )
+    
+    @classmethod
+    def from_parameter_dict( cls, parameter_dict: 'torch.nn.ParameterDict' ) -> 'SubnetInfo':
+        r""" Returns a SubnetInfo object from a torch parameter_dict.
+        """
+        return cls( **dict(parameter_dict) )

--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -790,14 +790,25 @@ class Subtensor:
             metagraph ( `bittensor.Metagraph` ):
                 The metagraph for the subnet at the block.
         """
+        status: Optional['rich.console.Status'] = None
         if bittensor.__use_console__:
-            with bittensor.__console__.status("Synchronizing Metagraph...", spinner="earth"):
-                neurons = self.neurons( netuid = netuid, block = block )
-        else:
-            neurons = self.neurons( netuid = netuid, block = block )
+            status = bittensor.__console__.status("Synchronizing Metagraph...", spinner="earth").start()
+        
+        # Get neurons.
+        neurons = self.neurons( netuid = netuid, block = block )
+        # Get subnet info.
+        subnet_info: Optional[bittensor.SubnetInfo] = self.get_subnet_info( netuid = netuid, block = block )
+        if subnet_info == None:
+            status.stop() if status else ...
+            raise ValueError('Could not find subnet info for netuid: {}'.format(netuid))
+
+        status.stop() if status else ...
+
         # Create metagraph.
         block_number = self.block
-        metagraph = bittensor.metagraph.from_neurons( network = self.network, neurons = neurons, netuid = netuid, block = block_number )
+
+        metagraph = bittensor.metagraph.from_neurons( network = self.network, netuid = netuid, info = subnet_info, neurons = neurons, block = block_number )
+        print("Metagraph subtensor: ", self.network)
         return metagraph
 
 


### PR DESCRIPTION
This PR adds an `info: SubnetInfo` attribute to `Metagraph` and allows it to be saved and loaded from/to the metagraph file.  