### PR TITLE
add cicleci check for requirements python version support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,18 @@ jobs:
             . env/bin/activate
             python -m black --exclude '(env|venv|.eggs)' --check .
 
+  check-compatibility:
+    docker:
+      - image: cimg/python:3.10
+    steps:
+      - checkout
+      - run:
+          name: Install jq
+          command: sudo apt-get update && sudo apt-get install -y jq
+      - run:
+          name: Check Python Version Compatibility
+          command: ./check_compatibility.sh
+
   build-and-test:
     resource_class: medium
     parallelism: 2
@@ -205,6 +217,7 @@ jobs:
 workflows:
   pr-requirements:
     jobs:
+      - check-compatibility
       - black:
           python-version: "3.8.12"
       - build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,9 @@ jobs:
           name: Install jq
           command: sudo apt-get update && sudo apt-get install -y jq
       - run:
+          name: Make script executable
+          command: chmod +x ./scripts/check_compatibility.sh
+      - run:
           name: Check Python Version Compatibility
           command: ./scripts/check_compatibility.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: sudo apt-get update && sudo apt-get install -y jq
       - run:
           name: Check Python Version Compatibility
-          command: ./check_compatibility.sh
+          command: ./scripts/check_compatibility.sh
 
   build-and-test:
     resource_class: medium

--- a/scripts/check_compatibility.sh
+++ b/scripts/check_compatibility.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+python_versions=("3.8" "3.9" "3.10" "3.11")
+all_passed=true
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+check_compatibility() {
+    python_version=$1
+    all_supported=0
+
+    while read -r requirement; do
+        package_name=$(echo "$requirement" | awk -F'[!=<>]' '{print $1}')
+        echo -n "Checking $package_name... "
+
+        url="https://pypi.org/pypi/$package_name/json"
+        response=$(curl -s $url)
+        status_code=$(curl -s -o /dev/null -w "%{http_code}" $url)
+
+        if [ "$status_code" != "200" ]; then
+            echo -e "${RED}Information not available${NC}"
+            continue
+        fi
+
+        classifiers=$(echo "$response" | jq -r '.info.classifiers[]')
+        requires_python=$(echo "$response" | jq -r '.info.requires_python')
+
+        base_version="Programming Language :: Python :: ${python_version%%.*}"
+        specific_version="Programming Language :: Python :: $python_version"
+
+        if echo "$classifiers" | grep -q "$specific_version" || echo "$classifiers" | grep -q "$base_version"; then
+            echo -e "${GREEN}Supported${NC}"
+        elif [ "$requires_python" != "null" ] && echo "$requires_python" | grep -Eq "==$python_version|>=$python_version|<=$python_version"; then
+            echo -e "${GREEN}Supported${NC}"
+        else
+            echo -e "${YELLOW}Warning: Specific version not listed, assuming compatibility${NC}"
+        fi
+    done < requirements/prod.txt
+
+    return $all_supported
+}
+
+for version in "${python_versions[@]}"
+do
+    echo ""
+    echo "Checking compatibility for Python $version..."
+    check_compatibility $version
+    if [ $? -eq 0 ]; then
+        echo -e "${GREEN}All requirements are compatible with Python $version.${NC}"
+    else
+        echo -e "${RED}All requirements are NOT compatible with Python $version.${NC}"
+        all_passed=false
+    fi
+done
+
+echo ""
+if $all_passed; then
+    echo -e "${GREEN}All tests passed.${NC}"
+else
+    echo -e "${RED}All tests did not pass.${NC}"
+    exit 1
+fi


### PR DESCRIPTION
Does 2 thins:
- Adds a bash script to verify that all python requirements are supported with the given our officially supported python versions. (e.g. 38, 39, 310, 311)
- Adds a circle CI job so that if any of the tests fail from the bash script, the job fails.