### PR TITLE
rm root flag in metagraph

### DIFF
--- a/bittensor/metagraph.py
+++ b/bittensor/metagraph.py
@@ -473,9 +473,7 @@ class metagraph(torch.nn.Module):
         # TODO: Check and test the creation of tensor
         return torch.nn.Parameter(torch.tensor(data, dtype=dtype), requires_grad=False)
 
-    def _set_weights_and_bonds(
-        self, subtensor: bittensor.subtensor = None
-    ):
+    def _set_weights_and_bonds(self, subtensor: bittensor.subtensor = None):
         """
         Computes and sets weights and bonds for each neuron.
 
@@ -483,7 +481,7 @@ class metagraph(torch.nn.Module):
             None.
         """
         # TODO: Check and test the computation of weights and bonds
-        if self.netiud == 0: # Is this the root network?
+        if self.netiud == 0:  # Is this the root network?
             self.weights = self._process_root_weights(
                 [neuron.weights for neuron in self.neurons], "weights", subtensor
             )

--- a/bittensor/metagraph.py
+++ b/bittensor/metagraph.py
@@ -340,7 +340,6 @@ class metagraph(torch.nn.Module):
         block: Optional[int] = None,
         lite: bool = True,
         subtensor: Optional["bittensor.subtensor"] = None,
-        root: bool = False,
     ) -> "metagraph":
         """
         Initiates the synchronization process of the metagraph.
@@ -364,7 +363,7 @@ class metagraph(torch.nn.Module):
 
         # If not a 'lite' version, compute and set weights and bonds for each neuron
         if not lite:
-            self._set_weights_and_bonds(root=root, subtensor=subtensor)
+            self._set_weights_and_bonds(subtensor=subtensor)
 
     def _initialize_subtensor(self, subtensor):
         """
@@ -475,7 +474,7 @@ class metagraph(torch.nn.Module):
         return torch.nn.Parameter(torch.tensor(data, dtype=dtype), requires_grad=False)
 
     def _set_weights_and_bonds(
-        self, root: bool = False, subtensor: bittensor.subtensor = None
+        self, subtensor: bittensor.subtensor = None
     ):
         """
         Computes and sets weights and bonds for each neuron.
@@ -484,7 +483,7 @@ class metagraph(torch.nn.Module):
             None.
         """
         # TODO: Check and test the computation of weights and bonds
-        if root:
+        if self.netiud == 0: # Is this the root network?
             self.weights = self._process_root_weights(
                 [neuron.weights for neuron in self.neurons], "weights", subtensor
             )

--- a/bittensor/metagraph.py
+++ b/bittensor/metagraph.py
@@ -481,7 +481,7 @@ class metagraph(torch.nn.Module):
             None.
         """
         # TODO: Check and test the computation of weights and bonds
-        if self.netiud == 0:  # Is this the root network?
+        if self.netuid == 0:  # Is this the root network?
             self.weights = self._process_root_weights(
                 [neuron.weights for neuron in self.neurons], "weights", subtensor
             )

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -2310,7 +2310,6 @@ class subtensor:
         netuid: int,
         lite: bool = True,
         block: Optional[int] = None,
-        root: bool = False,
     ) -> "bittensor.Metagraph":
         r"""Returns a synced metagraph for the subnet.
         Args:
@@ -2327,7 +2326,7 @@ class subtensor:
         metagraph_ = bittensor.metagraph(
             network=self.network, netuid=netuid, lite=lite, sync=False
         )
-        metagraph_.sync(block=block, lite=lite, subtensor=self, root=root)
+        metagraph_.sync(block=block, lite=lite, subtensor=self)
 
         return metagraph_
 


### PR DESCRIPTION
* Removes the flag `root` when setting up metagraph and loading weights for the root network.
* Replace with `netuid == 0` check for simplicity