### PR TITLE
Use delegate nice-names in senate view

### DIFF
--- a/bittensor/_cli/commands/senate.py
+++ b/bittensor/_cli/commands/senate.py
@@ -21,6 +21,8 @@ import bittensor
 from rich.prompt import Prompt, Confirm
 from rich.table import Table
 from typing import List, Union, Optional, Dict, Tuple
+from .utils import get_delegates_details, DelegatesDetails
+
 console = bittensor.__console__
 
 class SenateCommand:
@@ -35,16 +37,19 @@ class SenateCommand:
         console.print(":satellite: Syncing with chain: [white]{}[/white] ...".format(cli.config.subtensor.network))
 
         senate_members = subtensor.query_module("Senate", "Members").serialize()
+        delegate_info: Optional[Dict[str, DelegatesDetails]] = get_delegates_details(url = bittensor.__delegates_details_url__)
 
         table = Table(show_footer=False)
         table.title = (
             "[white]Senate"
         )
+        table.add_column("[overline white]NAME", footer_style = "overline white", style="rgb(50,163,219)", no_wrap=True)
         table.add_column("[overline white]ADDRESS", footer_style = "overline white", style='yellow', no_wrap=True)
         table.show_footer = True
 
         for ss58_address in senate_members:
             table.add_row(
+                delegate_info[ss58_address].name if ss58_address in delegate_info else "",
                 ss58_address
             )
 
@@ -79,7 +84,6 @@ class SenateCommand:
         bittensor.wallet.add_args( senate_parser )
         bittensor.subtensor.add_args( senate_parser )
 
-from .utils import get_delegates_details, DelegatesDetails
 def format_call_data(call_data: List) -> str:
     human_call_data = list()
 

--- a/tests/integration_tests/test_cli_no_network.py
+++ b/tests/integration_tests/test_cli_no_network.py
@@ -100,6 +100,7 @@ class TestCLINoNetwork(unittest.TestCase):
         config.no_version_checking = True
         config.ss58_address = bittensor.Keypair.create_from_seed( b'0' * 32 ).ss58_address
         config.public_key_hex = None
+        config.proposal_hash = ""
 
         cli = bittensor.cli
 

--- a/tests/integration_tests/test_cli_no_network.py
+++ b/tests/integration_tests/test_cli_no_network.py
@@ -304,7 +304,7 @@ class TestCLINoNetwork(unittest.TestCase):
         # Verify there are no duplicate commands
         # Listed twice. Once in the positional arguments and once in the optional arguments
         for command in commands:
-            pat = re.compile(rf'\n\s+({command})\s+\w')
+            pat = re.compile(rf'\n\s+({command})[^\S\r\n]+\w')
             matches = pat.findall(help_out)
             self.assertEqual( len(matches), 1, f"Duplicate command {command} in help output")
 

--- a/tests/integration_tests/test_cli_no_network.py
+++ b/tests/integration_tests/test_cli_no_network.py
@@ -298,15 +298,14 @@ class TestCLINoNetwork(unittest.TestCase):
         commands = [
             command for command in parser._actions[1].choices
         ]
-        # Verify that all commands are listed in the help message
-        for command in commands:
-            assert command in help_out
+        # Verify that all commands are listed in the help message, AND
         # Verify there are no duplicate commands
-        # Listed twice. Once in the positional arguments and once in the optional arguments
+        ##  Listed twice. Once in the positional arguments and once in the optional arguments
         for command in commands:
             pat = re.compile(rf'\n\s+({command})[^\S\r\n]+\w')
             matches = pat.findall(help_out)
-            self.assertEqual( len(matches), 1, f"Duplicate command {command} in help output")
+            self.assertGreaterEqual( len(matches), 1, f"Command {command} not found in help output")
+            self.assertLess( len(matches), 2, f"Duplicate command {command} in help output")
 
     def test_register_cuda_use_cuda_flag(self):
             class ExitEarlyException(Exception):


### PR DESCRIPTION
<img width="937" alt="Screenshot 2023-06-28 at 7 02 21 PM" src="https://github.com/opentensor/bittensor/assets/24501463/248387cf-5f3e-48a4-9f45-8385fcd32fba">
Adds names from the delegate names repo to senate commands.    


Also fixes the regex for the btcli help test.