### PR TITLE
Fix meta sync block display

### DIFF
--- a/bittensor/_metagraph/__init__.py
+++ b/bittensor/_metagraph/__init__.py
@@ -117,7 +117,7 @@ class metagraph( torch.nn.Module ):
         self.lite = lite
         self.n = torch.nn.Parameter( torch.tensor( len(self.neurons), dtype=torch.int64 ), requires_grad=False )
         self.version = torch.nn.Parameter( torch.tensor( [bittensor.__version_as_int__], dtype=torch.int64 ), requires_grad=False )
-        self.block = torch.nn.Parameter( torch.tensor( subtensor.block, dtype=torch.int64 ), requires_grad=False ) if not block else torch.nn.Parameter( torch.tensor( block, dtype=torch.int64 ), requires_grad=False )
+        self.block = torch.nn.Parameter( torch.tensor( block if block else subtensor.block, dtype=torch.int64 ), requires_grad=False )
         self.uids = torch.nn.Parameter( torch.tensor( [ neuron.uid for neuron in self.neurons ], dtype=torch.int64 ), requires_grad=False )
         self.trust = torch.nn.Parameter( torch.tensor( [ neuron.trust for neuron in self.neurons ], dtype=torch.float32 ), requires_grad=False )
         self.consensus = torch.nn.Parameter( torch.tensor( [ neuron.consensus for neuron in self.neurons ], dtype=torch.float32 ), requires_grad=False )

--- a/bittensor/_metagraph/__init__.py
+++ b/bittensor/_metagraph/__init__.py
@@ -117,7 +117,7 @@ class metagraph( torch.nn.Module ):
         self.lite = lite
         self.n = torch.nn.Parameter( torch.tensor( len(self.neurons), dtype=torch.int64 ), requires_grad=False )
         self.version = torch.nn.Parameter( torch.tensor( [bittensor.__version_as_int__], dtype=torch.int64 ), requires_grad=False )
-        self.block = torch.nn.Parameter( torch.tensor( subtensor.block, dtype=torch.int64 ), requires_grad=False )
+        self.block = torch.nn.Parameter( torch.tensor( subtensor.block, dtype=torch.int64 ), requires_grad=False ) if not block else torch.nn.Parameter( torch.tensor( block, dtype=torch.int64 ), requires_grad=False )
         self.uids = torch.nn.Parameter( torch.tensor( [ neuron.uid for neuron in self.neurons ], dtype=torch.int64 ), requires_grad=False )
         self.trust = torch.nn.Parameter( torch.tensor( [ neuron.trust for neuron in self.neurons ], dtype=torch.float32 ), requires_grad=False )
         self.consensus = torch.nn.Parameter( torch.tensor( [ neuron.consensus for neuron in self.neurons ], dtype=torch.float32 ), requires_grad=False )


### PR DESCRIPTION
### **Minor cosmetic issue**

**Problem**: Presently** metagraph sync sets its sync block at `subtensor.block` regardless of the block specified when calling `sync()`.  

**Solution**: Fix the `self.block` line to use the `block` if it's set. 