### PR TITLE
Normalize weights in r get weights table

### DIFF
--- a/bittensor/commands/root.py
+++ b/bittensor/commands/root.py
@@ -234,8 +234,10 @@ class RootGetWeightsCommand:
         netuids = set()
         for matrix in weights:
             [uid, weights_data] = matrix
-            
-            normalized_weights = np.array(weights_data)[:, 1] / np.sum(weights_data, axis=0)[1]
+
+            normalized_weights = (
+                np.array(weights_data)[:, 1] / np.sum(weights_data, axis=0)[1]
+            )
             for weight_data, normalized_weight in zip(weights_data, normalized_weights):
                 [netuid, _] = weight_data
                 netuids.add(netuid)
@@ -243,7 +245,6 @@ class RootGetWeightsCommand:
                     uid_to_weights[uid] = {}
 
                 uid_to_weights[uid][netuid] = normalized_weight
-                
 
         for netuid in netuids:
             table.add_column(
@@ -262,16 +263,12 @@ class RootGetWeightsCommand:
             for netuid in netuids:
                 if netuid in uid_weights:
                     normalized_weight = uid_weights[netuid]
-                    row.append(
-                        "{:0.2f}%".format(normalized_weight * 100)
-                    )
+                    row.append("{:0.2f}%".format(normalized_weight * 100))
                 else:
                     row.append("-")
             table.add_row(*row)
 
         table.show_footer = True
-
-        
 
         table.box = None
         table.pad_edge = False

--- a/bittensor/commands/root.py
+++ b/bittensor/commands/root.py
@@ -20,6 +20,7 @@ import re
 import torch
 import typing
 import argparse
+import numpy as np
 import bittensor
 from typing import List, Optional, Dict
 from rich.prompt import Prompt, Confirm
@@ -245,11 +246,12 @@ class RootGetWeightsCommand:
 
         for matrix in weights:
             uid = matrix[0]
+            weight_sum = np.sum(matrix[1])
             for weight_data in matrix[1]:
                 table.add_row(
                     str(uid),
                     str(weight_data[0]),
-                    "{:0.2f}%".format((weight_data[1] / 65535) * 100),
+                    "{:0.2f}%".format((weight_data[1] / weight_sum) * 100),
                 )
 
         table.box = None

--- a/bittensor/commands/root.py
+++ b/bittensor/commands/root.py
@@ -235,8 +235,8 @@ class RootGetWeightsCommand:
         for matrix in weights:
             [uid, weights_data] = matrix
 
-            normalized_weights = (
-                np.array(weights_data)[:, 1] / np.sum(weights_data, axis=0)[1]
+            normalized_weights = np.array(weights_data)[:, 1] / max(
+                np.sum(weights_data, axis=0)[1], 1
             )
             for weight_data, normalized_weight in zip(weights_data, normalized_weights):
                 [netuid, _] = weight_data


### PR DESCRIPTION
This adds proper normalization to calculate the percent weights for `btcli r get_weights`  
Before:
![image](https://github.com/opentensor/bittensor/assets/24501463/055d5cea-bd78-4aee-a46c-b20d4b5db601)

After:
![image](https://github.com/opentensor/bittensor/assets/24501463/dbc0a73a-ac5b-4015-86d8-ae4894633f02)


This second commit  1fe2c91 modifies the table structure: 
![image](https://github.com/opentensor/bittensor/assets/24501463/9729f297-8b73-45e4-a7fb-fa7db5b1909d)
