### PR TITLE
default use finney for network

### DIFF
--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -54,10 +54,11 @@ class cli:
         if config.subtensor:
             network = config.subtensor.get('network', bittensor.defaults.subtensor.network)
 
-        if network == 'finney':
-            return cli_impl.CLI( config = config)
-        elif network == 'nakamoto':
+        if network == 'nakamoto':
+            # Use nakamoto version of the CLI
             return naka_CLI(config=config)
+        else:
+            return cli_impl.CLI( config = config)
 
     @staticmethod   
     def config(args: List[str]) -> 'bittensor.config':

--- a/bittensor/_subtensor/__init__.py
+++ b/bittensor/_subtensor/__init__.py
@@ -119,12 +119,13 @@ class subtensor:
         subtensor.check_config( config )
         network = config.subtensor.get('network', bittensor.defaults.subtensor.network)
         if network == 'nakamoto':
+            # Use nakamoto-specific subtensor.
             return Nakamoto_subtensor( 
                 substrate = substrate,
                 network = config.subtensor.get('network', bittensor.defaults.subtensor.network),
                 chain_endpoint = config.subtensor.chain_endpoint,
             )
-        elif network =='finney':
+        else:
             return subtensor_impl.Subtensor( 
                 substrate = substrate,
                 network = config.subtensor.get('network', bittensor.defaults.subtensor.network),


### PR DESCRIPTION
This PR makes the default network a finney-type network, instead of relying on specific network naming.