### PR TITLE
fix bug in unstake command to manually enter wallet (bypassed)

### DIFF
--- a/bittensor/_cli/commands/unstake.py
+++ b/bittensor/_cli/commands/unstake.py
@@ -28,11 +28,11 @@ class UnStakeCommand:
 
     @classmethod   
     def check_config( cls, config: 'bittensor.Config' ):        
-        if config.is_set('wallet.name') and not config.no_prompt:
+        if not config.is_set('wallet.name') and not config.no_prompt:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if not config.get( 'hotkey_ss58address', d=None ) and config.is_set('wallet.hotkey') and not config.no_prompt and not config.get('all_hotkeys') and not config.get('hotkeys'):
+        if not config.get( 'hotkey_ss58address', d=None ) and not config.is_set('wallet.hotkey') and not config.no_prompt and not config.get('all_hotkeys') and not config.get('hotkeys'):
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 


### PR DESCRIPTION
Prompts correctly now for wallet and hotkey name upon calling.  Was just going to default without user input before.