### PR TITLE
[Revolution] Fix overview

### DIFF
--- a/bittensor/cli.py
+++ b/bittensor/cli.py
@@ -243,8 +243,11 @@ class cli:
             if isinstance(command_data, dict):
                 if config["subcommand"] != None:
                     command_data["commands"][config["subcommand"]].check_config(config)
+                    return
             else:
                 command_data.check_config(config)
+                return
+
         console.print(f":cross_mark:[red]Unknown command: {config.command}[/red]")
         sys.exit(1)
 

--- a/bittensor/cli.py
+++ b/bittensor/cli.py
@@ -243,13 +243,16 @@ class cli:
             if isinstance(command_data, dict):
                 if config["subcommand"] != None:
                     command_data["commands"][config["subcommand"]].check_config(config)
-                    return
+                else:
+                    console.print(
+                        f":cross_mark:[red]Missing subcommand for: {config.command}[/red]"
+                    )
+                    sys.exit(1)
             else:
                 command_data.check_config(config)
-                return
-
-        console.print(f":cross_mark:[red]Unknown command: {config.command}[/red]")
-        sys.exit(1)
+        else:
+            console.print(f":cross_mark:[red]Unknown command: {config.command}[/red]")
+            sys.exit(1)
 
     def run(self):
         """

--- a/bittensor/cli.py
+++ b/bittensor/cli.py
@@ -196,7 +196,7 @@ class cli:
                     help=command["help"],
                 )
                 subparser = subcmd_parser.add_subparsers(
-                    help=command["help"], dest="subcommand"
+                    help=command["help"], dest="subcommand", required=True
                 )
 
                 for subcommand in command["commands"].values():
@@ -241,19 +241,12 @@ class cli:
             command_data = COMMANDS[command]
 
             if isinstance(command_data, dict):
-                if config["subcommand"] == None:
-                    # This probably isn't the best solution, refactor
-                    for action in config["__parser"]._subparsers._actions:
-                        if action.dest == "command" and action.choices[command]:
-                            action.choices[command].print_help()
-                            sys.exit()
-
-                command_data["commands"][config["subcommand"]].check_config(config)
+                if config["subcommand"] != None:
+                    command_data["commands"][config["subcommand"]].check_config(config)
             else:
                 command_data.check_config(config)
-        else:
-            console.print(f":cross_mark:[red]Unknown command: {config.command}[/red]")
-            sys.exit()
+        console.print(f":cross_mark:[red]Unknown command: {config.command}[/red]")
+        sys.exit(1)
 
     def run(self):
         """

--- a/bittensor/commands/overview.py
+++ b/bittensor/commands/overview.py
@@ -116,18 +116,12 @@ class OverviewCommand:
             }
             all_hotkey_addresses = list(hotkey_addr_to_wallet.keys())
 
-            # Create a copy of the config without the parser and formatter_class.
-            ## This is needed to pass to the ProcessPoolExecutor, which cannot pickle the parser.
-            copy_config = cli.config.copy()
-            copy_config['__parser'] = None
-            copy_config['formatter_class'] = None
-
             # Pull neuron info for all keys.
             ## Max len(netuids) or 5 threads.
             with ProcessPoolExecutor(max_workers=max(len(netuids), 5)) as executor:
                 results = executor.map(
                     OverviewCommand._get_neurons_for_netuid,
-                    [(copy_config, netuid, all_hotkey_addresses) for netuid in netuids],
+                    [(cli.config, netuid, all_hotkey_addresses) for netuid in netuids],
                 )
                 executor.shutdown(wait=True)  # wait for all complete
 

--- a/bittensor/commands/overview.py
+++ b/bittensor/commands/overview.py
@@ -116,12 +116,18 @@ class OverviewCommand:
             }
             all_hotkey_addresses = list(hotkey_addr_to_wallet.keys())
 
+            # Create a copy of the config without the parser and formatter_class.
+            ## This is needed to pass to the ProcessPoolExecutor, which cannot pickle the parser.
+            copy_config = cli.config.copy()
+            copy_config['__parser'] = None
+            copy_config['formatter_class'] = None
+
             # Pull neuron info for all keys.
             ## Max len(netuids) or 5 threads.
             with ProcessPoolExecutor(max_workers=max(len(netuids), 5)) as executor:
                 results = executor.map(
                     OverviewCommand._get_neurons_for_netuid,
-                    [(cli.config, netuid, all_hotkey_addresses) for netuid in netuids],
+                    [(copy_config, netuid, all_hotkey_addresses) for netuid in netuids],
                 )
                 executor.shutdown(wait=True)  # wait for all complete
 

--- a/bittensor/config.py
+++ b/bittensor/config.py
@@ -152,7 +152,6 @@ class config(DefaultMunch):
         params = config.__parse_args__(args=args, parser=parser, strict=strict)
 
         _config = self
-        _config["__parser"] = parser
 
         # Splits params and add to config
         config.__split_params__(params=params, _config=_config)


### PR DESCRIPTION
This changes the subcommand handling to `required=True`   
This allows us to remove the check for this in `cli.check_config` and avoids storing the parser in the `config` object.  

Storing it there was causing issues with overview due to pickling of the `ArgumentParser`