### PR TITLE
Root Metagraph fixes

### DIFF
--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -2306,7 +2306,7 @@ class subtensor:
         return NeuronInfoLite.list_from_vec_u8(bytes_result)
 
     def metagraph(
-        self, netuid: int, lite: bool = True, block: Optional[int] = None
+        self, netuid: int, lite: bool = True, block: Optional[int] = None, root: bool = False
     ) -> "bittensor.Metagraph":
         r"""Returns a synced metagraph for the subnet.
         Args:
@@ -2323,7 +2323,7 @@ class subtensor:
         metagraph_ = bittensor.metagraph(
             network=self.network, netuid=netuid, lite=lite, sync=False
         )
-        metagraph_.sync(block=block, lite=lite, subtensor=self)
+        metagraph_.sync(block=block, lite=lite, subtensor=self, root=root)
 
         return metagraph_
 


### PR DESCRIPTION
`meta = sub.metagraph(0,lite=False)` breaks the current implementation of the metagraph. 
![image](https://github.com/opentensor/bittensor/assets/85906264/2b5cf769-aea9-4e14-abff-36c101874e9a)

This PR adds a new flag `root` that defines the metagraph's behaviour when a root network is expected.
The new correct method: `meta = sub.metagraph(0,lite=False, root=True)`