### PR TITLE
1052 dont prompt defaults

### DIFF
--- a/bittensor/_axon/__init__.py
+++ b/bittensor/_axon/__init__.py
@@ -159,6 +159,11 @@ class axon:
     def add_args(cls, parser: argparse.ArgumentParser, prefix: str = None):
         """Accept specific arguments from parser"""
         prefix_str = "" if prefix is None else prefix + "."
+        if prefix is not None:
+            if not hasattr(bittensor.defaults, prefix):
+                setattr(bittensor.defaults, prefix, bittensor.Config())
+            getattr(bittensor.defaults, prefix).axon = bittensor.defaults.axon
+
         bittensor.prioritythreadpool.add_args(parser, prefix=prefix_str + "axon")
         try:
             parser.add_argument(

--- a/bittensor/_cli/commands/delegates.py
+++ b/bittensor/_cli/commands/delegates.py
@@ -281,10 +281,7 @@ class DelegateUnstakeCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        # if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
-        #     config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
-
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -527,7 +524,7 @@ class MyDelegatesCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if not config.get( 'all', d=None ) and config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.get( 'all', d=None ) and not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 

--- a/bittensor/_cli/commands/delegates.py
+++ b/bittensor/_cli/commands/delegates.py
@@ -206,7 +206,7 @@ class DelegateStakeCommand:
             config.delegate_ss58key = str(delegates[int(delegate_index)].hotkey_ss58)
             console.print("Selected: [yellow]{}[/yellow]".format(config.delegate_ss58key))
 
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
@@ -410,11 +410,11 @@ class NominateCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if not config.is_set('wallet.hotkey') and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 

--- a/bittensor/_cli/commands/inspect.py
+++ b/bittensor/_cli/commands/inspect.py
@@ -139,7 +139,7 @@ class InspectCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if not config.get( 'all', d=None ) and config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.get( 'all', d=None ) and not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 

--- a/bittensor/_cli/commands/overview.py
+++ b/bittensor/_cli/commands/overview.py
@@ -333,7 +333,7 @@ class OverviewCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt and not config.get( 'all', d=None ):
+        if not config.is_set('wallet.name') and not config.no_prompt and not config.get( 'all', d=None ):
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 

--- a/bittensor/_cli/commands/register.py
+++ b/bittensor/_cli/commands/register.py
@@ -158,15 +158,15 @@ class RecycleRegisterCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.subtensor.get('network') == bittensor.defaults.subtensor.network and not config.no_prompt:
+        if not config.is_set('subtensor.network') and not config.no_prompt:
             config.subtensor.network = Prompt.ask("Enter subtensor network", choices=bittensor.__networks__, default = bittensor.defaults.subtensor.network)
 
         check_netuid_set( config, subtensor = bittensor.subtensor( config = config ) )
 
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if not config.is_set('wallet.hotkey') and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)

--- a/bittensor/_cli/commands/register.py
+++ b/bittensor/_cli/commands/register.py
@@ -83,11 +83,11 @@ class RegisterCommand:
     def check_config( config: 'bittensor.Config' ):
         check_netuid_set( config, subtensor = bittensor.subtensor( config = config ) )
 
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if not config.is_set('wallet.hotkey') and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 

