### PR TITLE
Always sync metagraph during subtensor.metagraph

### DIFF
--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -1396,8 +1396,8 @@ class Subtensor:
 
         return NeuronInfoLite.list_from_vec_u8( result )
 
-    def metagraph( self, netuid: int, lite: bool = True, block: Optional[int] = None, sync: bool = False ) -> 'bittensor.Metagraph':
-        r""" Returns the metagraph for the subnet.
+    def metagraph( self, netuid: int, lite: bool = True, block: Optional[int] = None ) -> 'bittensor.Metagraph':
+        r""" Returns a synced metagraph for the subnet.
         Args:
             netuid ( int ):
                 The network uid of the subnet to query.
@@ -1410,8 +1410,7 @@ class Subtensor:
                 The metagraph for the subnet at the block.
         """        
         metagraph_ = bittensor.metagraph( network = self.network, netuid = netuid, lite = lite, sync = False )
-        if sync:
-                metagraph_.sync( block = block, lite = lite, subtensor = self )
+        metagraph_.sync( block = block, lite = lite, subtensor = self )
 
         return metagraph_
     

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -2089,16 +2089,13 @@ class TestCLIWithNetworkAndConfig(unittest.TestCase):
             return uid
 
        
-        for i in range(4):
+        for i in range(5):
             _ = register_mock_neuron(
                 i
             )
+
+        _subtensor_mock.neurons_lite(netuid=config.netuid)
             
-        # Only wait for finalization on the last neuron
-        _ = register_mock_neuron(
-            i = 4
-        )
-        
         cli = bittensor.cli(config)
 
         mock_console = MockConsole()


### PR DESCRIPTION
Should sync on call. This fixes a flaky test as well