### PR TITLE
Fix Bug with Miner recieving messages in list of strings instead of list of dicts

### DIFF
--- a/bittensor/_synapse/text_prompting/synapse.py
+++ b/bittensor/_synapse/text_prompting/synapse.py
@@ -21,6 +21,7 @@ import bittensor
 
 from typing import List, Dict, Union, Callable
 from abc import ABC, abstractmethod
+import json
 
 class SynapseForward( bittensor.SynapseCall ):
     name: str = "text_prompting_forward"
@@ -35,7 +36,7 @@ class SynapseForward( bittensor.SynapseCall ):
         ):
         super().__init__( synapse = synapse, request_proto = request_proto )
         self.messages = request_proto.messages
-        self.formatted_messages = [ message for message in self.messages ]
+        self.formatted_messages = [ json.loads(message) for message in self.messages ]
         self.forward_callback = forward_callback
 
     def apply( self ):


### PR DESCRIPTION
This PR fixes #1292 

On the previous version of bittensor/_synapse/text_prompting/synapse.py (https://github.com/opentensor/bittensor/blob/eff272409704d801ce337a2ce850ba49368848d5/bittensor/_synapse/text_prompting/synapse.py)
On line 57 it is:

`formatted_messages = [ json.loads(message) for message in forward_call.messages ]`

The most recent update to the file made yesterday, had the json.loads function removed, causing the error:

`self.formatted_messages = [ message for message in self.messages ]`

So I simply added import of json and json loading the messages.

I will test the solution today to make doubly sure it solves the issue.