### PR TITLE
Call runtime apis using state call

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -127,6 +127,34 @@ __type_registry__ = {
     "types": {
         "Balance": "u64",  # Need to override default u128
     },
+    "runtime_api": {
+        "NeuronInfoRuntimeApi": {
+            "methods": {
+                "get_neuron_lite": {
+                    'params': [
+                        {
+                            "name": "netuid",
+                            "type": "u16",
+                        }, 
+                        {
+                            "name": "uid",
+                            "type": "u16",
+                        },
+                    ],
+                    "type": "Vec<u8>",
+                },
+                "get_neurons_lite": {
+                    'params': [
+                        {
+                            "name": "netuid",
+                            "type": "u16",
+                        },
+                    ],
+                    "type": "Vec<u8>",
+                },
+            }
+        },
+    }
 }
 
 # --- Prometheus ---

--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -131,11 +131,11 @@ __type_registry__ = {
         "NeuronInfoRuntimeApi": {
             "methods": {
                 "get_neuron_lite": {
-                    'params': [
+                    "params": [
                         {
                             "name": "netuid",
                             "type": "u16",
-                        }, 
+                        },
                         {
                             "name": "uid",
                             "type": "u16",
@@ -144,7 +144,7 @@ __type_registry__ = {
                     "type": "Vec<u8>",
                 },
                 "get_neurons_lite": {
-                    'params': [
+                    "params": [
                         {
                             "name": "netuid",
                             "type": "u16",
@@ -154,7 +154,7 @@ __type_registry__ = {
                 },
             }
         },
-    }
+    },
 }
 
 # --- Prometheus ---

--- a/bittensor/_subtensor/chain_data.py
+++ b/bittensor/_subtensor/chain_data.py
@@ -16,7 +16,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 from dataclasses import dataclass
-from typing import List, Tuple, Dict, Optional, Any, TypedDict, overload, Union
+from typing import List, Tuple, Dict, Optional, Any, TypedDict, Union
 import bittensor
 from bittensor import Balance, axon_info
 import torch
@@ -155,33 +155,6 @@ class ChainDataType(Enum):
 RAOPERTAO = 1e9
 U16_MAX = 65535
 U64_MAX = 18446744073709551615
-
-@overload
-def from_scale_encoding(
-    input: List[int],
-    type_name: ChainDataType,
-    is_vec: bool = False,
-    is_option: bool = False,
-) -> Optional[Dict]:
-    ...
-
-@overload
-def from_scale_encoding(
-    input: bytes,
-    type_name: ChainDataType,
-    is_vec: bool = False,
-    is_option: bool = False,
-) -> Optional[Dict]:
-    ...
-
-@overload
-def from_scale_encoding(
-    input: ScaleBytes,
-    type_name: ChainDataType,
-    is_vec: bool = False,
-    is_option: bool = False,
-) -> Optional[Dict]:
-    ...
 
 def from_scale_encoding(
     input: Union[List[int], bytes, ScaleBytes],

--- a/bittensor/_subtensor/chain_data.py
+++ b/bittensor/_subtensor/chain_data.py
@@ -156,6 +156,7 @@ RAOPERTAO = 1e9
 U16_MAX = 65535
 U64_MAX = 18446744073709551615
 
+
 def from_scale_encoding(
     input: Union[List[int], bytes, ScaleBytes],
     type_name: ChainDataType,
@@ -172,7 +173,7 @@ def from_scale_encoding(
             as_bytes = input
         else:
             raise TypeError("input must be a List[int], bytes, or ScaleBytes")
-        
+
         as_scale_bytes = ScaleBytes(as_bytes)
 
     rpc_runtime_config = RuntimeConfiguration()

--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -1800,7 +1800,10 @@ class Subtensor:
         if hex_bytes_result == None:
             return NeuronInfoLite._null_neuron()
         
-        bytes_result = bytes.fromhex(hex_bytes_result[2:])
+        if hex_bytes_result.startswith("0x"):
+            bytes_result = bytes.fromhex(hex_bytes_result[2:])
+        else:
+            bytes_result = bytes.fromhex(hex_bytes_result)
 
         return NeuronInfoLite.from_vec_u8(bytes_result)
 
@@ -1827,7 +1830,10 @@ class Subtensor:
         if hex_bytes_result == None:
             return None
         
-        bytes_result = bytes.fromhex(hex_bytes_result[2:])
+        if hex_bytes_result.startswith("0x"):
+            bytes_result = bytes.fromhex(hex_bytes_result[2:])
+        else:
+            bytes_result = bytes.fromhex(hex_bytes_result)
 
         return NeuronInfoLite.list_from_vec_u8(bytes_result)
 

--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -67,9 +67,10 @@ from loguru import logger
 
 logger = logger.opt(colors=True)
 
+
 class ParamWithTypes(TypedDict):
-    name: str # Name of the parameter.
-    type: str # ScaleType string of the parameter.
+    name: str  # Name of the parameter.
+    type: str  # ScaleType string of the parameter.
 
 
 class Subtensor:
@@ -1037,7 +1038,7 @@ class Subtensor:
                 )
 
         return make_substrate_call_with_retry()
-    
+
     def state_call(
         self,
         method: str,
@@ -1051,13 +1052,10 @@ class Subtensor:
                 params = [method, data]
                 if block_hash:
                     params = params + [block_hash]
-                return substrate.rpc_request(
-                    method="state_call",
-                    params=params
-                )
+                return substrate.rpc_request(method="state_call", params=params)
 
         return make_substrate_call_with_retry()
-    
+
     def query_runtime_api(
         self,
         runtime_api: str,
@@ -1066,34 +1064,34 @@ class Subtensor:
         block: Optional[int] = None,
     ) -> Optional[bytes]:
         """
-        Returns a Scale Bytes type that should be decoded. 
+        Returns a Scale Bytes type that should be decoded.
         """
-        call_definition = bittensor.__type_registry__['runtime_api'][runtime_api]['methods'][method]
+        call_definition = bittensor.__type_registry__["runtime_api"][runtime_api][
+            "methods"
+        ][method]
         json_result = self.state_call(
             method=f"{runtime_api}_{method}",
-            data='0x' if params is None else self._encode_params(
-                call_definition=call_definition,
-                params=params
-            ),
-            block=block
+            data="0x"
+            if params is None
+            else self._encode_params(call_definition=call_definition, params=params),
+            block=block,
         )
 
         if json_result is None:
             return None
-        
-        return_type = call_definition['type']
 
-        as_scale_bytes = scalecodec.ScaleBytes( json_result['result'] )
+        return_type = call_definition["type"]
+
+        as_scale_bytes = scalecodec.ScaleBytes(json_result["result"])
 
         rpc_runtime_config = RuntimeConfiguration()
-        rpc_runtime_config.update_type_registry(load_type_registry_preset('legacy'))
+        rpc_runtime_config.update_type_registry(load_type_registry_preset("legacy"))
         rpc_runtime_config.update_type_registry(custom_rpc_type_registry)
 
         obj = rpc_runtime_config.create_scale_object(return_type)
 
         return obj.decode(as_scale_bytes)
-        
-    
+
     def _encode_params(
         self,
         call_definition: List[ParamWithTypes],
@@ -1102,17 +1100,17 @@ class Subtensor:
         """
         Returns a hex encoded string of the params using their types.
         """
-        param_data = scalecodec.ScaleBytes(b'')
+        param_data = scalecodec.ScaleBytes(b"")
 
-        for i, param in enumerate(call_definition['params']):
-            scale_obj = self.substrate.create_scale_object(param['type'])
+        for i, param in enumerate(call_definition["params"]):
+            scale_obj = self.substrate.create_scale_object(param["type"])
             if type(params) is list:
                 param_data += scale_obj.encode(params[i])
             else:
-                if param['name'] not in params:
+                if param["name"] not in params:
                     raise ValueError(f"Missing param {param['name']} in params dict.")
 
-                param_data += scale_obj.encode(params[param['name']])
+                param_data += scale_obj.encode(params[param["name"]])
 
         return param_data.to_hex()
 
@@ -1786,11 +1784,11 @@ class Subtensor:
         """
         if uid == None:
             return NeuronInfoLite._null_neuron()
-        
+
         hex_bytes_result = self.query_runtime_api(
             runtime_api="NeuronInfoRuntimeApi",
             method="get_neuron_lite",
-            params={ 
+            params={
                 "netuid": netuid,
                 "uid": uid,
             },
@@ -1799,7 +1797,7 @@ class Subtensor:
 
         if hex_bytes_result == None:
             return NeuronInfoLite._null_neuron()
-        
+
         if hex_bytes_result.startswith("0x"):
             bytes_result = bytes.fromhex(hex_bytes_result[2:])
         else:
@@ -1829,7 +1827,7 @@ class Subtensor:
 
         if hex_bytes_result == None:
             return None
-        
+
         if hex_bytes_result.startswith("0x"):
             bytes_result = bytes.fromhex(hex_bytes_result[2:])
         else:

--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -1030,6 +1030,47 @@ class Subtensor:
                 )
 
         return make_substrate_call_with_retry()
+    
+    def state_call(
+        self,
+        method: str,
+        data: str,
+        block: Optional[int] = None,
+    ) -> Optional[object]:
+        @retry(delay=2, tries=3, backoff=2, max_delay=4)
+        def make_substrate_call_with_retry():
+            with self.substrate as substrate:
+                block_hash = None if block == None else substrate.get_block_hash(block)
+                params = [method, data]
+                if block_hash:
+                    params = params + [block_hash]
+                return substrate.rpc_request(
+                    method="state_call",
+                    params=params
+                )
+
+        return make_substrate_call_with_retry()
+    
+    def query_runtime_api(
+        self,
+        runtime_api: str,
+        method: str,
+        params: Optional[Union[bytearray, str]] = '0x',
+        block: Optional[int] = None,
+    ) -> Optional[bytes]:
+        """
+        Returns a Scale Bytes type that should be decoded. 
+        """
+        json_result = self.state_call(
+            method=f"{runtime_api}_{method}",
+            data='0x' if params is None else params.hex() if isinstance(params, bytearray) else params,
+            block=block
+        )
+
+        if json_result is None:
+            return None
+        
+        return json_result["result"]
 
     #####################################
     #### Hyper parameter calls. ####

--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -1776,26 +1776,24 @@ class Subtensor:
             neuron (List[NeuronInfoLite]):
                 List of neuron lite metadata objects.
         """
+        hex_scale_bytes_result = self.query_runtime_api(
+            runtime_api="NeuronInfoRuntimeApi",
+            method="get_neurons_lite",
+            params=self.substrate.encode_scale(
+                'u16', value=netuid, block_hash=self.substrate.get_block_hash(block) if block is not None else None
+            ).data,
+            block=block,
+        )
 
-        @retry(delay=2, tries=3, backoff=2, max_delay=4)
-        def make_substrate_call_with_retry():
-            with self.substrate as substrate:
-                block_hash = None if block == None else substrate.get_block_hash(block)
-                params = [netuid]
-                if block_hash:
-                    params = params + [block_hash]
-                return substrate.rpc_request(
-                    method="neuronInfo_getNeuronsLite",  # custom rpc method
-                    params=params,
-                )
+        if hex_scale_bytes_result == None:
+            return None
+        
+        hex_bytes_result = self.substrate.decode_scale(
+            'Bytes<Vec<u8>>', hex_scale_bytes_result
+        )
+        bytes_result = bytes.fromhex(hex_bytes_result[2:])
 
-        json_body = make_substrate_call_with_retry()
-        result = json_body["result"]
-
-        if result in (None, []):
-            return []
-
-        return NeuronInfoLite.list_from_vec_u8(result)
+        return NeuronInfoLite.list_from_vec_u8(bytes_result)
 
     def metagraph(
         self, netuid: int, lite: bool = True, block: Optional[int] = None

--- a/bittensor/_subtensor/subtensor_impl.py
+++ b/bittensor/_subtensor/subtensor_impl.py
@@ -1786,26 +1786,23 @@ class Subtensor:
         """
         if uid == None:
             return NeuronInfoLite._null_neuron()
+        
+        hex_bytes_result = self.query_runtime_api(
+            runtime_api="NeuronInfoRuntimeApi",
+            method="get_neuron_lite",
+            params={ 
+                "netuid": netuid,
+                "uid": uid,
+            },
+            block=block,
+        )
 
-        @retry(delay=2, tries=3, backoff=2, max_delay=4)
-        def make_substrate_call_with_retry():
-            with self.substrate as substrate:
-                block_hash = None if block == None else substrate.get_block_hash(block)
-                params = [netuid, uid]
-                if block_hash:
-                    params = params + [block_hash]
-                return substrate.rpc_request(
-                    method="neuronInfo_getNeuronLite",  # custom rpc method
-                    params=params,
-                )
-
-        json_body = make_substrate_call_with_retry()
-        result = json_body["result"]
-
-        if result in (None, []):
+        if hex_bytes_result == None:
             return NeuronInfoLite._null_neuron()
+        
+        bytes_result = bytes.fromhex(hex_bytes_result[2:])
 
-        return NeuronInfoLite.from_vec_u8(result)
+        return NeuronInfoLite.from_vec_u8(bytes_result)
 
     def neurons_lite(
         self, netuid: int, block: Optional[int] = None
@@ -1820,21 +1817,16 @@ class Subtensor:
             neuron (List[NeuronInfoLite]):
                 List of neuron lite metadata objects.
         """
-        hex_scale_bytes_result = self.query_runtime_api(
+        hex_bytes_result = self.query_runtime_api(
             runtime_api="NeuronInfoRuntimeApi",
             method="get_neurons_lite",
-            params=self.substrate.encode_scale(
-                'u16', value=netuid, block_hash=self.substrate.get_block_hash(block) if block is not None else None
-            ).data,
+            params=[netuid],
             block=block,
         )
 
-        if hex_scale_bytes_result == None:
+        if hex_bytes_result == None:
             return None
         
-        hex_bytes_result = self.substrate.decode_scale(
-            'Bytes<Vec<u8>>', hex_scale_bytes_result
-        )
         bytes_result = bytes.fromhex(hex_bytes_result[2:])
 
         return NeuronInfoLite.list_from_vec_u8(bytes_result)


### PR DESCRIPTION
This switches any custom RPC calls to instead use the `state_call` rpc to directly call the runtime API.   
This *should* allow us to change the runtime API signatures in the future, without modifying any RPCs.  
Meaning we would simply do a python-client code update for the metadata (or pull it live 👀 )