### PR TITLE
Add stake info runtime api

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -142,6 +142,28 @@ __type_registry__ = {
                 },
             }
         },
+        "StakeInfoRuntimeApi": {
+            "methods": {
+                "get_stake_info_for_coldkey": {
+                    "params": [
+                        {
+                            "name": "coldkey_account_vec",
+                            "type": "Vec<u8>",
+                        },
+                    ],
+                    "type": "Vec<u8>",
+                },
+                "get_stake_info_for_coldkeys": {
+                    "params": [
+                        {
+                            "name": "coldkey_account_vecs",
+                            "type": "Vec<Vec<u8>>",
+                        },
+                    ],
+                    "type": "Vec<u8>",
+                },
+            },
+        },
     },
 }
 

--- a/bittensor/chain_data.py
+++ b/bittensor/chain_data.py
@@ -716,7 +716,8 @@ class DelegateInfo:
         ]
 
         return decoded
-    
+
+
 @dataclass
 class StakeInfo:
     r"""
@@ -731,13 +732,9 @@ class StakeInfo:
         r"""Fixes the decoded values."""
 
         return cls(
-            hotkey_ss58=ss58_encode(
-                decoded["hotkey"], bittensor.__ss58_format__
-            ),
+            hotkey_ss58=ss58_encode(decoded["hotkey"], bittensor.__ss58_format__),
             coldkey_ss58=ss58_encode(decoded["coldkey"], bittensor.__ss58_format__),
-            stake=Balance.from_rao(
-                decoded["stake"]
-            ),
+            stake=Balance.from_rao(decoded["stake"]),
         )
 
     @classmethod

--- a/bittensor/chain_data.py
+++ b/bittensor/chain_data.py
@@ -241,6 +241,18 @@ def from_scale_encoding(
     is_vec: bool = False,
     is_option: bool = False,
 ) -> Optional[Dict]:
+    type_string = type_name.name
+    if type_name == ChainDataType.DelegatedInfo:
+        # DelegatedInfo is a tuple of (DelegateInfo, Compact<u64>)
+        type_string = f"({ChainDataType.DelegateInfo.name}, Compact<u64>)"
+    if is_option:
+        type_string = f"Option<{type_string}>"
+    if is_vec:
+        type_string = f"Vec<{type_string}>"
+
+    return from_scale_encoding_using_type_string(input, type_string)
+
+def from_scale_encoding_using_type_string(input: Union[List[int], bytes, ScaleBytes], type_string: str) -> Optional[Dict]:
     if isinstance(input, ScaleBytes):
         as_scale_bytes = input
     else:
@@ -257,15 +269,6 @@ def from_scale_encoding(
     rpc_runtime_config = RuntimeConfiguration()
     rpc_runtime_config.update_type_registry(load_type_registry_preset("legacy"))
     rpc_runtime_config.update_type_registry(custom_rpc_type_registry)
-
-    type_string = type_name.name
-    if type_name == ChainDataType.DelegatedInfo:
-        # DelegatedInfo is a tuple of (DelegateInfo, Compact<u64>)
-        type_string = f"({ChainDataType.DelegateInfo.name}, Compact<u64>)"
-    if is_option:
-        type_string = f"Option<{type_string}>"
-    if is_vec:
-        type_string = f"Vec<{type_string}>"
 
     obj = rpc_runtime_config.create_scale_object(type_string, data=as_scale_bytes)
 

--- a/bittensor/chain_data.py
+++ b/bittensor/chain_data.py
@@ -226,6 +226,7 @@ class ChainDataType(Enum):
     DelegateInfo = 3
     NeuronInfoLite = 4
     DelegatedInfo = 5
+    StakeInfo = 6
 
 
 # Constants
@@ -713,6 +714,56 @@ class DelegateInfo:
             (DelegateInfo.fix_decoded_values(d), Balance.from_rao(s))
             for d, s in decoded
         ]
+
+        return decoded
+    
+@dataclass
+class StakeInfo:
+    r"""
+    Dataclass for stake info.
+    """
+    hotkey_ss58: str  # Hotkey address
+    coldkey_ss58: str  # Coldkey address
+    stake: Balance  # Stake for the hotkey-coldkey pair
+
+    @classmethod
+    def fix_decoded_values(cls, decoded: Any) -> "StakeInfo":
+        r"""Fixes the decoded values."""
+
+        return cls(
+            hotkey_ss58=ss58_encode(
+                decoded["hotkey"], bittensor.__ss58_format__
+            ),
+            coldkey_ss58=ss58_encode(decoded["coldkey"], bittensor.__ss58_format__),
+            stake=Balance.from_rao(
+                decoded["stake"]
+            ),
+        )
+
+    @classmethod
+    def from_vec_u8(cls, vec_u8: List[int]) -> Optional["StakeInfo"]:
+        r"""Returns a StakeInfo object from a vec_u8."""
+        if len(vec_u8) == 0:
+            return None
+
+        decoded = from_scale_encoding(vec_u8, ChainDataType.StakeInfo)
+
+        if decoded is None:
+            return None
+
+        decoded = StakeInfo.fix_decoded_values(decoded)
+
+        return decoded
+
+    @classmethod
+    def list_from_vec_u8(cls, vec_u8: List[int]) -> List["StakeInfo"]:
+        r"""Returns a list of StakeInfo objects from a vec_u8."""
+        decoded = from_scale_encoding(vec_u8, ChainDataType.StakeInfo, is_vec=True)
+
+        if decoded is None:
+            return []
+
+        decoded = [StakeInfo.fix_decoded_values(d) for d in decoded]
 
         return decoded
 

--- a/bittensor/chain_data.py
+++ b/bittensor/chain_data.py
@@ -252,7 +252,10 @@ def from_scale_encoding(
 
     return from_scale_encoding_using_type_string(input, type_string)
 
-def from_scale_encoding_using_type_string(input: Union[List[int], bytes, ScaleBytes], type_string: str) -> Optional[Dict]:
+
+def from_scale_encoding_using_type_string(
+    input: Union[List[int], bytes, ScaleBytes], type_string: str
+) -> Optional[Dict]:
     if isinstance(input, ScaleBytes):
         as_scale_bytes = input
     else:
@@ -273,7 +276,6 @@ def from_scale_encoding_using_type_string(input: Union[List[int], bytes, ScaleBy
     obj = rpc_runtime_config.create_scale_object(type_string, data=as_scale_bytes)
 
     return obj.decode()
-
 
 
 # Dataclasses for chain data.
@@ -755,13 +757,16 @@ class StakeInfo:
         decoded = StakeInfo.fix_decoded_values(decoded)
 
         return decoded
-    
+
     @classmethod
-    def list_of_tuple_from_vec_u8(cls, vec_u8: List[int]) -> Dict[str, List["StakeInfo"]]:
+    def list_of_tuple_from_vec_u8(
+        cls, vec_u8: List[int]
+    ) -> Dict[str, List["StakeInfo"]]:
         r"""Returns a list of StakeInfo objects from a vec_u8."""
-        decoded: Optional[List[Tuple(str, List[object])]] = from_scale_encoding_using_type_string(
-            input=vec_u8, 
-            type_string="Vec<(AccountId, Vec<StakeInfo>)>"
+        decoded: Optional[
+            List[Tuple(str, List[object])]
+        ] = from_scale_encoding_using_type_string(
+            input=vec_u8, type_string="Vec<(AccountId, Vec<StakeInfo>)>"
         )
 
         if decoded is None:
@@ -770,7 +775,8 @@ class StakeInfo:
         stake_map = {
             ss58_encode(address=account_id, ss58_format=bittensor.__ss58_format__): [
                 StakeInfo.fix_decoded_values(d) for d in stake_info
-            ] for account_id, stake_info in decoded
+            ]
+            for account_id, stake_info in decoded
         }
 
         return stake_map

--- a/bittensor/chain_data.py
+++ b/bittensor/chain_data.py
@@ -275,6 +275,7 @@ def from_scale_encoding_using_type_string(input: Union[List[int], bytes, ScaleBy
     return obj.decode()
 
 
+
 # Dataclasses for chain data.
 @dataclass
 class NeuronInfo:
@@ -754,6 +755,25 @@ class StakeInfo:
         decoded = StakeInfo.fix_decoded_values(decoded)
 
         return decoded
+    
+    @classmethod
+    def list_of_tuple_from_vec_u8(cls, vec_u8: List[int]) -> Dict[str, List["StakeInfo"]]:
+        r"""Returns a list of StakeInfo objects from a vec_u8."""
+        decoded: Optional[List[Tuple(str, List[object])]] = from_scale_encoding_using_type_string(
+            input=vec_u8, 
+            type_string="Vec<(AccountId, Vec<StakeInfo>)>"
+        )
+
+        if decoded is None:
+            return {}
+
+        stake_map = {
+            ss58_encode(address=account_id, ss58_format=bittensor.__ss58_format__): [
+                StakeInfo.fix_decoded_values(d) for d in stake_info
+            ] for account_id, stake_info in decoded
+        }
+
+        return stake_map
 
     @classmethod
     def list_from_vec_u8(cls, vec_u8: List[int]) -> List["StakeInfo"]:

--- a/bittensor/chain_data.py
+++ b/bittensor/chain_data.py
@@ -137,6 +137,14 @@ custom_rpc_type_registry = {
                 ["ip_type", "u8"],
             ],
         },
+        "StakeInfo": {
+            "type": "struct",
+            "type_mapping": [
+                ["hotkey", "AccountId"],
+                ["coldkey", "AccountId"],
+                ["stake", "Compact<u64>"],
+            ],
+        },
     }
 }
 

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -1792,7 +1792,7 @@ class subtensor:
     ) -> List[Tuple[DelegateInfo, Balance]]:
         """Returns the list of StakeInfo objects for this coldkey"""
 
-        encoded_coldkey = ss58_to_vec_u8(coldkey_ss58)        
+        encoded_coldkey = ss58_to_vec_u8(coldkey_ss58)
 
         hex_bytes_result = self.query_runtime_api(
             runtime_api="StakeInfoRuntimeApi",
@@ -1803,19 +1803,21 @@ class subtensor:
 
         if hex_bytes_result == None:
             return None
-        
+
         if hex_bytes_result.startswith("0x"):
             bytes_result = bytes.fromhex(hex_bytes_result[2:])
         else:
             bytes_result = bytes.fromhex(hex_bytes_result)
-            
+
         return StakeInfo.list_from_vec_u8(bytes_result)
-    
+
     def get_stake_info_for_colkeys(
         self, coldkey_ss58_list: List[str], block: Optional[int] = None
     ) -> List[Tuple[DelegateInfo, Balance]]:
         """Returns the list of StakeInfo objects for all coldkeys in the list."""
-        encoded_coldkeys = [ss58_to_vec_u8(coldkey_ss58) for coldkey_ss58 in coldkey_ss58_list]
+        encoded_coldkeys = [
+            ss58_to_vec_u8(coldkey_ss58) for coldkey_ss58 in coldkey_ss58_list
+        ]
 
         hex_bytes_result = self.query_runtime_api(
             runtime_api="StakeInfoRuntimeApi",
@@ -1826,14 +1828,14 @@ class subtensor:
 
         if hex_bytes_result == None:
             return None
-        
+
         if hex_bytes_result.startswith("0x"):
             bytes_result = bytes.fromhex(hex_bytes_result[2:])
         else:
             bytes_result = bytes.fromhex(hex_bytes_result)
-            
+
         return StakeInfo.list_from_vec_u8(bytes_result)
-    
+
     ########################################
     #### Neuron information per subnet ####
     ########################################

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -36,6 +36,7 @@ from .chain_data import (
     DelegateInfo,
     PrometheusInfo,
     SubnetInfo,
+    StakeInfo,
     NeuronInfoLite,
     AxonInfo,
     ProposalVoteData,
@@ -1782,6 +1783,57 @@ class subtensor:
 
         return DelegateInfo.delegated_list_from_vec_u8(result)
 
+    ###########################
+    #### Stake Information ####
+    ###########################
+
+    def get_stake_info_for_colkey(
+        self, coldkey_ss58: str, block: Optional[int] = None
+    ) -> List[Tuple[DelegateInfo, Balance]]:
+        """Returns the list of StakeInfo objects for this coldkey"""
+
+        encoded_coldkey = ss58_to_vec_u8(coldkey_ss58)        
+
+        hex_bytes_result = self.query_runtime_api(
+            runtime_api="StakeInfoRuntimeApi",
+            method="get_stake_info_for_coldkey",
+            params=[encoded_coldkey],
+            block=block,
+        )
+
+        if hex_bytes_result == None:
+            return None
+        
+        if hex_bytes_result.startswith("0x"):
+            bytes_result = bytes.fromhex(hex_bytes_result[2:])
+        else:
+            bytes_result = bytes.fromhex(hex_bytes_result)
+            
+        return StakeInfo.list_from_vec_u8(bytes_result)
+    
+    def get_stake_info_for_colkeys(
+        self, coldkey_ss58_list: List[str], block: Optional[int] = None
+    ) -> List[Tuple[DelegateInfo, Balance]]:
+        """Returns the list of StakeInfo objects for all coldkeys in the list."""
+        encoded_coldkeys = [ss58_to_vec_u8(coldkey_ss58) for coldkey_ss58 in coldkey_ss58_list]
+
+        hex_bytes_result = self.query_runtime_api(
+            runtime_api="StakeInfoRuntimeApi",
+            method="get_stake_info_for_coldkey",
+            params=[encoded_coldkeys],
+            block=block,
+        )
+
+        if hex_bytes_result == None:
+            return None
+        
+        if hex_bytes_result.startswith("0x"):
+            bytes_result = bytes.fromhex(hex_bytes_result[2:])
+        else:
+            bytes_result = bytes.fromhex(hex_bytes_result)
+            
+        return StakeInfo.list_from_vec_u8(bytes_result)
+    
     ########################################
     #### Neuron information per subnet ####
     ########################################

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -1834,7 +1834,7 @@ class subtensor:
         else:
             bytes_result = bytes.fromhex(hex_bytes_result)
 
-        return StakeInfo.list_from_vec_u8(bytes_result)
+        return StakeInfo.list_of_tuple_from_vec_u8(bytes_result)
 
     ########################################
     #### Neuron information per subnet ####

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -1821,7 +1821,7 @@ class subtensor:
 
         hex_bytes_result = self.query_runtime_api(
             runtime_api="StakeInfoRuntimeApi",
-            method="get_stake_info_for_coldkey",
+            method="get_stake_info_for_coldkeys",
             params=[encoded_coldkeys],
             block=block,
         )

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -66,7 +66,7 @@ from .extrinsics.senate import (
     vote_senate_extrinsic,
 )
 from .types import AxonServeCallParams, PrometheusServeCallParams
-from .utils import U16_NORMALIZED_FLOAT
+from .utils import U16_NORMALIZED_FLOAT, ss58_to_vec_u8
 from .utils.balance import Balance
 from .utils.registration import POWSolution
 
@@ -1726,8 +1726,7 @@ class subtensor:
                     params=params,
                 )
 
-        hotkey_bytes: bytes = bittensor.utils.ss58_address_to_bytes(hotkey_ss58)
-        encoded_hotkey: List[int] = [int(byte) for byte in hotkey_bytes]
+        encoded_hotkey = ss58_to_vec_u8(hotkey_ss58)
         json_body = make_substrate_call_with_retry(encoded_hotkey)
         result = json_body["result"]
 
@@ -1774,8 +1773,7 @@ class subtensor:
                     params=params,
                 )
 
-        coldkey_bytes: bytes = bittensor.utils.ss58_address_to_bytes(coldkey_ss58)
-        encoded_coldkey: List[int] = [int(byte) for byte in coldkey_bytes]
+        encoded_coldkey = ss58_to_vec_u8(coldkey_ss58)
         json_body = make_substrate_call_with_retry(encoded_coldkey)
         result = json_body["result"]
 

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -31,6 +31,10 @@ RAOPERTAO = 1e9
 U16_MAX = 65535
 U64_MAX = 18446744073709551615
 
+def ss58_to_vec_u8(ss58_address: str) -> List[int]:
+    ss58_bytes: bytes = bittensor.utils.ss58_address_to_bytes(ss58_address)
+    encoded_address: List[int] = [int(byte) for byte in ss58_bytes]
+    return encoded_address
 
 def unbiased_topk(values, k, dim=0, sorted=True, largest=True):
     r"""Selects topk as in torch.topk but does not bias lower indices when values are equal.

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -31,10 +31,12 @@ RAOPERTAO = 1e9
 U16_MAX = 65535
 U64_MAX = 18446744073709551615
 
+
 def ss58_to_vec_u8(ss58_address: str) -> List[int]:
     ss58_bytes: bytes = bittensor.utils.ss58_address_to_bytes(ss58_address)
     encoded_address: List[int] = [int(byte) for byte in ss58_bytes]
     return encoded_address
+
 
 def unbiased_topk(values, k, dim=0, sorted=True, largest=True):
     r"""Selects topk as in torch.topk but does not bias lower indices when values are equal.


### PR DESCRIPTION
Adds methods to grab `StakeInfo` from the chain.  This is the mapping for `coldkey -> [hotkey+coldkey+stake]`, straight from the `Stake` map. 

See: https://github.com/opentensor/subtensor/pull/182