### PR TITLE
Update reward.py

### DIFF
--- a/neurons/text/prompting/validators/core/reward.py
+++ b/neurons/text/prompting/validators/core/reward.py
@@ -115,7 +115,7 @@ class RewardModel(nn.Module):
         chosen_rewards = rewards[:bs]
         rejected_rewards = rewards[bs:]
 
-        loss = 0
+        loss = -0.1
         inference = False
         for i in range(bs):
             if torch.all(torch.eq(chosen[i], rejected[i])).item():


### PR DESCRIPTION
If loss is 0, and the c_truncated_reward + r_truncated_reward = 0, then a validator with a score of 0 (those with a "Sorry, I cannot do that Dave" response) won't not get punished for sending a bad reply. This makes it so that the resulting score always needs to be positive.