### PR TITLE
[Hotfix] updates requests module version in requirements

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -27,7 +27,7 @@ psutil==5.9.4
 python-levenshtein==0.12.1
 pyyaml==6.0
 retry==0.9.2
-requests==2.25.0
+requests==2.26.0
 rich==12.5.1
 scalecodec==1.2.0
 substrate-interface==1.5.0


### PR DESCRIPTION
- bumps up requirement of the `requests` module in order to prevent conflicts with modern libraries (e.g. `tiktoken`) 