### PR TITLE
catch error on loading loras

### DIFF
--- a/neurons/text_to_image/miners/neuron.py
+++ b/neurons/text_to_image/miners/neuron.py
@@ -208,8 +208,11 @@ def main( config ):
 
                 # load lora weights
                 for model, weight in lora_models:
-                    i2i = load_lora_weights(i2i, model, weight)
-
+                    try:
+                        i2i = load_lora_weights(i2i, model, weight)
+                    except Exception as e:
+                        None
+                    
                 # load negative lora weights
                 for model, weight in negative_lora_models:
                     i2i = load_lora_weights(i2i, model, weight)


### PR DESCRIPTION
Miners will error out completely if someone attempts to load a lora that doesnt exist

this fixes it and instead attempts to load the lora, and if it doesnt exist, skips it