### PR TITLE
Header fix

### DIFF
--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -312,7 +312,9 @@ class axon:
         ].annotation
 
         # Parse required hash fields from the forward function protocol defaults
-        required_hash_fields = request_class.__dict__["__fields__"]["required_hash_fields"].default
+        required_hash_fields = request_class.__dict__["__fields__"][
+            "required_hash_fields"
+        ].default
 
         # Assert that the first argument of 'forward_fn' is a subclass of 'bittensor.Synapse'
         assert issubclass(

--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -271,7 +271,6 @@ class axon:
         blacklist_fn: Callable = None,
         priority_fn: Callable = None,
         verify_fn: Callable = None,
-        required_hash_fields: List[str] = [],
     ) -> "bittensor.axon":
         """
         Registers an API endpoint to the FastAPI application router.
@@ -311,6 +310,9 @@ class axon:
         request_class = forward_sig.parameters[
             list(forward_sig.parameters)[0]
         ].annotation
+
+        # Parse required hash fields from the forward function protocol defaults
+        required_hash_fields = request_class.__dict__["__fields__"]["required_hash_fields"].default
 
         # Assert that the first argument of 'forward_fn' is a subclass of 'bittensor.Synapse'
         assert issubclass(

--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -242,6 +242,7 @@ class axon:
         self.priority_fns = {}
         self.forward_fns = {}
         self.verify_fns = {}
+        self.required_hash_fields = {}
 
         # Instantiate FastAPI
         self.app = FastAPI()
@@ -484,8 +485,7 @@ class axon:
             # Exception handling for re-parsing arguments
             pass
 
-    @staticmethod
-    async def verify_body_integrity(request: Request):
+    async def verify_body_integrity(self, request: Request):
         """
         Asynchronously verifies the integrity of the body of a request by comparing the hash of required fields
         with the corresponding hashes provided in the request headers. This method is critical for ensuring

--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -628,7 +628,7 @@ class axon:
         subtensor.serve_axon(netuid=netuid, axon=self)
         return self
 
-    def default_verify(self, synapse: bittensor.Synapse):
+    async def default_verify(self, synapse: bittensor.Synapse):
         """
         This method is used to verify the authenticity of a received message using a digital signature.
         It ensures that the message was not tampered with and was sent by the expected sender.

--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -271,7 +271,7 @@ class axon:
         blacklist_fn: Callable = None,
         priority_fn: Callable = None,
         verify_fn: Callable = None,
-        required_hash_fields: List[str] = None,
+        required_hash_fields: List[str] = [],
     ) -> "bittensor.axon":
         """
         Registers an API endpoint to the FastAPI application router.

--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -286,7 +286,6 @@ class axon:
                                               Defaults to None, meaning no priority sorting will be applied.
             verify_fn (Callable, optional): Function to verify requests. It should take the same arguments as 'forward_fn' and return
                                             a boolean value. If None, 'self.default_verify' function will be used.
-            required_hash_fields (List[str], optional): List of fields in the request body that should be hashed and compared against
 
         Note: 'forward_fn', 'blacklist_fn', 'priority_fn', and 'verify_fn' should be designed to receive the same parameters.
 

--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -519,7 +519,7 @@ class axon:
 
         # Gather the required field names from the axon's required_hash_fields dict
         request_name = request.url.path.split("/")[1]
-        required_hash_fields = self.required_hash_fields[request.url.path]
+        required_hash_fields = self.required_hash_fields[request_name]
 
         # Load the body dict and check if all required field hashes match
         body_dict = json.loads(request_body)

--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -311,11 +311,6 @@ class axon:
             list(forward_sig.parameters)[0]
         ].annotation
 
-        # Parse required hash fields from the forward function protocol defaults
-        required_hash_fields = request_class.__dict__["__fields__"][
-            "required_hash_fields"
-        ].default
-
         # Assert that the first argument of 'forward_fn' is a subclass of 'bittensor.Synapse'
         assert issubclass(
             request_class, bittensor.Synapse
@@ -403,6 +398,11 @@ class axon:
             verify_fn or self.default_verify
         )  # Use 'default_verify' if 'verify_fn' is None
         self.forward_fns[request_name] = forward_fn
