### PR TITLE
fix example to use external_ip

### DIFF
--- a/bittensor/_axon/__init__.py
+++ b/bittensor/_axon/__init__.py
@@ -51,7 +51,7 @@ class axon:
     def __init__(
         self,
         wallet: "bittensor.Wallet",
-        metagraph: "bittensor.Metagraph",
+        metagraph: Optional["bittensor.Metagraph"] = None,
         config: Optional["bittensor.config"] = None,
         port: Optional[int] = None,
         ip: Optional[str] = None,

--- a/examples/text_prompting.py
+++ b/examples/text_prompting.py
@@ -45,6 +45,17 @@ dendrite = bittensor.text_prompting( axon = axon, keypair = wallet.hotkey )
 synapse = Synapse( axon = axon )
 axon.start()
 
+
+forward_call = dendrite.forward(
+    roles = ['system', 'assistant'],
+    messages = ['you are chat bot', 'what is the whether'],
+    timeout = 1e6
+)
+print ( forward_call )
+print ( 'success', forward_call.is_success, 'failed', forward_call.did_fail, 'timedout', forward_call.did_timeout )
+print ( 'completion', forward_call.completion )
+
+
 multi_forward_call = dendrite.multi_forward(
     roles = ['system', 'assistant'],
     messages = ['you are chat bot', 'what is the whether'],

--- a/examples/text_prompting.py
+++ b/examples/text_prompting.py
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright © 2021 Yuma Rao
+# Copyright © 2023 Yuma Rao
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 # documentation files (the “Software”), to deal in the Software without restriction, including without limitation
@@ -15,7 +15,6 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import json
 import torch
 import bittensor
 from typing import List, Dict, Union, Tuple
@@ -40,23 +39,11 @@ class Synapse( bittensor.TextPromptingSynapse ):
 
 # Create a mock wallet.
 wallet = bittensor.wallet().create_if_non_existent()
-axon = bittensor.axon( wallet = wallet, port = 9090, ip = "127.0.0.1", metagraph = None )
-dendrite = bittensor.text_prompting( axon = axon.info(), keypair = wallet.hotkey )
+axon = bittensor.axon( wallet = wallet, port = 9090, external_ip = "127.0.0.1", metagraph = None )
+
+dendrite = bittensor.text_prompting( axon = axon, keypair = wallet.hotkey )
 synapse = Synapse( axon = axon )
 axon.start()
-
-# bittensor.logging.debug( "Start example")
-# forward_call = dendrite.forward(
-#     roles = ['system', 'assistant'],
-#     messages = ['you are chat bot', 'what is the whether'],
-#     timeout = 1e6
-# )
-# print ( forward_call )
-# print ( 'success', forward_call.is_success, 'failed', forward_call.did_fail, 'timedout', forward_call.did_timeout )
-# backward_call = forward_call.backward( 1 )
-# print ( backward_call )
-# print ( 'success', backward_call.is_success, 'failed', backward_call.did_fail, 'timedout', backward_call.did_timeout )
-
 
 multi_forward_call = dendrite.multi_forward(
     roles = ['system', 'assistant'],

--- a/examples/text_prompting.py
+++ b/examples/text_prompting.py
@@ -39,7 +39,7 @@ class Synapse( bittensor.TextPromptingSynapse ):
 
 # Create a mock wallet.
 wallet = bittensor.wallet().create_if_non_existent()
-axon = bittensor.axon( wallet = wallet, port = 9090, external_ip = "127.0.0.1", metagraph = None )
+axon = bittensor.axon( wallet = wallet, port = 9090, external_ip = "127.0.0.1" )
 
 dendrite = bittensor.text_prompting( axon = axon, keypair = wallet.hotkey )
 synapse = Synapse( axon = axon )


### PR DESCRIPTION
- axon_info sets ip to be `external_ip`. We should simply change the example to use this instead of modifying `axon` or `dendrite` code.