### PR TITLE
add ability to turn off verbose logging for btcli cmds

### DIFF
--- a/bittensor/commands/overview.py
+++ b/bittensor/commands/overview.py
@@ -558,7 +558,7 @@ class OverviewCommand:
         result: List["bittensor.NeuronInfoLite"] = []
 
         try:
-            subtensor = bittensor.subtensor(config=subtensor_config)
+            subtensor = bittensor.subtensor(config=subtensor_config, log_verbose=False)
 
             all_neurons: List["bittensor.NeuronInfoLite"] = subtensor.neurons_lite(
                 netuid=netuid
@@ -587,7 +587,7 @@ class OverviewCommand:
         result: List[Tuple[str, "bittensor.Balance"]] = []
 
         try:
-            subtensor = bittensor.subtensor(config=subtensor_config)
+            subtensor = bittensor.subtensor(config=subtensor_config, log_verbose=False)
 
             # Pull all stake for our coldkey
             all_stake_info_for_coldkey = subtensor.get_stake_info_for_coldkey(

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -384,7 +384,7 @@ class subtensor:
 
         bittensor.logging.info(
             f"Connected to {self.network} network and {self.chain_endpoint}."
-        
+        )
 
     def __str__(self) -> str:
         if self.network == self.chain_endpoint:

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -299,6 +299,7 @@ class subtensor:
         network: str = None,
         config: "bittensor.config" = None,
         _mock: bool = False,
+        log_verbose: bool = True,
     ) -> None:
         """
         Initializes a Subtensor interface for interacting with the Bittensor blockchain.
@@ -334,7 +335,7 @@ class subtensor:
         if (
             self.network == "finney"
             or self.chain_endpoint == bittensor.__finney_entrypoint__
-        ):
+        ) and log_verbose:
             bittensor.logging.info(
                 f"You are connecting to {self.network} network with endpoint {self.chain_endpoint}."
             )
@@ -376,9 +377,10 @@ class subtensor:
             exit(1)
             # TODO (edu/phil): Advise to run local subtensor and point to dev docs.
 
-        bittensor.logging.info(
-            f"Connected to {self.network} network and {self.chain_endpoint}."
-        )
+        if log_verbose:
+            bittensor.logging.info(
+                f"Connected to {self.network} network and {self.chain_endpoint}."
+            )
 
     def __str__(self) -> str:
         if self.network == self.chain_endpoint:


### PR DESCRIPTION
* Ensures that `subtensor` init doesn't spam terminal on init for btcli commands like `overview`.