### PR TITLE
fix error calling metagraph from subtensor without passing

### DIFF
--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -1396,7 +1396,7 @@ class Subtensor:
 
         return NeuronInfoLite.list_from_vec_u8( result )
 
-    def metagraph( self, netuid: int, lite: bool = True, block: Optional[int] = None ) -> 'bittensor.Metagraph':
+    def metagraph( self, netuid: int, lite: bool = True, block: Optional[int] = None, sync: bool = False ) -> 'bittensor.Metagraph':
         r""" Returns the metagraph for the subnet.
         Args:
             netuid ( int ):
@@ -1409,8 +1409,8 @@ class Subtensor:
             metagraph ( `bittensor.Metagraph` ):
                 The metagraph for the subnet at the block.
         """        
-        metagraph_ = bittensor.metagraph( network = self.network, netuid = netuid, lite = lite, sync = False )
-        metagraph_.sync( block = block, lite = lite, subtensor = self)
+        metagraph_ = bittensor.metagraph( network = self.network, netuid = netuid, lite = lite, sync = sync )
+        metagraph_.sync( block = block, lite = lite, subtensor = self )
 
         return metagraph_
     

--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -1409,8 +1409,9 @@ class Subtensor:
             metagraph ( `bittensor.Metagraph` ):
                 The metagraph for the subnet at the block.
         """        
-        metagraph_ = bittensor.metagraph( network = self.network, netuid = netuid, lite = lite, sync = sync )
-        metagraph_.sync( block = block, lite = lite, subtensor = self )
+        metagraph_ = bittensor.metagraph( network = self.network, netuid = netuid, lite = lite, sync = False )
+        if sync:
+                metagraph_.sync( block = block, lite = lite, subtensor = self )
 
         return metagraph_
     


### PR DESCRIPTION
This is a complement to `dont-sync-meta-on-init`  https://github.com/opentensor/bittensor/pull/1423.

Must update `subtensor`'s wrapper for `metagraph` otherwise will error out.