### PR TITLE
Dendrite & Synapse updates and fixes

### DIFF
--- a/bittensor/dendrite.py
+++ b/bittensor/dendrite.py
@@ -76,8 +76,8 @@ class dendrite(torch.nn.Module):
     NOTE: When working with async aiohttp client sessions, it is recommended to use a context manager.
 
     Example with a context manager:
-        >>> aysnc with dendrite(wallet = bittensor.wallet() ) as dendrite_obj:
-        >>>     print(dendrite_obj)
+        >>> aysnc with dendrite(wallet = bittensor.wallet()) as d:
+        >>>     print(d)
         >>>     d( <axon> ) # ping axon
         >>>     d( [<axons>] ) # ping multiple
         >>>     d( bittensor.axon(), bittensor.Synapse )
@@ -85,8 +85,8 @@ class dendrite(torch.nn.Module):
     However, you are able to safely call dendrite.query() without a context manager in a synchronous setting.
 
     Example without a context manager:
-        >>> dendrite_obj = dendrite(wallet = bittensor.wallet() )
-        >>> print(dendrite_obj)
+        >>> d = dendrite(wallet = bittensor.wallet() )
+        >>> print(d)
         >>> d( <axon> ) # ping axon
         >>> d( [<axons>] ) # ping multiple
         >>> d( bittensor.axon(), bittensor.Synapse )

--- a/bittensor/dendrite.py
+++ b/bittensor/dendrite.py
@@ -152,6 +152,7 @@ class dendrite(torch.nn.Module):
         """
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self._session.close())
+        self._session = None
 
     async def aclose_session(self):
         """

--- a/bittensor/dendrite.py
+++ b/bittensor/dendrite.py
@@ -187,13 +187,15 @@ class dendrite(torch.nn.Module):
         """
         try:
             loop = asyncio.get_event_loop()
-            return loop.run_until_complete(self.forward(*args, **kwargs))
+            result = loop.run_until_complete(self.forward(*args, **kwargs))
         except:
             new_loop = asyncio.new_event_loop()
             asyncio.set_event_loop(new_loop)
             result = loop.run_until_complete(self.forward(*args, **kwargs))
-            self.close_session()
             new_loop.close()
+            return result
+        finally:
+            self.close_session()
             return result
 
     async def forward(

--- a/bittensor/dendrite.py
+++ b/bittensor/dendrite.py
@@ -131,10 +131,6 @@ class dendrite(torch.nn.Module):
 
         Returns:
             aiohttp.ClientSession: The aiohttp client session instance.
-
-        Usage:
-            async with dendrite_instance.session as session:
-                response = await session.get('http://example.com')
         """
         if self._session is None:
             self._session = aiohttp.ClientSession()
