### PR TITLE
Use SenateMembers in is_senate_member helper

### DIFF
--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -736,7 +736,7 @@ class Subtensor:
         hotkey_ss58: str,
         block: Optional[int] = None,
     ) -> bool:
-        senate_members = self.query_module(module="Senate", name="Members", block=block ).serialize()
+        senate_members = self.query_module(module="SenateMembers", name="Members", block=block ).serialize()
         return senate_members.count( hotkey_ss58 ) > 0
     
     def get_vote_data(


### PR DESCRIPTION
This PR is required for the new change in subtensor which removes the Senate collective instance, simplifying the runtime for ease-of-use. You can find the matching PR for subtensor [here.](https://github.com/opentensor/subtensor/pull/166)