--- a/bittensor/_cli/commands/stake.py
+++ b/bittensor/_cli/commands/stake.py
@@ -137,11 +137,11 @@ class StakeCommand:
 
     @classmethod
     def check_config( cls, config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt and not config.get('all_hotkeys') and not config.get('hotkeys'):
+        if not config.is_set('wallet.hotkey') and not config.no_prompt and not config.wallet.get('all_hotkeys') and not config.wallet.get('hotkeys'):
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 

--- a/bittensor/_cli/commands/transfer.py
+++ b/bittensor/_cli/commands/transfer.py
@@ -33,7 +33,7 @@ class TransferCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 

--- a/bittensor/_cli/commands/unstake.py
+++ b/bittensor/_cli/commands/unstake.py
@@ -26,13 +26,13 @@ console = bittensor.__console__
 
 class UnStakeCommand:
 
-    @classmethod
-    def check_config( cls, config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name and not config.no_prompt:
+    @classmethod   
+    def check_config( cls, config: 'bittensor.Config' ):        
+        if config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if not config.get('hotkey_ss58address') and config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt and not config.get('all_hotkeys') and not config.get('hotkeys'):
+        if not config.get( 'hotkey_ss58address', d=None ) and config.is_set('wallet.hotkey') and not config.no_prompt and not config.get('all_hotkeys') and not config.get('hotkeys'):
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 

--- a/bittensor/_cli/commands/utils.py
+++ b/bittensor/_cli/commands/utils.py
@@ -45,7 +45,7 @@ def check_netuid_set( config: 'bittensor.Config', subtensor: 'bittensor.Subtenso
             sys.exit()
 
         # Make sure netuid is set.
-        if config.get('netuid', 'notset') == 'notset':
+        if not config.is_set('netuid'):
             if not config.no_prompt:
                 netuid = IntListPrompt.ask("Enter netuid", choices=all_netuids, default=str(all_netuids[0]))
             else:

--- a/bittensor/_cli/commands/utils.py
+++ b/bittensor/_cli/commands/utils.py
@@ -38,7 +38,7 @@ class IntListPrompt(PromptBase):
 
 
 def check_netuid_set( config: 'bittensor.Config', subtensor: 'bittensor.Subtensor', allow_none: bool = False ):
-    if subtensor.network =='finney':
+    if subtensor.network != 'nakamoto':
         all_netuids = [str(netuid) for netuid in subtensor.get_subnets()]
         if len(all_netuids) == 0:
             console.print(":cross_mark:[red]There are no open networks.[/red]")

--- a/bittensor/_cli/commands/wallets.py
+++ b/bittensor/_cli/commands/wallets.py
@@ -44,7 +44,7 @@ class RegenColdkeyCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
         if config.mnemonic == None and config.get( 'seed', d=None ) == None and config.get( 'json', d=None ) == None:
@@ -128,7 +128,7 @@ class RegenColdkeypubCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
         if config.ss58_address == None and config.public_key_hex == None:
@@ -204,11 +204,11 @@ class RegenHotkeyCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if not config.is_set('wallet.hotkey') and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
         if config.mnemonic == None and config.get( 'seed', d=None ) == None and config.get( 'json', d=None ) == None:
@@ -295,11 +295,11 @@ class NewHotkeyCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if config.wallet.get('hotkey') == bittensor.defaults.wallet.hotkey and not config.no_prompt:
+        if not config.is_set('wallet.hotkey') and not config.no_prompt:
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 
@@ -351,7 +351,7 @@ class NewColdkeyCommand:
 
     @staticmethod
     def check_config( config: 'bittensor.Config' ):
-        if config.wallet.get('name') == bittensor.defaults.wallet.name  and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 

--- a/bittensor/_config/config_impl.py
+++ b/bittensor/_config/config_impl.py
@@ -71,7 +71,8 @@ class Config ( Munch ):
             prometheus_info = Info('config', 'Config Values')
             # Make copy, remove __is_set map
             config_copy = copy.deepcopy(self)
-            del config_copy.__is_set
+
+            del config_copy['__is_set']
 
             config_info = json_normalize(json.loads(json.dumps(config_copy)), sep='.').to_dict(orient='records')[0]
             formatted_info = {}

--- a/bittensor/_config/config_impl.py
+++ b/bittensor/_config/config_impl.py
@@ -113,6 +113,8 @@ class Config ( Munch ):
                 a = self
                 keys = key.split('.')
                 for key_ in keys[:-1]:
+                    if key_ not in a:
+                        a[key_] = {}
                     a = a[key_]
                 # Set leaf to default value
                 a[keys[-1]] = val

--- a/bittensor/_config/config_impl.py
+++ b/bittensor/_config/config_impl.py
@@ -25,11 +25,17 @@ import pandas
 import bittensor
 from munch import Munch
 from prometheus_client import Info
+from pandas import json_normalize
+from typing import Dict
+import copy
+import bittensor
 
 class Config ( Munch ):
     """
     Implementation of the config class, which manages the config of different bittensor modules.
     """
+    __is_set: Dict[str, bool]
+
     def __init__(self, loaded_config = None ):
         super().__init__()
         if loaded_config:
@@ -63,7 +69,11 @@ class Config ( Munch ):
         """
         try:
             prometheus_info = Info('config', 'Config Values')
-            config_info = pandas.json_normalize(json.loads(json.dumps(self)), sep='.').to_dict(orient='records')[0]
+            # Make copy, remove __is_set map
+            config_copy = copy.deepcopy(self)
+            del config_copy.__is_set
+
+            config_info = json_normalize(json.loads(json.dumps(config_copy)), sep='.').to_dict(orient='records')[0]
             formatted_info = {}
             for key in config_info:
                 config_info[key] = str(config_info[key])
@@ -73,6 +83,38 @@ class Config ( Munch ):
             # The user called this function twice in the same session.
             # TODO(const): need a way of distinguishing the various config items.
             bittensor.__console__.print("The config has already been added to prometheus.", highlight=True)
+
+    def is_set(self, param_name: str) -> bool:
+        """
+        Returns a boolean indicating whether the parameter has been set or is still the default.
+        """
+        if param_name not in self.get('__is_set'):
+            return False
+        else:
+            return self.get('__is_set')[param_name]
+
+    def __fill_with_defaults__(self, is_set_map: Dict[str, bool], defaults: 'Config') -> None:
+        """
+        Recursively fills the config with the default values using is_set_map
+        """
+        defaults_filtered = {}
+        for key in self.keys():
+            if key in defaults.keys():
+                defaults_filtered[key] = getattr(defaults, key)
+
+        flat_defaults = json_normalize(defaults_filtered, sep='.').to_dict('records')[0]
+        for key, val in flat_defaults.items():
+            if key not in is_set_map:
+                continue
+            elif not is_set_map[key]:
+                # If the key is not set, set it to the default value
+                # Loop through flattened key to get leaf
+                a = self
+                keys = key.split('.')
+                for key_ in keys[:-1]:
+                    a = a[key_]
+                # Set leaf to default value
+                a[keys[-1]] = val
 
     def to_defaults(self):
         try:

--- a/bittensor/_dataset/__init__.py
+++ b/bittensor/_dataset/__init__.py
@@ -134,6 +134,10 @@ class dataset:
         """ Accept specific arguments from parser
         """
         prefix_str = '' if prefix == None else prefix + '.'
+        if prefix is not None:
+            if not hasattr(bittensor.defaults, prefix):
+                setattr(bittensor.defaults, prefix, bittensor.Config())
+            getattr(bittensor.defaults, prefix).dataset = bittensor.defaults.dataset
         try:
             parser.add_argument('--' + prefix_str + 'dataset.batch_size', type=int, help='Batch size.', default = bittensor.defaults.dataset.batch_size)
             parser.add_argument('--' + prefix_str + 'dataset.block_size', type=int, help='Number of text items to pull for each example..', default = bittensor.defaults.dataset.block_size)

--- a/bittensor/_logging/__init__.py
+++ b/bittensor/_logging/__init__.py
@@ -143,6 +143,10 @@ class logging:
         """ Accept specific arguments fro parser
         """
         prefix_str = '' if prefix == None else prefix + '.'
+        if prefix is not None:
+            if not hasattr(bittensor.defaults, prefix):
+                setattr(bittensor.defaults, prefix, bittensor.Config())
+            getattr(bittensor.defaults, prefix).logging = bittensor.defaults.logging
         try:
             parser.add_argument('--' + prefix_str + 'logging.debug', action='store_true', help='''Turn on bittensor debugging information''', default = bittensor.defaults.logging.debug )
             parser.add_argument('--' + prefix_str + 'logging.trace', action='store_true', help='''Turn on bittensor trace level information''', default = bittensor.defaults.logging.trace )

--- a/bittensor/_prometheus/__init__.py
+++ b/bittensor/_prometheus/__init__.py
@@ -149,6 +149,10 @@ class prometheus:
         """ Accept specific arguments from parser
         """
         prefix_str = '' if prefix == None else prefix + '.'
+        if prefix is not None:
+            if not hasattr(bittensor.defaults, prefix):
+                setattr(bittensor.defaults, prefix, bittensor.Config())
+            getattr(bittensor.defaults, prefix).prometheus = bittensor.defaults.prometheus
         try:
             parser.add_argument('--' + prefix_str + 'prometheus.port',  type=int, required=False, default = bittensor.defaults.prometheus.port,
                 help='''Prometheus serving port.''')

--- a/bittensor/_subtensor/__init__.py
+++ b/bittensor/_subtensor/__init__.py
@@ -141,6 +141,10 @@ class subtensor:
     @classmethod
     def add_args(cls, parser: argparse.ArgumentParser, prefix: str = None ):
         prefix_str = '' if prefix == None else prefix + '.'
+        if prefix is not None:
+            if not hasattr(bittensor.defaults, prefix):
+                setattr(bittensor.defaults, prefix, bittensor.Config())
+            getattr(bittensor.defaults, prefix).subtensor = bittensor.defaults.subtensor
         try:
             parser.add_argument('--' + prefix_str + 'subtensor.network', default = argparse.SUPPRESS, type=str,
                                 help='''The subtensor network flag. The likely choices are:

--- a/bittensor/_subtensor/__init__.py
+++ b/bittensor/_subtensor/__init__.py
@@ -142,7 +142,7 @@ class subtensor:
     def add_args(cls, parser: argparse.ArgumentParser, prefix: str = None ):
         prefix_str = '' if prefix == None else prefix + '.'
         try:
-            parser.add_argument('--' + prefix_str + 'subtensor.network', default = bittensor.defaults.subtensor.network, type=str,
+            parser.add_argument('--' + prefix_str + 'subtensor.network', default = argparse.SUPPRESS, type=str,
                                 help='''The subtensor network flag. The likely choices are:
                                         -- finney (main network)
                                         -- local (local running network)

--- a/bittensor/_threadpool/__init__.py
+++ b/bittensor/_threadpool/__init__.py
@@ -55,6 +55,10 @@ class prioritythreadpool:
         """ Accept specific arguments from parser
         """
         prefix_str = '' if prefix == None else prefix + '.'
+        if prefix is not None:
+            if not hasattr(bittensor.defaults, prefix):
+                setattr(bittensor.defaults, prefix, bittensor.Config())
+            getattr(bittensor.defaults, prefix).priority = bittensor.defaults.priority
         try:
             parser.add_argument('--' + prefix_str + 'priority.max_workers', type = int, help='''maximum number of threads in thread pool''', default = bittensor.defaults.priority.max_workers)
             parser.add_argument('--' + prefix_str + 'priority.maxsize', type=int, help='''maximum size of tasks in priority queue''', default = bittensor.defaults.priority.maxsize)

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -108,8 +108,8 @@ class wallet:
         """
         prefix_str = '' if prefix == None else prefix + '.'
         try:
-            parser.add_argument('--' + prefix_str + 'wallet.name', required=False, default=bittensor.defaults.wallet.name, help='''The name of the wallet to unlock for running bittensor (name mock is reserved for mocking this wallet)''')
-            parser.add_argument('--' + prefix_str + 'wallet.hotkey', required=False, default=bittensor.defaults.wallet.hotkey, help='''The name of wallet's hotkey.''')
+            parser.add_argument('--' + prefix_str + 'wallet.name', required=False, default=argparse.SUPPRESS, help='''The name of the wallet to unlock for running bittensor (name mock is reserved for mocking this wallet)''')
+            parser.add_argument('--' + prefix_str + 'wallet.hotkey', required=False, default=argparse.SUPPRESS, help='''The name of wallet's hotkey.''')
             parser.add_argument('--' + prefix_str + 'wallet.path', required=False, default=bittensor.defaults.wallet.path, help='''The path to your bittensor wallets''')
             parser.add_argument('--' + prefix_str + 'wallet._mock', action='store_true', default=bittensor.defaults.wallet._mock, help='To turn on wallet mocking for testing purposes.')
 

--- a/bittensor/_wallet/__init__.py
+++ b/bittensor/_wallet/__init__.py
@@ -107,6 +107,10 @@ class wallet:
         """ Accept specific arguments from parser
         """
         prefix_str = '' if prefix == None else prefix + '.'
+        if prefix is not None:
+            if not hasattr(bittensor.defaults, prefix):
+                setattr(bittensor.defaults, prefix, bittensor.Config())
+            getattr(bittensor.defaults, prefix).wallet = bittensor.defaults.wallet
         try:
             parser.add_argument('--' + prefix_str + 'wallet.name', required=False, default=argparse.SUPPRESS, help='''The name of the wallet to unlock for running bittensor (name mock is reserved for mocking this wallet)''')
             parser.add_argument('--' + prefix_str + 'wallet.hotkey', required=False, default=argparse.SUPPRESS, help='''The name of wallet's hotkey.''')

--- a/tests/integration_tests/test_cli_no_network.py
+++ b/tests/integration_tests/test_cli_no_network.py
@@ -341,5 +341,115 @@ class TestCLINoNetwork(unittest.TestCase):
 
                             assert cli.config.subtensor.register.cuda.use_cuda == False
 
+
+class TestCLIDefaultsNoNetwork(unittest.TestCase):
+    _patched_subtensor = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        mock_delegate_info = {
+            "hotkey_ss58": "",
+            "total_stake": bittensor.Balance.from_rao(0),
+            "nominators": [],
+            "owner_ss58": "",
+            "take": 0.18, 
+            "validator_permits": [],
+            "registrations": [], 
+            "return_per_1000": bittensor.Balance.from_rao(0), 
+            "total_daily_return": bittensor.Balance.from_rao(0)
+        }
+        cls._patched_subtensor = patch('bittensor._subtensor.subtensor_mock.mock_subtensor.mock', new=MagicMock(
+            return_value=MagicMock(
+                get_subnets=MagicMock(return_value=[1]), # Mock subnet 1 ONLY.
+                block=10_000,
+                get_delegates=MagicMock(return_value=[
+                    bittensor.DelegateInfo( **mock_delegate_info )
+                ]),
+            )
+        ))
+        cls._patched_subtensor.start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._patched_subtensor.stop()
+
+    def test_inspect_prompt_wallet_name(self):
+        # Patch command to exit early
+        with patch('bittensor._cli.commands.inspect.InspectCommand.run', return_value=None):
+
+            # Test prompt happens when no wallet name is passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                cli = bittensor.cli(args=[
+                        'inspect',
+                        # '--wallet.name', 'mock',
+                    ])
+                cli.run()
+
+                # Prompt happened
+                mock_ask_prompt.assert_called_once()
+
+            # Test NO prompt happens when wallet name is passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                cli = bittensor.cli(args=[
+                        'inspect',
+                        '--wallet.name', 'coolwalletname',
+                    ])
+                cli.run()
+
+                # NO prompt happened
+                mock_ask_prompt.assert_not_called()
+
+            # Test NO prompt happens when wallet name 'default' is passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                cli = bittensor.cli(args=[
+                        'inspect',
+                        '--wallet.name', 'default',
+                    ])
+                cli.run()
+
+                # NO prompt happened
+                mock_ask_prompt.assert_not_called()
+
+    def test_overview_prompt_wallet_name(self):
+        # Patch command to exit early
+        with patch('bittensor._cli.commands.overview.OverviewCommand.run', return_value=None):
+
+            # Test prompt happens when no wallet name is passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                cli = bittensor.cli(args=[
+                        'overview',
+                        # '--wallet.name', 'mock',
+                        '--netuid', '1'
+                    ])
+                cli.run()
+
+                # Prompt happened
+                mock_ask_prompt.assert_called_once()
+
+            # Test NO prompt happens when wallet name is passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                cli = bittensor.cli(args=[
+                        'overview',
+                        '--wallet.name', 'coolwalletname',
+                        '--netuid', '1',
+                    ])
+                cli.run()
+
+                # NO prompt happened
+                mock_ask_prompt.assert_not_called()
+
+            # Test NO prompt happens when wallet name 'default' is passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                cli = bittensor.cli(args=[
+                        'overview',
+                        '--wallet.name', 'default',
+                        '--netuid', '1',
+                    ])
+                cli.run()
+
+                # NO prompt happened
+                mock_ask_prompt.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Re-open/cherry-pick of #1054

> This PR adds a map `Config.__is_set` to the `Config` class.  
>This map is from the flattened parameter name (e.g. `config.subtensor.network` -> `config.__is_set["subtensor.network"]`) to a boolean value indicating if the value has been set in a flag (or not).  
>
>This map is created from the defaults set in `bittensor.defaults` on creation of the config, from the parser. Any args that use `default=argparse.SUPPRESS` will be set to `False` in the map unless they are set as a flag. 
>
>Then, the config will be filled with the default values for these flags, avoiding a breaking change to the config class.  
>
>You can then check if any of these args are set using `config.is_set('subtensor.network')`.  
>
>The result, is we don't require prompting the user for values that are set, even if the arg is equal to the default. i.e. `btcli --subtensor.network finney` will not prompt for network again. 

Closes #1052 