### PR TITLE
Reset scores for validators

### DIFF
--- a/neurons/text/prompting/validators/core/neuron.py
+++ b/neurons/text/prompting/validators/core/neuron.py
@@ -712,6 +712,8 @@ class neuron:
         for uid, hotkey in enumerate( self.hotkeys ):
             if hotkey != self.metagraph.hotkeys[ uid ]:
                 self.moving_averaged_scores[ uid ] = 0 #hotkey has been replaced
+            if self.metagraph.validator_permit[ uid ]:
+                self.moving_averaged_scores[ uid ] = 0 # hotkey has validation rights
         if len(self.hotkeys) < len(self.metagraph.hotkeys):
             new_moving_average  = torch.zeros((self.metagraph.n)).to( self.device )
             new_moving_average[:len(self.hotkeys)] = self.moving_averaged_scores


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/opentensor/bittensor/pull/1307

This PR proposes that the weights for UIDs with a validator permit are reset on every weight check round. The reasoning is that a UID may gain a validator permit after it has been queried in the past, which in turn allows it to 'freeze' its current weights and avoid any form of decay.

#### Changes
<!-- What are the changes made in this pull request? -->

- Reset the moving averages for keys which have a validator permit.
  - The reasoning here is that keys with a validator permit are not queried during the training process - their weights do not decay and are instead stable, which affects the evaluation process of the validators.