### PR TITLE
Axon fix

### DIFF
--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -748,7 +748,7 @@ class AxonMiddleware(BaseHTTPMiddleware):
         # Start of catching all exceptions, updating the status message, and processing time.
         except Exception as e:
             # Log the exception for debugging purposes.
-            bittensor.logging.trace(f"Forward exception: {traceback.format_exc()}")
+            bittensor.logging.error(f"Forward exception: {traceback.format_exc()}")
 
             # Set the status message of the synapse to the string representation of the exception.
             synapse.axon.status_message = f"{str(e)}"

--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -729,6 +729,22 @@ class AxonMiddleware(BaseHTTPMiddleware):
             # Call the postprocess function
             response = await self.postprocess(synapse, response, start_time)
 
+        # Catch the error case where axon is not configured to handle the request.
+        except KeyError:
+            # Log key error.
+            bittensor.logging.error(f"Synapse name {request_name} not found.")
+
+            # Create a synapse instance with status code 404 (not found) and status message.
+            synapse: bittensor.Synapse = bittensor.Synapse()
+            synapse.axon.status_code = "404"
+            synapse.axon.status_message = f"Synapse name {request_name} not found."
+
+            # Create a JSON response with a status code of 404 (not found error),
+            # synapse headers, and an empty content.
+            response = JSONResponse(
+                status_code=404, headers=synapse.to_headers(), content={}
+            )
+
         # Start of catching all exceptions, updating the status message, and processing time.
         except Exception as e:
             # Log the exception for debugging purposes.

--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -732,7 +732,9 @@ class AxonMiddleware(BaseHTTPMiddleware):
         # Catch the error case where axon is not configured to handle the request.
         except KeyError:
             # Log key error.
-            bittensor.logging.error(f"Synapse name {request_name} not found.")
+            bittensor.logging.error(
+                f"Key Error: Synapse name {request_name} not found."
+            )
 
             # Create a synapse instance with status code 404 (not found) and status message.
             synapse: bittensor.Synapse = bittensor.Synapse()
@@ -748,7 +750,8 @@ class AxonMiddleware(BaseHTTPMiddleware):
         # Start of catching all exceptions, updating the status message, and processing time.
         except Exception as e:
             # Log the exception for debugging purposes.
-            bittensor.logging.error(f"Forward exception: {traceback.format_exc()}")
+            bittensor.logging.error(f"Exception: {str(e)}")
+            bittensor.logging.trace(f"Forward exception: {traceback.format_exc()}")
 
             # Set the status message of the synapse to the string representation of the exception.
             synapse.axon.status_message = f"{str(e)}"


### PR DESCRIPTION
Catches a `KeyError` exception where axon's do not have the route attached that is being queries. 

This causes issues downstream and makes the error difficult to identify.

Now return a synapse populated with 404 and a helpful error message.