### PR TITLE
removes miniupnpc from prod requirements

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -14,7 +14,6 @@ hypothesis==6.47.4
 loguru==0.6.0
 msgpack==1.0.4
 msgpack-numpy==0.4.7.1
-miniupnpc==2.0.2
 munch==2.5.0
 nest_asyncio==1.5.6
 netaddr==0.8.0


### PR DESCRIPTION
caused pip install to fail