### PR TITLE
Add taostats explorer to map

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -107,9 +107,16 @@ __rao_symbol__: str = chr(0x03C1)
 # Block Explorers map network to explorer url
 ## Must all be polkadotjs explorer urls
 __network_explorer_map__ = {
-    "local": "https://explorer.finney.opentensor.ai/#/explorer",
-    "endpoint": "https://explorer.finney.opentensor.ai/#/explorer",
-    "finney": "https://explorer.finney.opentensor.ai/#/explorer",
+    "opentensor": {
+        "local": "https://explorer.finney.opentensor.ai/#/explorer",
+        "endpoint": "https://explorer.finney.opentensor.ai/#/explorer",
+        "finney": "https://explorer.finney.opentensor.ai/#/explorer",
+    },
+    "taostats": {
+        "local": "https://x.taostats.io",
+        "endpoint": "https://x.taostats.io",
+        "finney": "https://x.taostats.io",
+    },
 }
 
 # --- Type Registry ---

--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -108,9 +108,9 @@ __rao_symbol__: str = chr(0x03C1)
 ## Must all be polkadotjs explorer urls
 __network_explorer_map__ = {
     "opentensor": {
-        "local": "https://explorer.finney.opentensor.ai/#/explorer",
-        "endpoint": "https://explorer.finney.opentensor.ai/#/explorer",
-        "finney": "https://explorer.finney.opentensor.ai/#/explorer",
+        "local": "https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fentrypoint-finney.opentensor.ai%3A443#/explorer",
+        "endpoint": "https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fentrypoint-finney.opentensor.ai%3A443#/explorer",
+        "finney": "https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fentrypoint-finney.opentensor.ai%3A443#/explorer",
     },
     "taostats": {
         "local": "https://x.taostats.io",

--- a/bittensor/extrinsics/transfer.py
+++ b/bittensor/extrinsics/transfer.py
@@ -129,12 +129,19 @@ def transfer_extrinsic(
                 "[green]Block Hash: {}[/green]".format(block_hash)
             )
 
-            explorer_url = bittensor.utils.get_explorer_url_for_network(
+            explorer_urls = bittensor.utils.get_explorer_url_for_network(
                 subtensor.network, block_hash, bittensor.__network_explorer_map__
             )
-            if explorer_url is not None:
+            if explorer_urls != {}:
                 bittensor.__console__.print(
-                    "[green]Explorer Link: {}[/green]".format(explorer_url)
+                    "[green]Opentensor Explorer Link: {}[/green]".format(
+                        explorer_urls.get("opentensor")
+                    )
+                )
+                bittensor.__console__.print(
+                    "[green]Taostats   Explorer Link: {}[/green]".format(
+                        explorer_urls.get("taostats")
+                    )
                 )
         else:
             bittensor.__console__.print(

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -123,8 +123,8 @@ def strtobool(val: str) -> Union[bool, Literal["==SUPRESS=="]]:
 
 
 def get_explorer_root_url_by_network_from_map(
-    network: str, network_map: Dict[str, str]
-) -> Optional[str]:
+    network: str, network_map: Dict[str, Dict[str, str]]
+) -> Optional[Dict[str, str]]:
     r"""
     Returns the explorer root url for the given network name from the given network map.
 
@@ -136,42 +136,48 @@ def get_explorer_root_url_by_network_from_map(
         The explorer url for the given network.
         Or None if the network is not in the network map.
     """
-    explorer_url: Optional[str] = None
-    if network in network_map:
-        explorer_url = network_map[network]
+    explorer_urls: Optional[Dict[str, str]] = {}
+    for entity_nm, entity_network_map in network_map.items():
+        if network in entity_network_map:
+            explorer_urls[entity_nm] = entity_network_map[network]
 
-    return explorer_url
+    return explorer_urls
 
 
 def get_explorer_url_for_network(
     network: str, block_hash: str, network_map: Dict[str, str]
-) -> Optional[str]:
+) -> Optional[List[str]]:
     r"""
     Returns the explorer url for the given block hash and network.
 
     Args:
         network(str): The network to get the explorer url for.
         block_hash(str): The block hash to get the explorer url for.
-        network_map(Dict[str, str]): The network map to get the explorer url from.
+        network_map(Dict[str, Dict[str, str]]): The network maps to get the explorer urls from.
 
     Returns:
         The explorer url for the given block hash and network.
         Or None if the network is not known.
     """
 
-    explorer_url: Optional[str] = None
+    explorer_urls: Optional[Dict[str, str]] = {}
     # Will be None if the network is not known. i.e. not in network_map
-    explorer_root_url: Optional[str] = get_explorer_root_url_by_network_from_map(
-        network, network_map
-    )
+    explorer_root_urls: Optional[
+        Dict[str, str]
+    ] = get_explorer_root_url_by_network_from_map(network, network_map)
 
-    if explorer_root_url is not None:
+    if explorer_root_urls != {}:
         # We are on a known network.
-        explorer_url = "{root_url}/query/{block_hash}".format(
-            root_url=explorer_root_url, block_hash=block_hash
+        explorer_opentensor_url = "{root_url}/query/{block_hash}".format(
+            root_url=explorer_root_urls.get("opentensor"), block_hash=block_hash
         )
+        explorer_taostats_url = "{root_url}/search?query={block_hash}".format(
+            root_url=explorer_root_urls.get("taostats"), block_hash=block_hash
+        )
+        explorer_urls["opentensor"] = explorer_opentensor_url
+        explorer_urls["taostats"] = explorer_taostats_url
 
-    return explorer_url
+    return explorer_urls
 
 
 def ss58_address_to_bytes(ss58_address: str) -> bytes:

--- a/tests/unit_tests/utils/test_utils.py
+++ b/tests/unit_tests/utils/test_utils.py
@@ -704,21 +704,21 @@ class TestExplorerURL(unittest.TestCase):
         (
             "local",
             {
-                "opentensor": "https://explorer.finney.opentensor.ai/#/explorer",
+                "opentensor": "https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fentrypoint-finney.opentensor.ai%3A443#/explorer",
                 "taostats": "https://x.taostats.io",
             },
         ),
         (
             "endpoint",
             {
-                "opentensor": "https://explorer.finney.opentensor.ai/#/explorer",
+                "opentensor": "https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fentrypoint-finney.opentensor.ai%3A443#/explorer",
                 "taostats": "https://x.taostats.io",
             },
         ),
         (
             "finney",
             {
-                "opentensor": "https://explorer.finney.opentensor.ai/#/explorer",
+                "opentensor": "https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fentrypoint-finney.opentensor.ai%3A443#/explorer",
                 "taostats": "https://x.taostats.io",
             },
         ),
@@ -742,7 +742,7 @@ class TestExplorerURL(unittest.TestCase):
             "local",
             "0x123",
             {
-                "opentensor": "https://explorer.finney.opentensor.ai/#/explorer/query/0x123",
+                "opentensor": "https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fentrypoint-finney.opentensor.ai%3A443#/explorer/query/0x123",
                 "taostats": "https://x.taostats.io/search?query=0x123",
             },
         ),
@@ -750,7 +750,7 @@ class TestExplorerURL(unittest.TestCase):
             "endpoint",
             "0x456",
             {
-                "opentensor": "https://explorer.finney.opentensor.ai/#/explorer/query/0x456",
+                "opentensor": "https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fentrypoint-finney.opentensor.ai%3A443#/explorer/query/0x456",
                 "taostats": "https://x.taostats.io/search?query=0x456",
             },
         ),

--- a/tests/unit_tests/utils/test_utils.py
+++ b/tests/unit_tests/utils/test_utils.py
@@ -700,63 +700,71 @@ class TestCUDASolverRun(unittest.TestCase):
 
 @ddt
 class TestExplorerURL(unittest.TestCase):
-    network_map: Dict[str, str] = {
-        "nakamoto": "https://polkadot.js.org/apps/?rpc=wss://archivelb.nakamoto.opentensor.ai:9943#/explorer",
-        "example": "https://polkadot.js.org/apps/?rpc=wss://example.example.com#/explorer",
-        "nobunaga": "https://polkadot.js.org/apps/?rpc=wss://nobunaga.bittensor.com:9943#/explorer",
-        # "bad": None # no explorer for this network
-    }
-
     @data(
         (
-            "nobunaga",
-            "https://polkadot.js.org/apps/?rpc=wss://nobunaga.bittensor.com:9943#/explorer",
+            "local",
+            {
+                "opentensor": "https://explorer.finney.opentensor.ai/#/explorer",
+                "taostats": "https://x.taostats.io",
+            },
         ),
         (
-            "nakamoto",
-            "https://polkadot.js.org/apps/?rpc=wss://archivelb.nakamoto.opentensor.ai:9943#/explorer",
+            "endpoint",
+            {
+                "opentensor": "https://explorer.finney.opentensor.ai/#/explorer",
+                "taostats": "https://x.taostats.io",
+            },
         ),
         (
-            "example",
-            "https://polkadot.js.org/apps/?rpc=wss://example.example.com#/explorer",
+            "finney",
+            {
+                "opentensor": "https://explorer.finney.opentensor.ai/#/explorer",
+                "taostats": "https://x.taostats.io",
+            },
         ),
-        ("bad", None),
-        ("", None),
-        ("networknamewithoutexplorer", None),
+        ("bad", {}),
+        ("", {}),
+        ("unknown", {}),
     )
     @unpack
     def test_get_explorer_root_url_by_network_from_map(
-        self, network: str, expected: str
-    ) -> str:
+        self, network: str, expected: dict
+    ) -> None:
         self.assertEqual(
             bittensor.utils.get_explorer_root_url_by_network_from_map(
-                network, self.network_map
+                network, bittensor.__network_explorer_map__
             ),
             expected,
         )
 
     @data(
         (
-            "nobunaga",
+            "local",
             "0x123",
-            "https://polkadot.js.org/apps/?rpc=wss://nobunaga.bittensor.com:9943#/explorer/query/0x123",
+            {
+                "opentensor": "https://explorer.finney.opentensor.ai/#/explorer/query/0x123",
+                "taostats": "https://x.taostats.io/search?query=0x123",
+            },
         ),
         (
-            "example",
-            "0x123",
-            "https://polkadot.js.org/apps/?rpc=wss://example.example.com#/explorer/query/0x123",
+            "endpoint",
+            "0x456",
+            {
+                "opentensor": "https://explorer.finney.opentensor.ai/#/explorer/query/0x456",
+                "taostats": "https://x.taostats.io/search?query=0x456",
+            },
         ),
-        ("bad", "0x123", None),
-        ("", "0x123", None),
-        ("networknamewithoutexplorer", "0x123", None),
+        ("bad", "0x789", {}),
+        ("", "0xabc", {}),
+        ("unknown", "0xdef", {}),
     )
     @unpack
     def test_get_explorer_url_for_network_by_network_and_block_hash(
-        self, network: str, block_hash: str, expected: str
-    ) -> str:
+        self, network: str, block_hash: str, expected: dict
+    ) -> None:
         self.assertEqual(
             bittensor.utils.get_explorer_url_for_network(
-                network, block_hash, self.network_map
+                network, block_hash, bittensor.__network_explorer_map__
             ),
             expected,
         )


### PR DESCRIPTION
* Adds the taostats explorer to map
* Prints taostats explorer link upon `btcli wallet transfer`

<img width="895" alt="image" src="https://github.com/opentensor/bittensor/assets/31426574/06a866d0-30a3-4e67-8063-2a23b08a994d">

Closes https://github.com/opentensor/bittensor/issues/1583
