### PR TITLE
recycled_register

### DIFF
--- a/bittensor/_cli/__init__.py
+++ b/bittensor/_cli/__init__.py
@@ -160,7 +160,7 @@ class cli:
             DelegateUnstakeCommand.check_config( config )
         elif config.command == "my_delegates":
             MyDelegatesCommand.check_config( config )
-        elif config.command == "burned_register":
+        elif config.command == "recycled_register":
             BurnedRegisterCommand.check_config( config )
         else:
             console.print(":cross_mark:[red]Unknown command: {}[/red]".format(config.command))

--- a/bittensor/_cli/cli_impl.py
+++ b/bittensor/_cli/cli_impl.py
@@ -90,6 +90,6 @@ class CLI:
             ListDelegatesCommand.run( self )
         elif self.config.command == 'list_subnets':
             ListSubnetsCommand.run( self )
-        elif self.config.command == 'burned_register':
+        elif self.config.command == 'recycled_register':
             BurnedRegisterCommand.run( self )
         

--- a/bittensor/_cli/commands/register.py
+++ b/bittensor/_cli/commands/register.py
@@ -101,7 +101,7 @@ class BurnedRegisterCommand:
 
     @staticmethod
     def run( cli ):
-        r""" Register neuron by burning some TAO. """
+        r""" Register neuron by recycling some TAO. """
         wallet = bittensor.wallet( config = cli.config )
         subtensor = bittensor.subtensor( config = cli.config )
 
@@ -116,11 +116,11 @@ class BurnedRegisterCommand:
 
         # Check balance is sufficient
         if balance < current_burn:
-            bittensor.__console__.print(f"[red]Insufficient balance {balance} to register neuron. Current burn is {current_burn} TAO[/red]")
+            bittensor.__console__.print(f"[red]Insufficient balance {balance} to register neuron. Current recycle is {current_burn} TAO[/red]")
             sys.exit(1)
 
         if not cli.config.no_prompt:
-            if Confirm.ask(f"Your balance is: [bold green]{balance}[/bold green]\nThe cost to register by burn is [bold red]{current_burn}[/bold red]\nDo you want to continue?", default = False) == False:
+            if Confirm.ask(f"Your balance is: [bold green]{balance}[/bold green]\nThe cost to register by recycle is [bold red]{current_burn}[/bold red]\nDo you want to continue?", default = False) == False:
                 sys.exit(1)
         
         subtensor.burned_register(
@@ -133,7 +133,7 @@ class BurnedRegisterCommand:
     @staticmethod
     def add_args( parser: argparse.ArgumentParser ):
         burned_register_parser = parser.add_parser(
-            'burned_register', 
+            'recycled_register', 
             help='''Register a wallet to a network.'''
         )
         burned_register_parser.add_argument( 

--- a/bittensor/_subtensor/extrinsics/registration.py
+++ b/bittensor/_subtensor/extrinsics/registration.py
@@ -189,7 +189,7 @@ def burned_register_extrinsic (
     wait_for_finalization: bool = True,
     prompt: bool = False
 ) -> bool:
-    r""" Registers the wallet to chain by burning TAO.
+    r""" Registers the wallet to chain by recycling TAO.
     Args:
         wallet (bittensor.wallet):
             bittensor wallet object.
@@ -231,10 +231,10 @@ def burned_register_extrinsic (
         
     if prompt:
         # Prompt user for confirmation.
-        if not Confirm.ask( f"Burn {burn_amount} to register on subnet:{netuid}?" ):
+        if not Confirm.ask( f"Recycle {burn_amount} to register on subnet:{netuid}?" ):
             return False
 
-    with bittensor.__console__.status(":satellite: Burning TAO for Registration..."):
+    with bittensor.__console__.status(":satellite: Recycling TAO for Registration..."):
        with subtensor.substrate as substrate:
             # create extrinsic call
             call = substrate.compose_call( 

--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -209,7 +209,7 @@ class Subtensor:
         wait_for_finalization: bool = True,
         prompt: bool = False
     ) -> bool:
-        """ Registers the wallet to chain by burning TAO."""
+        """ Registers the wallet to chain by recycling TAO."""
         return burned_register_extrinsic( 
             subtensor = self, 
             wallet = wallet, 

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -1872,7 +1872,7 @@ class TestCLIWithNetworkAndConfig(unittest.TestCase):
       
     def test_burned_register( self ):
         config = self.config
-        config.command = "burned_register"
+        config.command = "recycled_register"
         config.no_prompt = True
 
         mock_wallet = generate_wallet()


### PR DESCRIPTION
this is a hotfix to replace burned_register with a more accurate name, receycled_register. Please note that this only changes the user prompts and the CLI command. The original burn code remains the same until I sufficiently test it.