### PR TITLE
Remove datasets req

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -5,7 +5,6 @@ backoff==2.1.0
 bittensor-config==0.0.0
 bittensor-wallet==0.0.4
 cryptography==41.0.0
-datasets==2.14.0
 fuzzywuzzy==0.18.0
 grpcio==1.42.0
 grpcio-tools==1.42.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -5,7 +5,7 @@ backoff==2.1.0
 bittensor-config==0.0.0
 bittensor-wallet==0.0.4
 cryptography==41.0.0
-datasets==2.12.0
+datasets==2.14.0
 fuzzywuzzy==0.18.0
 grpcio==1.42.0
 grpcio-tools==1.42.0


### PR DESCRIPTION
This obviates a misleading version mismatch error that breaks `btcli` due to new python installs with `multiprocess==0.70.15`.

`validators` will need a hotfix to bump `datasets>=2.14.0` to fix an error with multiprocessing update that was added for python 3.11 support.