### PR TITLE
Nonce security update

### DIFF
--- a/bittensor/_keyfile/keyfile_impl.py
+++ b/bittensor/_keyfile/keyfile_impl.py
@@ -90,7 +90,7 @@ def deserialize_keypair_from_keyfile_data( keyfile_data:bytes ) -> 'bittensor.Ke
                 'ss58Address': string_value
             }
         else:
-            raise KeyFileError('Keypair could not be created from keyfile data: {}'.format( string_value ))
+            raise KeyFileError('Keypair could not be created from keyfile data')
 
     if "secretSeed" in keyfile_dict and keyfile_dict['secretSeed'] != None:
         return bittensor.Keypair.create_from_seed(keyfile_dict['secretSeed'])
@@ -102,7 +102,12 @@ def deserialize_keypair_from_keyfile_data( keyfile_data:bytes ) -> 'bittensor.Ke
         return bittensor.Keypair( ss58_address = keyfile_dict['ss58Address'] )
 
     else:
-        raise KeyFileError('Keypair could not be created from keyfile data: {}'.format( keyfile_dict ))
+        raise KeyFileError('Keypair could not be created from keyfile data: {}'.format( 
+            {
+                'accountId': keyfile_dict['accountId'],
+                'publicKey': keyfile_dict['publicKey'],
+            }
+        ))
 
 def validate_password( password:str ) -> bool:
     """ Validates the password again a password policy.
@@ -243,7 +248,7 @@ def decrypt_keyfile_data(keyfile_data: bytes, password: str = None, coldkey_name
                 decrypted_keyfile_data = cipher_suite.decrypt( keyfile_data )   
             # Unknown.
             else: 
-                raise KeyFileError( "Keyfile data: {} is corrupt".format( keyfile_data ))
+                raise KeyFileError( "Keyfile data is corrupted.")
 
     except (InvalidSignature, InvalidKey, InvalidToken):
         raise KeyFileError('Invalid password')


### PR DESCRIPTION
This PR would address the following from the weekly security status report (28 Mar). 

Point 3
- removed uncessary keyfile data print

Point 5 
- nonce should be bounded by a +/- block_time
- nonce key (ss58_address) should be validated by suvvessful decoding before being written to memory
- added pruning when the nonces dictionary grow to big so that the memory for it would not grow indefinitely  