### PR TITLE
set weights era parameter

### DIFF
--- a/bittensor/_subtensor/extrinsics/set_weights.py
+++ b/bittensor/_subtensor/extrinsics/set_weights.py
@@ -90,7 +90,8 @@ def set_weights_extrinsic(
                         'version_key': version_key,
                     }
                 )
-                extrinsic = substrate.create_signed_extrinsic( call = call, keypair = wallet.hotkey )
+                # Period dictates how long the extrinsic will stay as part of waiting pool
+                extrinsic = substrate.create_signed_extrinsic( call = call, keypair = wallet.hotkey, era={'period':100})
                 response = substrate.submit_extrinsic( extrinsic, wait_for_inclusion = wait_for_inclusion, wait_for_finalization = wait_for_finalization )
                 # We only wait here if we expect finalization.
                 if not wait_for_finalization and not wait_for_inclusion:


### PR DESCRIPTION
- Adds the era parameter to signed extrinsics. This ensures that waiting transactions are not immortal and will be discarded by the time the next set_weights extrinsics is submitted
(https://github.com/polkascan/py-substrate-interface/blob/master/substrateinterface/base.py#L1474)