### PR TITLE
Adds timeout option to dendrite

### DIFF
--- a/bittensor/dendrite.py
+++ b/bittensor/dendrite.py
@@ -62,7 +62,8 @@ class dendrite(torch.nn.Module):
 
     def __init__(
             self, 
-            wallet: Optional[Union['bt.wallet', 'bt.keypair']] = None
+            wallet: Optional[Union['bt.wallet', 'bt.keypair']] = None,
+            timeout: float = 12.0
         ):
         """
         Initializes the Dendrite object, setting up essential properties.
@@ -79,7 +80,7 @@ class dendrite(torch.nn.Module):
         self.uuid = str(uuid.uuid1())
 
         # HTTP client for making requests
-        self.client = httpx.AsyncClient()
+        self.client = httpx.AsyncClient(timeout=timeout)
 
         # Get the external IP
         self.external_ip = bt.utils.networking.get_external_ip()

--- a/bittensor/tensor.py
+++ b/bittensor/tensor.py
@@ -25,8 +25,11 @@ import msgpack_numpy
 from typing import Dict, Optional, Tuple, Union, List, Callable
 
 TORCH_DTYPES = {
+    'torch.float16': torch.float16,
     'torch.float32': torch.float32,
     'torch.float64': torch.float64,
+    'torch.uint8': torch.uint8,
+    'torch.int32': torch.int32,
     'torch.int64': torch.int64,
 }
 


### PR DESCRIPTION
If a response takes too long the dendrite will fail to parse. The default setting for the AsyncClient timeout is 5s and this change updates the default to 12s