### PR TITLE
[bug-fix] pin prod requirements transformers version to <=4.28.0

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -35,7 +35,7 @@ scalecodec==1.2.0
 sentencepiece==0.1.97
 termcolor==2.1.1
 torch==1.13.1
-transformers>=4.20.1
+transformers>=4.20.1,<=4.28.0
 numpy==1.21.6
 wheel==0.37.1
 tqdm==4.64.1


### PR DESCRIPTION
# Bug Fix

## Identify the Bug
Running a subnet 1 validator results in crash during startup. This began with v5.1.0 and quite possibly a contributing factor to the slow rollout of the upgrade across subnet 1 validators.

```
Downloading readme: 100%|██████████| 8.02k/8.02k [00:00<00:00, 8.92MB/s]
2023-06-05 13:03:39.672 |       INFO       | Loading reward model          
Downloading (…)lve/main/config.json: 100%|██████████| 930/930 [00:00<00:00, 7.00MB/s]
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ /root/.bittensor/bittensor/neurons/text/prompting/validators/core/neuron.py: │
│ 803 in <module>                                                              │
│                                                                              │
│   800                                                                        │
│   801 if __name__ == '__main__':                                             │
│   802 │   bittensor.logging.info( 'neuron().train()' )                       │
│ ❱ 803 │   neuron().run()                                                     │
│   804                                                                        │
│                                                                              │
│ /root/.bittensor/bittensor/neurons/text/prompting/validators/core/neuron.py: │
│ 163 in __init__                                                              │
│                                                                              │
│   160 │   │   │   │   │   checkpoint = os.path.join( self.config.neuron.rewa │
│   161 │   │   │   │   │   break                                              │
│   162 │   │   │   ckpt_state = torch.load( checkpoint )                      │
│ ❱ 163 │   │   │   self.reward_model.load_state_dict( ckpt_state )            │
│   164 │   │   │   self.reward_model.eval()                                   │
│   165 │   │   │   self.reward_model.half()                                   │
│   166 │   │   │   self.reward_model.requires_grad_( False )                  │
│                                                                              │
│ /opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py:1671 in   │
│ load_state_dict                                                              │
│                                                                              │
│   1668 │   │   │   │   │   │   ', '.join('"{}"'.format(k) for k in missing_k │
│   1669 │   │                                                                 │
│   1670 │   │   if len(error_msgs) > 0:                                       │
│ ❱ 1671 │   │   │   raise RuntimeError('Error(s) in loading state_dict for {} │
│   1672 │   │   │   │   │   │   │      self.__class__.__name__, "\n\t".join(e │
│   1673 │   │   return _IncompatibleKeys(missing_keys, unexpected_keys)       │
│   1674                                                                       │
╰──────────────────────────────────────────────────────────────────────────────╯
RuntimeError: Error(s) in loading state_dict for RewardModel:
        Unexpected key(s) in state_dict: "model.transformer.h.0.attn.bias", 
"model.transformer.h.0.attn.masked_bias", "model.transformer.h.1.attn.bias", 
"model.transformer.h.1.attn.masked_bias", "model.transformer.h.2.attn.bias", 
"model.transformer.h.2.attn.masked_bias", "model.transformer.h.3.attn.bias", 
"model.transformer.h.3.attn.masked_bias", "model.transformer.h.4.attn.bias", 
"model.transformer.h.4.attn.masked_bias", "model.transformer.h.5.attn.bias", 
"model.transformer.h.5.attn.masked_bias", "model.transformer.h.6.attn.bias", 
"model.transformer.h.6.attn.masked_bias", "model.transformer.h.7.attn.bias", 
"model.transformer.h.7.attn.masked_bias", "model.transformer.h.8.attn.bias", 
"model.transformer.h.8.attn.masked_bias", "model.transformer.h.9.attn.bias", 
"model.transformer.h.9.attn.masked_bias", "model.transformer.h.10.attn.bias", 
"model.transformer.h.10.attn.masked_bias", "model.transformer.h.11.attn.bias", 
"model.transformer.h.11.attn.masked_bias", "model.transformer.h.12.attn.bias", 
"model.transformer.h.12.attn.masked_bias", "model.transformer.h.13.attn.bias", 
"model.transformer.h.13.attn.masked_bias", "model.transformer.h.14.attn.bias", 
"model.transformer.h.14.attn.masked_bias", "model.transformer.h.15.attn.bias", 
"model.transformer.h.15.attn.masked_bias", "model.transformer.h.16.attn.bias", 
"model.transformer.h.16.attn.masked_bias", "model.transformer.h.17.attn.bias", 
"model.transformer.h.17.attn.masked_bias", "model.transformer.h.18.attn.bias", 
"model.transformer.h.18.attn.masked_bias", "model.transformer.h.19.attn.bias", 
"model.transformer.h.19.attn.masked_bias", "model.transformer.h.20.attn.bias", 
"model.transformer.h.20.attn.masked_bias", "model.transformer.h.21.attn.bias", 
"model.transformer.h.21.attn.masked_bias", "model.transformer.h.22.attn.bias", 
"model.transformer.h.22.attn.masked_bias", "model.transformer.h.23.attn.bias", 
"model.transformer.h.23.attn.masked_bias", "model.transformer.h.24.attn.bias", 
"model.transformer.h.24.attn.masked_bias", "model.transformer.h.25.attn.bias", 
"model.transformer.h.25.attn.masked_bias", "model.transformer.h.26.attn.bias", 
"model.transformer.h.26.attn.masked_bias", "model.transformer.h.27.attn.bias", 
"model.transformer.h.27.attn.masked_bias", "transformer.h.0.attn.bias", 
"transformer.h.0.attn.masked_bias", "transformer.h.1.attn.bias", 
"transformer.h.1.attn.masked_bias", "transformer.h.2.attn.bias", 
"transformer.h.2.attn.masked_bias", "transformer.h.3.attn.bias", 
"transformer.h.3.attn.masked_bias", "transformer.h.4.attn.bias", 
"transformer.h.4.attn.masked_bias", "transformer.h.5.attn.bias", 
"transformer.h.5.attn.masked_bias", "transformer.h.6.attn.bias", 
"transformer.h.6.attn.masked_bias", "transformer.h.7.attn.bias", 
"transformer.h.7.attn.masked_bias", "transformer.h.8.attn.bias", 
"transformer.h.8.attn.masked_bias", "transformer.h.9.attn.bias", 
"transformer.h.9.attn.masked_bias", "transformer.h.10.attn.bias", 
"transformer.h.10.attn.masked_bias", "transformer.h.11.attn.bias", 
"transformer.h.11.attn.masked_bias", "transformer.h.12.attn.bias", 
"transformer.h.12.attn.masked_bias", "transformer.h.13.attn.bias", 
"transformer.h.13.attn.masked_bias", "transformer.h.14.attn.bias", 
"transformer.h.14.attn.masked_bias", "transformer.h.15.attn.bias", 
"transformer.h.15.attn.masked_bias", "transformer.h.16.attn.bias", 
"transformer.h.16.attn.masked_bias", "transformer.h.17.attn.bias", 
"transformer.h.17.attn.masked_bias", "transformer.h.18.attn.bias", 
"transformer.h.18.attn.masked_bias", "transformer.h.19.attn.bias", 
"transformer.h.19.attn.masked_bias", "transformer.h.20.attn.bias", 
"transformer.h.20.attn.masked_bias", "transformer.h.21.attn.bias", 
"transformer.h.21.attn.masked_bias", "transformer.h.22.attn.bias", 
"transformer.h.22.attn.masked_bias", "transformer.h.23.attn.bias", 
"transformer.h.23.attn.masked_bias", "transformer.h.24.attn.bias", 
"transformer.h.24.attn.masked_bias", "transformer.h.25.attn.bias", 
"transformer.h.25.attn.masked_bias", "transformer.h.26.attn.bias", 
"transformer.h.26.attn.masked_bias", "transformer.h.27.attn.bias", 
"transformer.h.27.attn.masked_bias".
```
## Description of the Change

This change pins the `transformers` dep in `prod.txt` to `<=4.28.0`. This is the same change already being made in [https://github.com/opentensor/bittensor/pull/1380](https://github.com/opentensor/bittensor/pull/1380).

## Possible Drawbacks

The unknown unknowns I suppose. However, I do know that without this change, I (and likely others) are unable to start a subnet 1 validator.

## Verification Process

I made this change and the validator starts and runs as expected.