+
+        # Parse required hash fields from the forward function protocol defaults
+        required_hash_fields = request_class.__dict__["__fields__"][
+            "required_hash_fields"
+        ].default
         self.required_hash_fields[request_name] = required_hash_fields
 
         return self

--- a/bittensor/synapse.py
+++ b/bittensor/synapse.py
@@ -503,7 +503,7 @@ class Synapse(pydantic.BaseModel):
 
         The body of the Synapse instance comprises its serialized and encoded
         non-optional fields. This property retrieves these fields using the
-        `required_fields_hash` field, then concatenates their string representations, 
+        `required_fields_hash` field, then concatenates their string representations,
         and finally computes a SHA3-256 hash of the resulting string.
 
         Returns:

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -200,11 +200,11 @@ def u8_key_to_ss58(u8_key: List[int]) -> str:
     return scalecodec.ss58_encode(bytes(u8_key).hex(), bittensor.__ss58_format__)
 
 
-def hash(content, hash_type="md5", encoding="utf-8"):
-    algo = hashlib.md5() if hash_type == "md5" else hashlib.sha256()
+def hash(content, encoding="utf-8"):
+    sha3 = hashlib.sha3_256()
 
     # Update the hash object with the concatenated string
-    algo.update(content.encode(encoding))
+    sha3.update(content.encode(encoding))
 
     # Produce the hash
-    return algo.hexdigest()
+    return sha3.hexdigest()

--- a/tests/unit_tests/test_synapse.py
+++ b/tests/unit_tests/test_synapse.py
@@ -40,9 +40,6 @@ def test_parse_headers_to_inputs():
         "header_size": "111",
         "total_size": "111",
         "computed_body_hash": "0xabcdef",
-        "hash_fields": base64.b64encode(
-            json.dumps(["key1", "key2"]).encode("utf-8")
-        ).decode("utf-8"),
     }
     print(headers)
 
@@ -60,7 +57,6 @@ def test_parse_headers_to_inputs():
         "header_size": "111",
         "total_size": "111",
         "computed_body_hash": "0xabcdef",
-        "hash_fields": ["key1", "key2"],
     }
 
 
@@ -82,9 +78,6 @@ def test_from_headers():
         "header_size": "111",
         "total_size": "111",
         "computed_body_hash": "0xabcdef",
-        "hash_fields": base64.b64encode(
-            json.dumps(["key1", "key2"]).encode("utf-8")
-        ).decode("utf-8"),
     }
 
     # Run the function to test
@@ -264,9 +257,10 @@ def test_required_fields_override():
     # Create a Synapse instance
     synapse_instance = bittensor.Synapse()
 
-    # Try to set the body_hash property and expect an AttributeError
+    # Try to set the required_hash_fields property and expect a TypeError
     with pytest.raises(
-        AttributeError,
-        match="required_hash_fields property is read-only and cannot be overridden.",
+        TypeError,
+        match='"required_hash_fields" has allow_mutation set to False and cannot be assigned',
     ):
         synapse_instance.required_hash_fields = []
+

--- a/tests/unit_tests/test_synapse.py
+++ b/tests/unit_tests/test_synapse.py
@@ -263,4 +263,3 @@ def test_required_fields_override():
         match='"required_hash_fields" has allow_mutation set to False and cannot be assigned',
     ):
         synapse_instance.required_hash_fields = []
-


### PR DESCRIPTION
* Move from md5 (broken) -> sha3 hashing
* Eliminate parsing `required_hash_fields` and let subclasses define them directly as a pydantic field
* `required_hash_fields` is parsed in the `attach()` method directly from the `synapse` protocol subclass
* Makes `default_verify` async (as it should be)