### PR TITLE
Fix cli ask for wallet hotkey name

### DIFF
--- a/bittensor/_cli/commands/stake.py
+++ b/bittensor/_cli/commands/stake.py
@@ -19,7 +19,6 @@ import sys
 import argparse
 import bittensor
 from tqdm import tqdm
-from rich.prompt import Confirm
 from rich.prompt import Confirm, Prompt
 from bittensor.utils.balance import Balance
 from typing import List, Union, Optional, Dict, Tuple

--- a/bittensor/_cli/commands/unstake.py
+++ b/bittensor/_cli/commands/unstake.py
@@ -20,7 +20,7 @@ import bittensor
 from tqdm import tqdm
 from rich.prompt import Confirm, Prompt
 from bittensor.utils.balance import Balance
-from typing import List, Union, Optional, Dict, Tuple
+from typing import List, Union, Optional, Tuple
 from .utils import get_hotkey_wallets_for_wallet
 console = bittensor.__console__
 
@@ -32,7 +32,7 @@ class UnStakeCommand:
             wallet_name = Prompt.ask("Enter wallet name", default = bittensor.defaults.wallet.name)
             config.wallet.name = str(wallet_name)
 
-        if not config.get( 'hotkey_ss58address', d=None ) and config.is_set('wallet.hotkey') and not config.no_prompt and not config.get('all_hotkeys') and not config.get('hotkeys'):
+        if not config.get( 'hotkey_ss58address', d=None ) and not config.is_set('wallet.hotkey') and not config.no_prompt and not config.get('all_hotkeys') and not config.get('hotkeys'):
             hotkey = Prompt.ask("Enter hotkey name", default = bittensor.defaults.wallet.hotkey)
             config.wallet.hotkey = str(hotkey)
 

--- a/tests/integration_tests/test_cli_no_network.py
+++ b/tests/integration_tests/test_cli_no_network.py
@@ -24,6 +24,8 @@ import pytest
 from copy import deepcopy
 import re
 
+from tests.helpers import get_mock_coldkey
+
 import bittensor
 
 
@@ -681,6 +683,89 @@ class TestCLIDefaultsNoNetwork(unittest.TestCase):
 
                 # NO prompt happened
                 mock_ask_prompt.assert_not_called()
+
+    def test_delegate_prompt_wallet_name(self):
+        base_args = [
+            'delegate',
+            '--all',
+            '--delegate_ss58key', get_mock_coldkey(0)
+        ]
+        # Patch command to exit early
+        with patch('bittensor._cli.commands.delegates.DelegateStakeCommand.run', return_value=None):
+
+            # Test prompt happens when 
+            # - wallet name IS NOT passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                mock_ask_prompt.side_effect = ['mock']
+
+                cli = bittensor.cli(args=base_args + [
+                        # '--wallet.name', 'mock',
+                    ])
+                cli.run()
+
+                # Prompt happened
+                mock_ask_prompt.assert_called()
+                self.assertEqual(mock_ask_prompt.call_count, 1, msg="Prompt should have been called ONCE")
+                args0, kwargs0 = mock_ask_prompt.call_args_list[0]
+                combined_args_kwargs0 = [arg for arg in args0] + [val for val in kwargs0.values()]
+                # check that prompt was called for wallet name
+                self.assertTrue(
+                    any(filter(lambda x: 'wallet name' in x.lower(), combined_args_kwargs0)),
+                    msg=f"Prompt should have been called for wallet name: {combined_args_kwargs0}"
+                )
+
+            # Test NO prompt happens when
+            # - wallet name IS passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                cli = bittensor.cli(args=base_args + [
+                        '--wallet.name', 'coolwalletname',
+                    ])
+                cli.run()
+
+                # NO prompt happened
+                mock_ask_prompt.assert_not_called()
+
+    def test_undelegate_prompt_wallet_name(self):
+        base_args = [
+            'undelegate',
+            '--all',
+            '--delegate_ss58key', get_mock_coldkey(0)
+        ]
+        # Patch command to exit early
+        with patch('bittensor._cli.commands.delegates.DelegateUnstakeCommand.run', return_value=None):
+
+            # Test prompt happens when 
+            # - wallet name IS NOT passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                mock_ask_prompt.side_effect = ['mock']
+
+                cli = bittensor.cli(args=base_args + [
+                        # '--wallet.name', 'mock',
+                    ])
+                cli.run()
+
+                # Prompt happened
+                mock_ask_prompt.assert_called()
+                self.assertEqual(mock_ask_prompt.call_count, 1, msg="Prompt should have been called ONCE")
+                args0, kwargs0 = mock_ask_prompt.call_args_list[0]
+                combined_args_kwargs0 = [arg for arg in args0] + [val for val in kwargs0.values()]
+                # check that prompt was called for wallet name
+                self.assertTrue(
+                    any(filter(lambda x: 'wallet name' in x.lower(), combined_args_kwargs0)),
+                    msg=f"Prompt should have been called for wallet name: {combined_args_kwargs0}"
+                )
+
+            # Test NO prompt happens when
+            # - wallet name IS passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                cli = bittensor.cli(args=base_args + [
+                        '--wallet.name', 'coolwalletname',
+                    ])
+                cli.run()
+
+                # NO prompt happened
+                mock_ask_prompt.assert_not_called()
+
 
 
 if __name__ == "__main__":