@@ -173,6 +169,8 @@ class dendrite(torch.nn.Module):
     ) -> Union[bittensor.Synapse, List[bittensor.Synapse]]:
         """
         Makes a synchronous request to multiple target Axons and returns the server responses.
+
+        Cleanup is automatically handled and sessions are closed upon completed requests.
 
         Args:
             axons (Union[List[Union['bittensor.AxonInfo', 'bittensor.axon']], Union['bittensor.AxonInfo', 'bittensor.axon']]):

--- a/bittensor/synapse.py
+++ b/bittensor/synapse.py
@@ -410,7 +410,6 @@ class Synapse(pydantic.BaseModel):
         Headers for 'name' and 'timeout' are directly taken from the instance.
         Further headers are constructed from the properties 'axon' and 'dendrite'.
 
-        If the object is a tensor, its shape and data type are added to the headers.
         For non-optional objects, these are serialized and encoded before adding to the headers.
 
         Finally, the function adds the sizes of the headers and the total size to the headers.
@@ -453,28 +452,6 @@ class Synapse(pydantic.BaseModel):
             # Skipping the field if it's already in the headers or its value is None
             if field in headers or value is None:
                 continue
-
-            # Adding the tensor shape and data type to the headers if the object is a tensor
-            if isinstance(value, bittensor.Tensor):
-                headers[f"bt_header_tensor_{field}"] = f"{value.shape}-{value.dtype}"
-
-            elif isinstance(value, list) and all(
-                isinstance(elem, bittensor.Tensor) for elem in value
-            ):
-                serialized_list_tensor = []
-                for i, tensor in enumerate(value):
-                    serialized_list_tensor.append(f"{tensor.shape}-{tensor.dtype}")
-                headers[f"bt_header_list_tensor_{field}"] = str(serialized_list_tensor)
-
-            elif isinstance(value, dict) and all(
-                isinstance(elem, bittensor.Tensor) for elem in value.values()
-            ):
-                serialized_dict_tensor = []
-                for key, tensor in value.items():
-                    serialized_dict_tensor.append(
-                        f"{key}-{tensor.shape}-{tensor.dtype}"
-                    )
-                headers[f"bt_header_dict_tensor_{field}"] = str(serialized_dict_tensor)
 
             elif required and field in required:
                 try:
@@ -561,50 +538,6 @@ class Synapse(pydantic.BaseModel):
                 except Exception as e:
                     bittensor.logging.error(
                         f"Error while parsing 'dendrite' header {key}: {e}"
-                    )
-                    continue
-            # Handle 'tensor' headers
-            elif "bt_header_tensor_" in key:
-                try:
-                    new_key = key.split("bt_header_tensor_")[1]
-                    shape, dtype = value.split("-")
-                    # TODO: Verify if the shape and dtype values need to be converted before being used
-                    inputs_dict[new_key] = bittensor.Tensor(shape=shape, dtype=dtype)
-                except Exception as e:
-                    bittensor.logging.error(
-                        f"Error while parsing 'tensor' header {key}: {e}"
-                    )
-                    continue
-            elif "bt_header_list_tensor_" in key:
-                try:
-                    new_key = key.split("bt_header_list_tensor_")[1]
-                    deserialized_tensors = []
-                    stensors = ast.literal_eval(value)
-                    for value in stensors:
-                        shape, dtype = value.split("-")
-                        deserialized_tensors.append(
-                            bittensor.Tensor(shape=shape, dtype=dtype)
-                        )
-                    inputs_dict[new_key] = deserialized_tensors
-                except Exception as e:
-                    bittensor.logging.error(
-                        f"Error while parsing 'tensor' header {key}: {e}"
-                    )
-                    continue
-            elif "bt_header_dict_tensor_" in key:
-                try:
-                    new_key = key.split("bt_header_dict_tensor_")[1]
-                    deserialized_dict_tensors = {}
-                    stensors = ast.literal_eval(value)
-                    for value in stensors:
-                        key, shape, dtype = value.split("-")
-                        deserialized_dict_tensors[key] = bittensor.Tensor(
-                            shape=shape, dtype=dtype
-                        )
-                    inputs_dict[new_key] = deserialized_dict_tensors
-                except Exception as e:
-                    bittensor.logging.error(
-                        f"Error while parsing 'tensor' header {key}: {e}"
                     )
                     continue
             # Handle 'input_obj' headers

--- a/bittensor/synapse.py
+++ b/bittensor/synapse.py
@@ -441,7 +441,7 @@ class Synapse(pydantic.BaseModel):
         property_type_hints = typing.get_type_hints(self)
 
         # Getting the fields of the instance
-        instance_fields = self.__dict__
+        instance_fields = self.dict()
 
         # Iterating over the fields of the instance
         for field, value in instance_fields.items():

--- a/tests/unit_tests/test_dendrite.py
+++ b/tests/unit_tests/test_dendrite.py
@@ -18,9 +18,19 @@
 # DEALINGS IN THE SOFTWARE.
 
 import pytest
+import typing
 import bittensor
 from unittest.mock import MagicMock, Mock, patch
 from tests.helpers import _get_mock_wallet
+
+
+class Dummy(bittensor.Synapse):
+    input: int
+    output: typing.Optional[int] = None
+
+def dummy(synapse: Dummy) -> Dummy:
+    synapse.output = synapse.input + 1
+    return synapse
 
 
 @pytest.fixture
@@ -31,6 +41,13 @@ def setup_dendrite():
     dendrite_obj = bittensor.dendrite(user_wallet)
     return dendrite_obj
 
+@pytest.fixture(scope="session")
+def setup_axon():
+    axon = bittensor.axon()
+    axon.attach(forward_fn=dummy)
+    axon.start()
+    yield axon
+    del axon
 
 def test_init(setup_dendrite):
     dendrite_obj = setup_dendrite
@@ -48,6 +65,31 @@ def test_repr(setup_dendrite):
     dendrite_obj = setup_dendrite
     expected_string = "dendrite({})".format(setup_dendrite.keypair.ss58_address)
     assert repr(dendrite_obj) == expected_string
+
+
+def test_close(setup_dendrite, setup_axon):
+    axon = setup_axon
+    dendrite_obj = setup_dendrite = d = bittensor.dendrite()
+
+    dendrite_obj.query(axon, Dummy(input=1))
+    dendrite_obj.close_session()
+    assert dendrite_obj._session.closed == True
+
+
+@pytest.mark.asyncio
+async def test_aclose(setup_dendrite, setup_axon):
+    axon = setup_axon
+    dendrite_obj = setup_dendrite = d = bittensor.dendrite()
+
+    async with dendrite_obj:
+        resp = await dendrite_obj(
+            [axon],
+            Dummy(input=1),
+            deserialize=False
+        )
+
+    assert dendrite_obj._session == None
+    del axon
 
 
 class AsyncMock(Mock):

--- a/tests/unit_tests/test_dendrite.py
+++ b/tests/unit_tests/test_dendrite.py
@@ -28,6 +28,7 @@ class Dummy(bittensor.Synapse):
     input: int
     output: typing.Optional[int] = None
 
+
 def dummy(synapse: Dummy) -> Dummy:
     synapse.output = synapse.input + 1
     return synapse
@@ -41,6 +42,7 @@ def setup_dendrite():
     dendrite_obj = bittensor.dendrite(user_wallet)
     return dendrite_obj
 
+
 @pytest.fixture(scope="session")
 def setup_axon():
     axon = bittensor.axon()
@@ -48,6 +50,7 @@ def setup_axon():
     axon.start()
     yield axon
     del axon
+
 
 def test_init(setup_dendrite):
     dendrite_obj = setup_dendrite
@@ -82,11 +85,7 @@ async def test_aclose(setup_dendrite, setup_axon):
     dendrite_obj = setup_dendrite = d = bittensor.dendrite()
 
     async with dendrite_obj:
-        resp = await dendrite_obj(
-            [axon],
-            Dummy(input=1),
-            deserialize=False
-        )
+        resp = await dendrite_obj([axon], Dummy(input=1), deserialize=False)
 
     assert dendrite_obj._session == None
 

--- a/tests/unit_tests/test_dendrite.py
+++ b/tests/unit_tests/test_dendrite.py
@@ -75,11 +75,7 @@ def test_close(setup_dendrite, setup_axon):
     dendrite_obj = setup_dendrite
     # Query the axon to open a session
     dendrite_obj.query(axon, SynapseDummy(input=1))
-    assert dendrite_obj._session != None
-    # We haven't called close yet, so the session should still be open
-    assert dendrite_obj._session.closed == False
-    # We call close and should delete the session after closing
-    dendrite_obj.close_session()
+    # Session should be automatically closed after query
     assert dendrite_obj._session == None
 
 

--- a/tests/unit_tests/test_dendrite.py
+++ b/tests/unit_tests/test_dendrite.py
@@ -89,7 +89,6 @@ async def test_aclose(setup_dendrite, setup_axon):
         )
 
     assert dendrite_obj._session == None
-    del axon
 
 
 class AsyncMock(Mock):

--- a/tests/unit_tests/test_dendrite.py
+++ b/tests/unit_tests/test_dendrite.py
@@ -24,12 +24,12 @@ from unittest.mock import MagicMock, Mock, patch
 from tests.helpers import _get_mock_wallet
 
 
-class Dummy(bittensor.Synapse):
+class SynapseDummy(bittensor.Synapse):
     input: int
     output: typing.Optional[int] = None
 
 
-def dummy(synapse: Dummy) -> Dummy:
+def dummy(synapse: SynapseDummy) -> SynapseDummy:
     synapse.output = synapse.input + 1
     return synapse
 
@@ -74,7 +74,7 @@ def test_close(setup_dendrite, setup_axon):
     axon = setup_axon
     dendrite_obj = setup_dendrite
     # Query the axon to open a session
-    dendrite_obj.query(axon, Dummy(input=1))
+    dendrite_obj.query(axon, SynapseDummy(input=1))
     assert dendrite_obj._session != None
     # We haven't called close yet, so the session should still be open
     assert dendrite_obj._session.closed == False
@@ -89,7 +89,7 @@ async def test_aclose(setup_dendrite, setup_axon):
     dendrite_obj = setup_dendrite
     # Use context manager to open an async session
     async with dendrite_obj:
-        resp = await dendrite_obj([axon], Dummy(input=1), deserialize=False)
+        resp = await dendrite_obj([axon], SynapseDummy(input=1), deserialize=False)
     # Close should automatically be called on the session after context manager scope
     assert dendrite_obj._session == None
 

--- a/tests/unit_tests/test_dendrite.py
+++ b/tests/unit_tests/test_dendrite.py
@@ -72,21 +72,25 @@ def test_repr(setup_dendrite):
 
 def test_close(setup_dendrite, setup_axon):
     axon = setup_axon
-    dendrite_obj = setup_dendrite = d = bittensor.dendrite()
-
+    dendrite_obj = setup_dendrite
+    # Query the axon to open a session
     dendrite_obj.query(axon, Dummy(input=1))
+    assert dendrite_obj._session != None
+    # We haven't called close yet, so the session should still be open
+    assert dendrite_obj._session.closed == False
+    # We call close and should delete the session after closing
     dendrite_obj.close_session()
-    assert dendrite_obj._session.closed == True
+    assert dendrite_obj._session == None
 
 
 @pytest.mark.asyncio
 async def test_aclose(setup_dendrite, setup_axon):
     axon = setup_axon
-    dendrite_obj = setup_dendrite = d = bittensor.dendrite()
-
+    dendrite_obj = setup_dendrite
+    # Use context manager to open an async session
     async with dendrite_obj:
         resp = await dendrite_obj([axon], Dummy(input=1), deserialize=False)
-
+    # Close should automatically be called on the session after context manager scope
     assert dendrite_obj._session == None
 
 

--- a/tests/unit_tests/test_synapse.py
+++ b/tests/unit_tests/test_synapse.py
@@ -188,3 +188,39 @@ def test_required_fields_override():
         match='"required_hash_fields" has allow_mutation set to False and cannot be assigned',
     ):
         synapse_instance.required_hash_fields = []
+
+
+def test_default_instance_fields_dict_consistency():
+    synapse_instance = bittensor.Synapse()
+    assert synapse_instance.dict() == {
+        "name": "Synapse",
+        "timeout": 12.0,
+        "total_size": 0,
+        "header_size": 0,
+        "dendrite": {
+            "status_code": None,
+            "status_message": None,
+            "process_time": None,
+            "ip": None,
+            "port": None,
+            "version": None,
+            "nonce": None,
+            "uuid": None,
+            "hotkey": None,
+            "signature": None,
+        },
+        "axon": {
+            "status_code": None,
+            "status_message": None,
+            "process_time": None,
+            "ip": None,
+            "port": None,
+            "version": None,
+            "nonce": None,
+            "uuid": None,
+            "hotkey": None,
+            "signature": None,
+        },
+        "computed_body_hash": "",
+        "required_hash_fields": [],
+    }

--- a/tests/unit_tests/test_synapse.py
+++ b/tests/unit_tests/test_synapse.py
@@ -25,7 +25,6 @@ import bittensor
 def test_parse_headers_to_inputs():
     class Test(bittensor.Synapse):
         key1: typing.List[int]
-        key2: bittensor.Tensor
 
     # Define a mock headers dictionary to use for testing
     headers = {
@@ -34,7 +33,6 @@ def test_parse_headers_to_inputs():
         "bt_header_input_obj_key1": base64.b64encode(
             json.dumps([1, 2, 3, 4]).encode("utf-8")
         ).decode("utf-8"),
-        "bt_header_tensor_key2": "[3]-torch.float32",
         "timeout": "12",
         "name": "Test",
         "header_size": "111",
@@ -51,7 +49,6 @@ def test_parse_headers_to_inputs():
         "axon": {"nonce": "111"},
         "dendrite": {"ip": "12.1.1.2"},
         "key1": [1, 2, 3, 4],
-        "key2": bittensor.Tensor(dtype="torch.float32", shape=[3]),
         "timeout": "12",
         "name": "Test",
         "header_size": "111",
@@ -63,7 +60,6 @@ def test_parse_headers_to_inputs():
 def test_from_headers():
     class Test(bittensor.Synapse):
         key1: typing.List[int]
-        key2: bittensor.Tensor
 
     # Define a mock headers dictionary to use for testing
     headers = {
@@ -72,7 +68,6 @@ def test_from_headers():
         "bt_header_input_obj_key1": base64.b64encode(
             json.dumps([1, 2, 3, 4]).encode("utf-8")
         ).decode("utf-8"),
-        "bt_header_tensor_key2": "[3]-torch.float32",
         "timeout": "12",
         "name": "Test",
         "header_size": "111",
@@ -91,8 +86,6 @@ def test_from_headers():
     assert synapse.axon.nonce == 111
     assert synapse.dendrite.ip == "12.1.1.2"
     assert synapse.key1 == [1, 2, 3, 4]
-    assert synapse.key2.shape == [3]
-    assert synapse.key2.dtype == "torch.float32"
     assert synapse.timeout == 12
     assert synapse.name == "Test"
     assert synapse.header_size == 111
@@ -139,7 +132,6 @@ def test_custom_synapse():
         c: typing.Optional[int]  # Not carried through headers
         d: typing.Optional[typing.List[int]]  # Not carried through headers
         e: typing.List[int]  # Carried through headers
-        f: bittensor.Tensor  # Carried through headers, but not buffer.
 
     # Create an instance of the custom Synapse subclass
     synapse = Test(
@@ -147,7 +139,6 @@ def test_custom_synapse():
         c=3,
         d=[1, 2, 3, 4],
         e=[1, 2, 3, 4],
-        f=bittensor.Tensor.serialize(torch.randn(10)),
     )
 
     # Ensure the instance created is of type Test and has the expected properties
@@ -158,7 +149,6 @@ def test_custom_synapse():
     assert synapse.c == 3
     assert synapse.d == [1, 2, 3, 4]
     assert synapse.e == [1, 2, 3, 4]
-    assert synapse.f.shape == [10]
 
     # Convert the Test instance to a headers dictionary
     headers = synapse.to_headers()
@@ -174,71 +164,6 @@ def test_custom_synapse():
     assert next_synapse.c == None
     assert next_synapse.d == None
     assert next_synapse.e == []  # Empty list is default for list types
-    assert next_synapse.f.shape == [10]  # Shape is passed through
-    assert next_synapse.f.dtype == "torch.float32"  # Type is passed through
-    assert next_synapse.f.buffer == None  # Buffer is not passed through
-
-
-def test_list_tensors():
-    class Test(bittensor.Synapse):
-        a: typing.List[bittensor.Tensor]
-
-    synapse = Test(
-        a=[bittensor.Tensor.serialize(torch.randn(10))],
-    )
-    headers = synapse.to_headers()
-    assert "bt_header_list_tensor_a" in headers
-    assert headers["bt_header_list_tensor_a"] == "['[10]-torch.float32']"
-    next_synapse = synapse.from_headers(synapse.to_headers())
-    assert next_synapse.a[0].dtype == "torch.float32"
-    assert next_synapse.a[0].shape == [10]
-
-    class Test(bittensor.Synapse):
-        a: typing.List[bittensor.Tensor]
-
-    synapse = Test(
-        a=[
-            bittensor.Tensor.serialize(torch.randn(10)),
-            bittensor.Tensor.serialize(torch.randn(11)),
-            bittensor.Tensor.serialize(torch.randn(12)),
-        ],
-    )
-    headers = synapse.to_headers()
-    assert "bt_header_list_tensor_a" in headers
-    assert (
-        headers["bt_header_list_tensor_a"]
-        == "['[10]-torch.float32', '[11]-torch.float32', '[12]-torch.float32']"
-    )
-    next_synapse = synapse.from_headers(synapse.to_headers())
-    assert next_synapse.a[0].dtype == "torch.float32"
-    assert next_synapse.a[0].shape == [10]
-    assert next_synapse.a[1].dtype == "torch.float32"
-    assert next_synapse.a[1].shape == [11]
-    assert next_synapse.a[2].dtype == "torch.float32"
-    assert next_synapse.a[2].shape == [12]
-
-
-def test_dict_tensors():
-    class Test(bittensor.Synapse):
-        a: typing.Dict[str, bittensor.Tensor]
-
-    synapse = Test(
-        a={
-            "cat": bittensor.tensor(torch.randn(10)),
-            "dog": bittensor.tensor(torch.randn(11)),
-        },
-    )
-    headers = synapse.to_headers()
-    assert "bt_header_dict_tensor_a" in headers
-    assert (
-        headers["bt_header_dict_tensor_a"]
-        == "['cat-[10]-torch.float32', 'dog-[11]-torch.float32']"
-    )
-    next_synapse = synapse.from_headers(synapse.to_headers())
-    assert next_synapse.a["cat"].dtype == "torch.float32"
-    assert next_synapse.a["cat"].shape == [10]
-    assert next_synapse.a["dog"].dtype == "torch.float32"
-    assert next_synapse.a["dog"].shape == [11]
 
 
 def test_body_hash_override():


### PR DESCRIPTION
* Fixes dendrite `UnclosedSessionError` by introducing context manager via `__aexit__` and `__del__`
* Updates dendrite documentation
* Fixes inconsistent use of `self.__dict__` vs `self.dict()` in synapse methods. `.dict()` preferred.  See https://github.com/opentensor/bittensor/pull/1548.
* Includes https://github.com/opentensor/bittensor/pull/1554
* Adds tests for dendrite proper close session and `synapse.dict()` call