### PR TITLE
Rename requiremenets.txt to requirements.txt

### DIFF
--- a/neurons/text/prompting/miners/pythia/requiremenets.txt
+++ b/neurons/text/prompting/miners/pythia/requiremenets.txt
@@ -1,1 +1,0 @@
-transformers

--- a/neurons/text/prompting/miners/pythia/requirements.txt
+++ b/neurons/text/prompting/miners/pythia/requirements.txt
@@ -1,0 +1,1 @@
+transformers


### PR DESCRIPTION
Fixing a typo in the `requirements.txt` file