--- a/tests/integration_tests/test_cli_no_network.py
+++ b/tests/integration_tests/test_cli_no_network.py
@@ -766,6 +766,126 @@ class TestCLIDefaultsNoNetwork(unittest.TestCase):
                 # NO prompt happened
                 mock_ask_prompt.assert_not_called()
 
+    def test_delegate_prompt_hotkey(self):
+        # Tests when
+        # - wallet name IS passed, AND
+        # - delegate hotkey IS NOT passed
+        base_args = [
+            'delegate',
+            '--all',
+            '--wallet.name', 'mock', 
+        ]
+
+        delegate_ss58 = get_mock_coldkey(0)
+        with patch('bittensor._cli.commands.delegates.show_delegates'):
+            with patch('bittensor.Subtensor.get_delegates', return_value=[
+                bittensor.DelegateInfo(
+                    hotkey_ss58=delegate_ss58, # return delegate with mock coldkey
+                    total_stake=bittensor.Balance.from_float(0.1),
+                    nominators=[],
+                    owner_ss58='',
+                    take=0.18,
+                    validator_permits=[],
+                    registrations=[],
+                    return_per_1000=bittensor.Balance.from_float(0.1),
+                    total_daily_return=bittensor.Balance.from_float(0.1)
+                )
+            ]):
+                # Patch command to exit early
+                with patch('bittensor._cli.commands.delegates.DelegateStakeCommand.run', return_value=None):
+
+                    # Test prompt happens when 
+                    # - delegate hotkey IS NOT passed
+                    with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                        mock_ask_prompt.side_effect = ['0'] # select delegate with mock coldkey
+
+                        cli = bittensor.cli(args=base_args + [
+                                # '--delegate_ss58key', delegate_ss58,
+                            ])
+                        cli.run()
+
+                        # Prompt happened
+                        mock_ask_prompt.assert_called()
+                        self.assertEqual(mock_ask_prompt.call_count, 1, msg="Prompt should have been called ONCE")
+                        args0, kwargs0 = mock_ask_prompt.call_args_list[0]
+                        combined_args_kwargs0 = [arg for arg in args0] + [val for val in kwargs0.values()]
+                        # check that prompt was called for delegate hotkey 
+                        self.assertTrue(
+                            any(filter(lambda x: 'delegate' in x.lower(), combined_args_kwargs0)),
+                            msg=f"Prompt should have been called for delegate: {combined_args_kwargs0}"
+                        )
+
+                    # Test NO prompt happens when
+                    # - delegate hotkey IS passed
+                    with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                        cli = bittensor.cli(args=base_args + [
+                                '--delegate_ss58key', delegate_ss58,
+                            ])
+                        cli.run()
+
+                        # NO prompt happened
+                        mock_ask_prompt.assert_not_called()
+
+    def test_undelegate_prompt_hotkey(self):
+        # Tests when
+        # - wallet name IS passed, AND
+        # - delegate hotkey IS NOT passed
+        base_args = [
+            'undelegate',
+            '--all',
+            '--wallet.name', 'mock', 
+        ]
+
+        delegate_ss58 = get_mock_coldkey(0)
+        with patch('bittensor._cli.commands.delegates.show_delegates'):
+            with patch('bittensor.Subtensor.get_delegates', return_value=[
+                bittensor.DelegateInfo(
+                    hotkey_ss58=delegate_ss58, # return delegate with mock coldkey
+                    total_stake=bittensor.Balance.from_float(0.1),
+                    nominators=[],
+                    owner_ss58='',
+                    take=0.18,
+                    validator_permits=[],
+                    registrations=[],
+                    return_per_1000=bittensor.Balance.from_float(0.1),
+                    total_daily_return=bittensor.Balance.from_float(0.1)
+                )
+            ]):
+                # Patch command to exit early
+                with patch('bittensor._cli.commands.delegates.DelegateUnstakeCommand.run', return_value=None):
+
+                    # Test prompt happens when 
+                    # - delegate hotkey IS NOT passed
+                    with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                        mock_ask_prompt.side_effect = ['0'] # select delegate with mock coldkey
+
+                        cli = bittensor.cli(args=base_args + [
+                                # '--delegate_ss58key', delegate_ss58,
+                            ])
+                        cli.run()
+
+                        # Prompt happened
+                        mock_ask_prompt.assert_called()
+                        self.assertEqual(mock_ask_prompt.call_count, 1, msg="Prompt should have been called ONCE")
+                        args0, kwargs0 = mock_ask_prompt.call_args_list[0]
+                        combined_args_kwargs0 = [arg for arg in args0] + [val for val in kwargs0.values()]
+                        # check that prompt was called for delegate hotkey 
+                        self.assertTrue(
+                            any(filter(lambda x: 'delegate' in x.lower(), combined_args_kwargs0)),
+                            msg=f"Prompt should have been called for delegate: {combined_args_kwargs0}"
+                        )
+
+                    # Test NO prompt happens when
+                    # - delegate hotkey IS passed
+                    with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                        cli = bittensor.cli(args=base_args + [
+                                '--delegate_ss58key', delegate_ss58,
+                            ])
+                        cli.run()
+
+                        # NO prompt happened
+                        mock_ask_prompt.assert_not_called()
+
 
 
 if __name__ == "__main__":

