### PR TITLE
Blacklist improvements

### DIFF
--- a/bittensor/_synapse/text_prompting/miner.py
+++ b/bittensor/_synapse/text_prompting/miner.py
@@ -94,8 +94,8 @@ class BasePromptingMiner( ABC ):
 
             return False, 'passed blacklist'
         except Exception as e:
-            bittensor.logging.warning( "Blacklisted. Error in `registration_check` or `stake_check()" )
-            return True, 'Error in `registration_check` or `stake_check()'
+            bittensor.logging.warning( "Blacklisted. Error in `is_registered()` or `enough_stake()` or `has_vpermit()`" )
+            return True, 'Error in `is_registered()` or `enough_stake()` or `has_vpermit()`'
 
     @abstractmethod
     def forward( self, messages: List[Dict[str, str]] ) -> str:

--- a/bittensor/_synapse/text_prompting/miner.py
+++ b/bittensor/_synapse/text_prompting/miner.py
@@ -185,7 +185,7 @@ class BasePromptingMiner( ABC ):
             '--neuron.blacklist.allow_non_registered',
             action = 'store_true',
             help = 'If True, this miner will allow non-registered hotkeys to query it.',
-            default = True
+            default = False
         )
         parser.add_argument(
             '--neuron.blacklist.default_stake',


### PR DESCRIPTION
Hi guys,

I was reviewing the code for blacklisting in the BasePromptingMiner. I was quite verbose in my commit messages but in short I noticed that:

1. The registration_check() and stake_check() functions weren't actually doing anything. The only time a blacklist would actually occur is if either of the functions encounter an error -- and this is only going to be when looking up a hotkey that isn't in the metagraph (not registered).
2. I added a new argument called neuron.blacklist.vpermit_required plus the corresponding function which requires that the neuron querying this miner has a vpermit.
3. I changed the default value of neuron.blacklist.allow_non_registered to False as the associated action is "store_true".

Also the registration_check() and stake_check() functions returned False if it was OK to proceed and True if not which I thought was confusing. I renamed the functions and reworked them a little bit.

Spent about an hour testing on a live miner in production -- encountered a few blacklists due to the amount of stake but didn't know how to test the vpermit change.

Let me know if you have any questions.
@unconst @shibshib 