### PR TITLE
dont sync metagraph on neuron init

### DIFF
--- a/bittensor/_neuron/base_miner_neuron.py
+++ b/bittensor/_neuron/base_miner_neuron.py
@@ -106,7 +106,9 @@ class BaseMinerNeuron:
         bittensor.logging( config = self.config, logging_dir = self.config.neuron.full_path )
         self.subtensor = bittensor.subtensor( self.config )
         self.wallet = bittensor.wallet( self.config )
-        self.metagraph = self.subtensor.metagraph( self.config.netuid )
+        self.metagraph = self.subtensor.metagraph( self.config.netuid, sync=False )
+        self.metagraph.sync( lite = True, subtensor=self.subtensor )
+
         self.axon = bittensor.axon( wallet = self.wallet, config = self.config )
         self.blacklister = bittensor.blacklist( config = self.config.neuron )
         self.prioritizer = bittensor.priority( config = self.config.neuron )
@@ -169,7 +171,7 @@ class BaseMinerNeuron:
 
             # --- Update the metagraph with the latest network state.
             try:
-                self.metagraph.sync( lite = True )
+                self.metagraph.sync( lite = True, subtensor=self.subtensor )
                 uid = self.metagraph.hotkeys.index( self.wallet.hotkey.ss58_address )
             except:
                 # --- If we fail to sync the metagraph, wait and try again.

--- a/bittensor/_neuron/base_validator.py
+++ b/bittensor/_neuron/base_validator.py
@@ -94,7 +94,8 @@ class BaseValidator:
         bittensor.logging( config = self.config, logging_dir = self.config.neuron.full_path )
         self.subtensor = bittensor.subtensor( self.config )
         self.wallet = bittensor.wallet( self.config )
-        self.metagraph = self.subtensor.metagraph( self.config.netuid )
+        self.metagraph = self.subtensor.metagraph( self.config.netuid, sync=False )
+        self.metagraph.sync( lite = True, subtensor = self.subtensor )
 
         # Used for backgounr process.
         self.is_running = False
@@ -146,7 +147,7 @@ class BaseValidator:
             last_update = self.subtensor.get_current_block()
 
             # --- Update the metagraph with the latest network state.
-            self.metagraph.sync( lite = True )
+            self.metagraph.sync( lite = True, subtensor = self.subtensor )
             uid = self.metagraph.hotkeys.index( self.wallet.hotkey.ss58_address )
 
             # --- Set weights.

--- a/neurons/text/prompting/miners/self_hosted/neuron.py
+++ b/neurons/text/prompting/miners/self_hosted/neuron.py
@@ -104,7 +104,7 @@ def main():
     wallet.register(netuid=config.netuid, subtensor=subtensor)
 
     # --- Create our network state cache
-    metagraph = bittensor.metagraph(config=config, netuid=config.netuid, )
+    metagraph = bittensor.metagraph(config=config, netuid=config.netuid, sync=False )
     metagraph.sync(netuid=config.netuid, subtensor=subtensor).save()
     uid = metagraph.hotkeys.index(wallet.hotkey.ss58_address)
 

--- a/neurons/text/prompting/validators/core/neuron.py
+++ b/neurons/text/prompting/validators/core/neuron.py
@@ -139,7 +139,9 @@ class neuron:
         self.subtensor = bt.subtensor ( config = self.config )
         self.device = torch.device( self.config.neuron.device )
         self.wallet = bt.wallet ( config = self.config )
-        self.metagraph = bt.metagraph( netuid = self.config.netuid, network = self.subtensor.network )
+        self.metagraph = bt.metagraph( netuid = self.config.netuid, network = self.subtensor.network, sync=False )
+        self.metagraph.sync( subtensor=self.subtensor )
+
         self.wallet.create_if_non_existent()
         self.wallet.reregister( subtensor = self.subtensor, netuid = self.config.netuid )
         self.uid = self.wallet.get_uid( subtensor = self.subtensor, netuid = self.config.netuid )
@@ -642,7 +644,7 @@ class neuron:
 
                 # Resync metagraph before returning. (sync every 15 min or ~75 blocks)
                 if self.subtensor.block - self.last_sync > 100:
-                    self.metagraph.sync()
+                    self.metagraph.sync( subtensor=self.subtensor )
                     self.last_sync = self.subtensor.block
                     self.save()
                     delegates = self.subtensor.get_delegated( self.wallet.coldkeypub.ss58_address )
@@ -731,7 +733,7 @@ class neuron:
             while True:
                 time.sleep(12)
                 if self.subtensor.block -last_sync > 100:
-                    self.metagraph.sync()
+                    self.metagraph.sync( subtensor=self.subtensor )
                     self.last_sync = self.subtensor.block
                     self.load(inference_only = True)
 


### PR DESCRIPTION
This fixes errors that require the subtensor config to be passed on the CLI. 