### PR TITLE
[BIT-351] Ask for wallet name on btcli unstake

### DIFF
--- a/bittensor/_cli/commands/unstake.py
+++ b/bittensor/_cli/commands/unstake.py
@@ -28,7 +28,7 @@ class UnStakeCommand:
 
     @classmethod   
     def check_config( cls, config: 'bittensor.Config' ):        
-        if config.is_set('wallet.name') and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 


### PR DESCRIPTION
Previous:  
<img width="412" alt="Screenshot 2023-06-08 at 9 58 16 AM" src="https://github.com/opentensor/bittensor/assets/24501463/f765977f-8c3c-416f-8730-51f3524f65ea">  

Expected behaviour (with fix):  
<img width="415" alt="Screenshot 2023-06-08 at 9 53 36 AM" src="https://github.com/opentensor/bittensor/assets/24501463/d0dc4292-a0a0-48d8-bb1b-6ddd4fc34ae2">
