### PR TITLE
fix blocks since last update for server

### DIFF
--- a/bittensor/_synapse/text_prompting/miner.py
+++ b/bittensor/_synapse/text_prompting/miner.py
@@ -224,7 +224,7 @@ class BasePromptingMiner( ABC ):
             last_update = self.subtensor.get_current_block()
 
             # --- Update the metagraph with the latest network state.
-            self.metagraph.sync( lite = True )
+            self.metagraph.sync( netuid = 1, subtensor = self.subtensor )
             uid = self.metagraph.hotkeys.index( self.wallet.hotkey.ss58_address )
 
             # --- Log performance.


### PR DESCRIPTION
### Identify the Bug

Link to the issue describing the bug that you're fixing.

https://github.com/opentensor/bittensor/blob/text_prompting/bittensor/_synapse/text_prompting/miner.py#L227

### Description of the Change

We are syncing the wrong metagraph when updating the metagraph. This causes our blocks since last update to display incorrectly. This change sets the netuid to 1 rather than setting lite = True.

### Alternate Designs

N/A

### Possible Drawbacks

N/A

### Verification Process

Since we do not have a development branch for our second master branch ("text_prompting").. there is no way to test this change.

### Release Notes


We are syncing the wrong metagraph when updating the metagraph. This causes our blocks since last update to display incorrectly. This change sets the netuid to 1 rather than setting lite = True.

