### PR TITLE
fixes tensors not hashing correctly

### DIFF
--- a/bittensor/synapse.py
+++ b/bittensor/synapse.py
@@ -513,8 +513,7 @@ class Synapse(pydantic.BaseModel):
         hashes = []
 
         # Getting the fields of the instance
-        instance_fields = self.__dict__
-
+        instance_fields = self.dict() # __dict__ converts the Tensor types into strings causing a mismatch in the hash, so we use .dict() instead
         for field, value in instance_fields.items():
             # If the field is required in the subclass schema, hash and add it.
             if field in self.required_hash_fields:


### PR DESCRIPTION
This issue was caused from using `__dict__` which converted the Tensor object into one with just its datatype and shape values, disregarding the actual buffer or content within the Tensor.

The Axon.py file when it was trying to decode the response from the sender would then compare the hash using the buffer that was sent, causing a mismatch of hashes.

This change fixes that by utilizing `.dict()` instead.