--- a/tests/integration_tests/test_cli_no_network.py
+++ b/tests/integration_tests/test_cli_no_network.py
@@ -457,6 +457,231 @@ class TestCLIDefaultsNoNetwork(unittest.TestCase):
                 # NO prompt happened
                 mock_ask_prompt.assert_not_called()
 
+    def test_stake_prompt_wallet_name_and_hotkey_name(self):
+        base_args = [
+            'stake',
+            '--all',
+        ]
+        # Patch command to exit early
+        with patch('bittensor._cli.commands.stake.StakeCommand.run', return_value=None):
+
+            # Test prompt happens when 
+            # - wallet name IS NOT passed, AND
+            # - hotkey name IS NOT passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                mock_ask_prompt.side_effect = ['mock', 'mock_hotkey']
+
+                cli = bittensor.cli(args=base_args + [
+                        # '--wallet.name', 'mock',
+                        #'--wallet.hotkey', 'mock_hotkey', 
+                    ])
+                cli.run()
+
+                # Prompt happened
+                mock_ask_prompt.assert_called()
+                self.assertEqual(mock_ask_prompt.call_count, 2, msg="Prompt should have been called twice")
+                args0, kwargs0 = mock_ask_prompt.call_args_list[0]
+                combined_args_kwargs0 = [arg for arg in args0] + [val for val in [val for val in kwargs0.values()]]
+                # check that prompt was called for wallet name
+                self.assertTrue(
+                    any(filter(lambda x: 'wallet name' in x.lower(), combined_args_kwargs0)),
+                    msg=f"Prompt should have been called for wallet name: {combined_args_kwargs0}"
+                )
+
+                args1, kwargs1 = mock_ask_prompt.call_args_list[1]
+                combined_args_kwargs1 = [arg for arg in args1] + [val for val in kwargs1.values()]
+                # check that prompt was called for hotkey
+
+                self.assertTrue(
+                    any(filter(lambda x: 'hotkey' in x.lower(), combined_args_kwargs1)),
+                    msg=f"Prompt should have been called for hotkey: {combined_args_kwargs1}"
+                )
+
+            # Test prompt happens when 
+            # - wallet name IS NOT passed, AND
+            # - hotkey name IS passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                mock_ask_prompt.side_effect = ['mock', 'mock_hotkey']
+
+                cli = bittensor.cli(args=base_args + [
+                        #'--wallet.name', 'mock',
+                        '--wallet.hotkey', 'mock_hotkey', 
+                    ])
+                cli.run()
+
+                # Prompt happened
+                mock_ask_prompt.assert_called()
+                self.assertEqual(mock_ask_prompt.call_count, 1, msg="Prompt should have been called ONCE")
+                args0, kwargs0 = mock_ask_prompt.call_args_list[0]
+                combined_args_kwargs0 = [arg for arg in args0] + [val for val in kwargs0.values()]
+                # check that prompt was called for wallet name
+                self.assertTrue(
+                    any(filter(lambda x: 'wallet name' in x.lower(), combined_args_kwargs0)),
+                    msg=f"Prompt should have been called for wallet name: {combined_args_kwargs0}"
+                )
+
+            # Test prompt happens when 
+            # - wallet name IS passed, AND
+            # - hotkey name IS NOT passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                mock_ask_prompt.side_effect = ['mock', 'mock_hotkey']
+
+                cli = bittensor.cli(args=base_args + [
+                        '--wallet.name', 'mock',
+                        #'--wallet.hotkey', 'mock_hotkey', 
+                    ])
+                cli.run()
+
+                # Prompt happened
+                mock_ask_prompt.assert_called()
+                self.assertEqual(mock_ask_prompt.call_count, 1, msg="Prompt should have been called ONCE")
+                args0, kwargs0 = mock_ask_prompt.call_args_list[0]
+                combined_args_kwargs0 = [arg for arg in args0] + [val for val in kwargs0.values()]
+                # check that prompt was called for hotkey
+                self.assertTrue(
+                    any(filter(lambda x: 'hotkey' in x.lower(), combined_args_kwargs0)),
+                    msg=f"Prompt should have been called for hotkey {combined_args_kwargs0}"
+                )
+
+
+            # Test NO prompt happens when
+            # - wallet name IS passed, AND
+            # - hotkey name IS passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                cli = bittensor.cli(args=base_args + [
+                        '--wallet.name', 'coolwalletname',
+                        '--wallet.hotkey', 'coolwalletname_hotkey',
+                    ])
+                cli.run()
+
+                # NO prompt happened
+                mock_ask_prompt.assert_not_called()
+
+            # Test NO prompt happens when
+            # - wallet name 'default' IS passed, AND
+            # - hotkey name 'default' IS passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                cli = bittensor.cli(args=base_args + [
+                        '--wallet.name', 'default',
+                        '--wallet.hotkey', 'default',
+                    ])
+                cli.run()
+
+                # NO prompt happened
+                mock_ask_prompt.assert_not_called()
+
+    def test_unstake_prompt_wallet_name_and_hotkey_name(self):
+        base_args = [
+            'unstake',
+            '--all',
+        ]
+        # Patch command to exit early
+        with patch('bittensor._cli.commands.unstake.UnStakeCommand.run', return_value=None):
+
+            # Test prompt happens when 
+            # - wallet name IS NOT passed, AND
+            # - hotkey name IS NOT passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                mock_ask_prompt.side_effect = ['mock', 'mock_hotkey']
+
+                cli = bittensor.cli(args=base_args + [
+                        # '--wallet.name', 'mock',
+                        #'--wallet.hotkey', 'mock_hotkey', 
+                    ])
+                cli.run()
+
+                # Prompt happened
+                mock_ask_prompt.assert_called()
+                self.assertEqual(mock_ask_prompt.call_count, 2, msg="Prompt should have been called twice")
+                args0, kwargs0 = mock_ask_prompt.call_args_list[0]
+                combined_args_kwargs0 = [arg for arg in args0] + [val for val in kwargs0.values()]
+                # check that prompt was called for wallet name
+                self.assertTrue(
+                    any(filter(lambda x: 'wallet name' in x.lower(), combined_args_kwargs0)),
+                    msg=f"Prompt should have been called for wallet name: {combined_args_kwargs0}"
+                )
+
+                args1, kwargs1 = mock_ask_prompt.call_args_list[1]
+                combined_args_kwargs1 = [arg for arg in args1] + [val for val in kwargs1.values()]
+                # check that prompt was called for hotkey
+                self.assertTrue(
+                    any(filter(lambda x: 'hotkey' in x.lower(), combined_args_kwargs1)),
+                    msg=f"Prompt should have been called for hotkey {combined_args_kwargs1}"
+                )
+
+            # Test prompt happens when 
+            # - wallet name IS NOT passed, AND
+            # - hotkey name IS passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                mock_ask_prompt.side_effect = ['mock', 'mock_hotkey']
+
+                cli = bittensor.cli(args=base_args + [
+                        #'--wallet.name', 'mock',
+                        '--wallet.hotkey', 'mock_hotkey', 
+                    ])
+                cli.run()
+
+                # Prompt happened
+                mock_ask_prompt.assert_called()
+                self.assertEqual(mock_ask_prompt.call_count, 1, msg="Prompt should have been called ONCE")
+                args0, kwargs0 = mock_ask_prompt.call_args_list[0]
+                combined_args_kwargs0 = [arg for arg in args0] + [val for val in kwargs0.values()]
+                # check that prompt was called for wallet name
+                self.assertTrue(
+                    any(filter(lambda x: 'wallet name' in x.lower(), combined_args_kwargs0)),
+                    msg=f"Prompt should have been called for wallet name: {combined_args_kwargs0}"
+                )
+
+            # Test prompt happens when 
+            # - wallet name IS passed, AND
+            # - hotkey name IS NOT passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                mock_ask_prompt.side_effect = ['mock', 'mock_hotkey']
+
+                cli = bittensor.cli(args=base_args + [
+                        '--wallet.name', 'mock',
+                        #'--wallet.hotkey', 'mock_hotkey', 
+                    ])
+                cli.run()
+
+                # Prompt happened
+                mock_ask_prompt.assert_called()
+                self.assertEqual(mock_ask_prompt.call_count, 1, msg="Prompt should have been called ONCE")
+                args0, kwargs0 = mock_ask_prompt.call_args_list[0]
+                combined_args_kwargs0 = [arg for arg in args0] + [val for val in kwargs0.values()]
+                # check that prompt was called for hotkey
+                self.assertTrue(
+                    any(filter(lambda x: 'hotkey' in x.lower(), combined_args_kwargs0)),
+                    msg=f"Prompt should have been called for hotkey {combined_args_kwargs0}"
+                )
+
+
+            # Test NO prompt happens when
+            # - wallet name IS passed, AND
+            # - hotkey name IS passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                cli = bittensor.cli(args=base_args + [
+                        '--wallet.name', 'coolwalletname',
+                        '--wallet.hotkey', 'coolwalletname_hotkey',
+                    ])
+                cli.run()
+
+                # NO prompt happened
+                mock_ask_prompt.assert_not_called()
+
+            # Test NO prompt happens when
+            # - wallet name 'default' IS passed, AND
+            # - hotkey name 'default' IS passed
+            with patch('rich.prompt.Prompt.ask') as mock_ask_prompt:
+                cli = bittensor.cli(args=base_args + [
+                        '--wallet.name', 'default',
+                        '--wallet.hotkey', 'default',
+                    ])
+                cli.run()
+
+                # NO prompt happened
+                mock_ask_prompt.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds tests for:
- `btcli <stake|unstake|delegate|undelegate>` prompts for wallet name
- `btcli <stake|unstake>` prompts for hotkey
- `btcli <delegate|undelegate>` prompts for delegate hotkey

Fixes:
- `btcli stake --wallet.name NAME --wallet.hotkey HOTKEY` prompts for hotkey