### PR TITLE
simplify hashing for request verification

### DIFF
--- a/bittensor/commands/network.py
+++ b/bittensor/commands/network.py
@@ -166,7 +166,7 @@ HYPERPARAMS = {
     "immunity_period": "sudo_set_immunity_period",
     "min_allowed_weights": "sudo_set_min_allowed_weights",
     "activity_cutoff": "sudo_set_activity_cutoff",
-    "max_validators": "sudo_set_max_allowed_validators"
+    "max_validators": "sudo_set_max_allowed_validators",
 }
 
 

--- a/bittensor/commands/root.py
+++ b/bittensor/commands/root.py
@@ -121,8 +121,10 @@ class RootList:
                 if neuron_data.hotkey in delegate_info
                 else "",
                 neuron_data.hotkey,
-                "{:.5f}".format(float(subtensor.get_total_stake_for_hotkey(neuron_data.hotkey))),
-                "Yes" if neuron_data.hotkey in senate_members else "No"
+                "{:.5f}".format(
+                    float(subtensor.get_total_stake_for_hotkey(neuron_data.hotkey))
+                ),
+                "Yes" if neuron_data.hotkey in senate_members else "No",
             )
 
         table.box = None

--- a/bittensor/dendrite.py
+++ b/bittensor/dendrite.py
@@ -347,40 +347,11 @@ class dendrite(torch.nn.Module):
             }
         )
 
-        # Sign the request using the dendrite, axon info, and the synapse body hashes
-        body_hashes = self.hash_synapse_body(synapse)
-
-        message = f"{synapse.dendrite.nonce}.{synapse.dendrite.hotkey}.{synapse.axon.hotkey}.{synapse.dendrite.uuid}.{body_hashes}"
+        # Sign the request using the dendrite, axon info, and the synapse body hash
+        message = f"{synapse.dendrite.nonce}.{synapse.dendrite.hotkey}.{synapse.axon.hotkey}.{synapse.dendrite.uuid}.{synapse.body_hash}"
         synapse.dendrite.signature = f"0x{self.keypair.sign(message).hex()}"
 
         return synapse
-
-    @staticmethod
-    def hash_synapse_body(synapse: bittensor.Synapse) -> str:
-        """
-        Compute a SHA-256 hash of the serialized body of the Synapse instance.
-
-        The body of the Synapse instance comprises its serialized and encoded
-        non-optional fields. This property retrieves these fields using the
-        `get_body` method, then concatenates their string representations, and
-        finally computes a SHA-256 hash of the resulting string.
-
-        Returns:
-            str: The hexadecimal representation of the SHA-256 hash of the instance's body.
-        """
-        # Hash the body for verification
-        hashes = []
-
-        # Getting the fields of the instance
-        instance_fields = synapse.__dict__
-
-        # Iterating over the fields of the instance
-        for field, value in instance_fields.items():
-            # If the field is required in the subclass schema, add it.
-            if field in synapse.required_hash_fields:
-                hashes.append(bittensor.utils.hash(str(value)))
-
-        return hashes
 
     def process_server_response(
         self,

--- a/bittensor/synapse.py
+++ b/bittensor/synapse.py
@@ -690,7 +690,9 @@ class Synapse(pydantic.BaseModel):
         inputs_dict["total_size"] = headers.get("total_size", None)
         inputs_dict["computed_body_hash"] = headers.get("computed_body_hash", None)
         inputs_dict["hash_fields"] = json.loads(
-            base64.b64decode(headers.get("hash_fields", "W10=").encode()).decode("utf-8")
+            base64.b64decode(headers.get("hash_fields", "W10=").encode()).decode(
+                "utf-8"
+            )
         )
 
         return inputs_dict

--- a/bittensor/synapse.py
+++ b/bittensor/synapse.py
@@ -542,7 +542,6 @@ class Synapse(pydantic.BaseModel):
         headers["header_size"] = str(sys.getsizeof(headers))
         headers["total_size"] = str(self.get_total_size())
         headers["computed_body_hash"] = self.body_hash
-        print("required_hash_fields", self.required_hash_fields)
         headers["hash_fields"] = base64.b64encode(
             json.dumps(self.required_hash_fields).encode()
         ).decode("utf-8")

--- a/bittensor/synapse.py
+++ b/bittensor/synapse.py
@@ -323,6 +323,10 @@ class Synapse(pydantic.BaseModel):
             raise AttributeError(
                 "required_hash_fields property is read-only and cannot be overridden."
             )
+        if name == "body_hash":
+            raise AttributeError(
+                "body_hash property is read-only and cannot be overridden."
+            )
         super().__setattr__(name, value)
 
     @property

--- a/bittensor/synapse.py
+++ b/bittensor/synapse.py
@@ -542,6 +542,7 @@ class Synapse(pydantic.BaseModel):
         headers["header_size"] = str(sys.getsizeof(headers))
         headers["total_size"] = str(self.get_total_size())
         headers["computed_body_hash"] = self.body_hash
+        print("required_hash_fields", self.required_hash_fields)
         headers["hash_fields"] = base64.b64encode(
             json.dumps(self.required_hash_fields).encode()
         ).decode("utf-8")
@@ -690,7 +691,7 @@ class Synapse(pydantic.BaseModel):
         inputs_dict["total_size"] = headers.get("total_size", None)
         inputs_dict["computed_body_hash"] = headers.get("computed_body_hash", None)
         inputs_dict["hash_fields"] = json.loads(
-            base64.b64decode(headers.get("hash_fields", "").encode()).decode("utf-8")
+            base64.b64decode(headers.get("hash_fields", "W10=").encode()).decode("utf-8")
         )
 
         return inputs_dict

--- a/bittensor/synapse.py
+++ b/bittensor/synapse.py
@@ -297,6 +297,24 @@ class Synapse(pydantic.BaseModel):
         repr=False,
     )
 
+    computed_body_hash: Optional[str] = pydantic.Field(
+        title="computed_body_hash",
+        description="The computed body hash of the request.",
+        examples="0x0813029319030129u4120u10841824y0182u091u230912u",
+        default="",
+        allow_mutation=False,
+        repr=False,
+    )
+
+    hash_fields: Optional[List[str]] = pydantic.Field(
+        title="hash_fields",
+        description="The list of required fields to compute the body hash.",
+        examples=["roles", "messages"],
+        default=[],
+        allow_mutation=False,
+        repr=False,
+    )
+
     def __setattr__(self, name: str, value: Any):
         """
         Override the __setattr__ method to make the `required_hash_fields` property read-only.
@@ -505,15 +523,12 @@ class Synapse(pydantic.BaseModel):
 
             elif required and field in required:
                 try:
-                    # Create an empty (dummy) instance of type(value) to pass pydantic validation on the axon side
+                    # create an empty (dummy) instance of type(value) to pass pydantic validation on the axon side
                     serialized_value = json.dumps(value.__class__.__call__())
-                    # Create a hash of the original data so we can verify on the axon side
-                    hash_value = bittensor.utils.hash(str(value))
                     encoded_value = base64.b64encode(serialized_value.encode()).decode(
                         "utf-8"
                     )
                     headers[f"bt_header_input_obj_{field}"] = encoded_value
-                    headers[f"bt_header_input_hash_{field}"] = hash_value
                 except TypeError as e:
                     raise ValueError(
                         f"Error serializing {field} with value {value}. Objects must be json serializable."
@@ -522,8 +537,39 @@ class Synapse(pydantic.BaseModel):
         # Adding the size of the headers and the total size to the headers
         headers["header_size"] = str(sys.getsizeof(headers))
         headers["total_size"] = str(self.get_total_size())
-
+        headers["computed_body_hash"] = self.body_hash
+        headers["hash_fields"] = base64.b64encode(
+            json.dumps(self.required_hash_fields).encode()
+        ).decode("utf-8")
         return headers
+
+    @property
+    def body_hash(self) -> str:
+        """
+        Compute a SHA-256 hash of the serialized body of the Synapse instance.
+
+        The body of the Synapse instance comprises its serialized and encoded
+        non-optional fields. This property retrieves these fields using the
+        `get_body` method, then concatenates their string representations, and
+        finally computes a SHA-256 hash of the resulting string.
+
+        Returns:
+            str: The hexadecimal representation of the SHA-256 hash of the instance's body.
+        """
+        # Hash the body for verification
+        hashes = []
+
+        # Getting the fields of the instance
+        instance_fields = self.__dict__
+
+        # Iterating over the fields of the instance
+        for field, value in instance_fields.items():
+            # If the field is required in the subclass schema, add it.
+            if field in self.required_hash_fields:
+                hashes.append(bittensor.utils.hash(str(value)))
+
+        # Hash and return the hashes that have been concatenated
+        return bittensor.utils.hash("".join(hashes))
 
     @classmethod
     def parse_headers_to_inputs(cls, headers: dict) -> dict:
@@ -630,27 +676,18 @@ class Synapse(pydantic.BaseModel):
                         f"Error while parsing 'input_obj' header {key}: {e}"
                     )
                     continue
-            elif "bt_header_input_hash" in key:
-                try:
-                    new_key = key.split("bt_header_input_hash_")[1] + "_hash"
-                    # Skip if the key already exists in the dictionary
-                    if new_key in inputs_dict:
-                        continue
-                    # Decode and load the serialized object
-                    inputs_dict[new_key] = value
-                except Exception as e:
-                    bittensor.logging.error(
-                        f"Error while parsing 'input_hash' header {key}: {e}"
-                    )
-                    continue
             else:
-                pass  # log unexpected keys
+                pass  # TODO: log unexpected keys
 
         # Assign the remaining known headers directly
         inputs_dict["timeout"] = headers.get("timeout", None)
         inputs_dict["name"] = headers.get("name", None)
         inputs_dict["header_size"] = headers.get("header_size", None)
         inputs_dict["total_size"] = headers.get("total_size", None)
+        inputs_dict["computed_body_hash"] = headers.get("computed_body_hash", None)
+        inputs_dict["hash_fields"] = json.loads(
+            base64.b64decode(headers.get("hash_fields", "").encode()).decode("utf-8")
+        )
 
         return inputs_dict
 

--- a/tests/unit_tests/test_synapse.py
+++ b/tests/unit_tests/test_synapse.py
@@ -39,11 +39,16 @@ def test_parse_headers_to_inputs():
         "name": "Test",
         "header_size": "111",
         "total_size": "111",
+        "computed_body_hash": "0xabcdef",
+        "hash_fields": base64.b64encode(
+            json.dumps(["key1", "key2"]).encode("utf-8")
+        ).decode("utf-8"),
     }
+    print(headers)
 
     # Run the function to test
     inputs_dict = Test.parse_headers_to_inputs(headers)
-
+    print(inputs_dict)
     # Check the resulting dictionary
     assert inputs_dict == {
         "axon": {"nonce": "111"},
@@ -54,6 +59,8 @@ def test_parse_headers_to_inputs():
         "name": "Test",
         "header_size": "111",
         "total_size": "111",
+        "computed_body_hash": "0xabcdef",
+        "hash_fields": ["key1", "key2"],
     }
 
 
@@ -74,6 +81,10 @@ def test_from_headers():
         "name": "Test",
         "header_size": "111",
         "total_size": "111",
+        "computed_body_hash": "0xabcdef",
+        "hash_fields": base64.b64encode(
+            json.dumps(["key1", "key2"]).encode("utf-8")
+        ).decode("utf-8"),
     }
 
     # Run the function to test
@@ -238,6 +249,18 @@ def test_dict_tensors():
 
 
 def test_body_hash_override():
+    # Create a Synapse instance
+    synapse_instance = bittensor.Synapse()
+
+    # Try to set the body_hash property and expect an AttributeError
+    with pytest.raises(
+        AttributeError,
+        match="body_hash property is read-only and cannot be overridden.",
+    ):
+        synapse_instance.body_hash = []
+
+
+def test_required_fields_override():
     # Create a Synapse instance
     synapse_instance = bittensor.Synapse()
 


### PR DESCRIPTION
Simplifies the verification process by having a single hash to send over the wire instead of hashes for each field. Also cleans up the naming convention issues with splitting on `_hash_`.

2-step verification process:
* Dendrite calls `synapse.to_headers()` on synapse instance to get required information for the request, which now includes `computed_body_hash` as a hash of the concatenated hashes for each required body field, as well as `hash_fields` which passes the list of required fields that must be hashed in order to verify the request.
* Axon middleware receives request and does intercept verification (blacklist pre-verify) using only header information, which ensures the hashes passed in the request headers were indeed signed by the calling keypair.
* `verify_body_integrity` is called via dependency injection in fastapi to unwrap the body at an appropriate place in its lifecycle. This verifies the body itself was not modified in transit.
* `forward_fn` is processed with the verified body and returned after `run()` completes, returning the response from the server.