### PR TITLE
Expand dendrite json and Pyandtic v2 Upgrade

### DIFF
--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -597,7 +597,7 @@ class axon:
         self.forward_fns[request_name] = forward_fn
 
         # Parse required hash fields from the forward function protocol defaults
-        required_hash_fields = request_class.__dict__["__fields__"][
+        required_hash_fields = request_class.__dict__["model_fields"][
             "required_hash_fields"
         ].default
         self.required_hash_fields[request_name] = required_hash_fields

--- a/bittensor/dendrite.py
+++ b/bittensor/dendrite.py
@@ -524,7 +524,7 @@ class dendrite(torch.nn.Module):
             async with (await self.session).post(
                 url,
                 headers=synapse.to_headers(),
-                json=synapse.dict(),
+                json=json.loads(synapse.json()),
                 timeout=timeout,
             ) as response:
                 # Extract the JSON response from the server
@@ -606,7 +606,7 @@ class dendrite(torch.nn.Module):
             async with (await self.session).post(
                 url,
                 headers=synapse.to_headers(),
-                json=synapse.dict(),
+                json=json.loads(synapse.json()),
                 timeout=timeout,
             ) as response:
                 # Use synapse subclass' process_streaming_response method to yield the response chunks

--- a/bittensor/dendrite.py
+++ b/bittensor/dendrite.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import uuid
 import time
 import torch

--- a/bittensor/stream.py
+++ b/bittensor/stream.py
@@ -4,7 +4,7 @@ from starlette.responses import StreamingResponse as _StreamingResponse
 from starlette.responses import Response
 from starlette.types import Send, Receive, Scope
 from typing import Callable, Awaitable, List
-from pydantic import BaseModel
+from pydantic import ConfigDict, BaseModel
 from abc import ABC, abstractmethod
 
 
@@ -36,8 +36,7 @@ class StreamingSynapse(bittensor.Synapse, ABC):
     and extract JSON data. It also includes a method to create a streaming response object.
     """
 
-    class Config:
-        validate_assignment = True
+    model_config = ConfigDict(validate_assignment=True)
 
     class BTStreamingResponse(_StreamingResponse):
         """

--- a/bittensor/synapse.py
+++ b/bittensor/synapse.py
@@ -24,9 +24,10 @@ import base64
 import typing
 import hashlib
 import pydantic
-from pydantic.schema import schema
+from pydantic.v1.schema import schema
 import bittensor
 from typing import Optional, List, Any
+from pydantic import ConfigDict
 
 
 def get_size(obj, seen=None) -> int:
@@ -146,8 +147,7 @@ class TerminalInfo(pydantic.BaseModel):
     TerminalInfo plays a pivotal role in providing transparency and control over network operations, making it an indispensable tool for developers and users interacting with the Bittensor ecosystem.
     """
 
-    class Config:
-        validate_assignment = True
+    model_config = ConfigDict(validate_assignment=True)
 
     # The HTTP status code from: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
     status_code: Optional[int] = pydantic.Field(
@@ -357,8 +357,7 @@ class Synapse(pydantic.BaseModel):
     standardized communication in a decentralized environment.
     """
 
-    class Config:
-        validate_assignment = True
+    model_config = ConfigDict(validate_assignment=True)
 
     def deserialize(self) -> "Synapse":
         """
@@ -628,17 +627,19 @@ class Synapse(pydantic.BaseModel):
         # Getting the fields of the instance
         instance_fields = self.dict()
 
+        # Fetch the required fields from the model schema (pydantic v2)
+        required = []
+        for k, v in self.__class__.__dict__["model_fields"].items():
+            if v.is_required():
+                required.append(k)
+
         # Iterating over the fields of the instance
         for field, value in instance_fields.items():
-            # If the object is not optional, serializing it, encoding it, and adding it to the headers
-            required = schema([self.__class__])["definitions"][self.name].get(
-                "required"
-            )
-
             # Skipping the field if it's already in the headers or its value is None
             if field in headers or value is None:
                 continue
 
+            # If the object is not optional, serializing it, encoding it, and adding it to the headers
             elif required and field in required:
                 try:
                     # create an empty (dummy) instance of type(value) to pass pydantic validation on the axon side

--- a/bittensor/tensor.py
+++ b/bittensor/tensor.py
@@ -24,6 +24,7 @@ import msgpack
 import pydantic
 import msgpack_numpy
 from typing import Dict, Optional, Tuple, Union, List, Callable
+from pydantic import ConfigDict
 
 TORCH_DTYPES = {
     "torch.float16": torch.float16,
@@ -116,8 +117,7 @@ class Tensor(pydantic.BaseModel):
         shape (List[int]): Tensor shape.
     """
 
-    class Config:
-        validate_assignment = True
+    model_config = ConfigDict(validate_assignment=True)
 
     def tensor(self) -> torch.Tensor:
         return self.deserialize()

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -6,7 +6,7 @@ black==23.7.0
 cryptography==41.0.3
 ddt==1.6.0
 fuzzywuzzy>=0.18.0
-fastapi==0.99.1
+fastapi==0.105.0
 loguru==0.7.0
 munch==2.5.0
 netaddr
@@ -16,7 +16,7 @@ nest_asyncio
 pycryptodome>=3.18.0,<4.0.0
 pyyaml
 password_strength
-pydantic!=1.8,!=1.8.1,<2.0.0,>=1.7.4
+pydantic==2.5.2
 PyNaCl>=1.3.0,<=1.5.0
 pytest-asyncio
 python-Levenshtein

--- a/tests/unit_tests/test_synapse.py
+++ b/tests/unit_tests/test_synapse.py
@@ -19,6 +19,7 @@ import torch
 import base64
 import typing
 import pytest
+import pydantic
 import bittensor
 
 
@@ -159,10 +160,10 @@ def test_custom_synapse():
 
     # Create a new Test from the headers and check its properties
     next_synapse = synapse.from_headers(synapse.to_headers())
-    assert next_synapse.a == 0  # Default value is 0
+    assert next_synapse.a == 0  # Default value is 0 for int type
     assert next_synapse.b == None
-    assert next_synapse.c == None
-    assert next_synapse.d == None
+    assert next_synapse.c == 0  # Default value is 0 for int type
+    assert next_synapse.d == []  # Empty list is default for list types
     assert next_synapse.e == []  # Empty list is default for list types
 
 
@@ -184,8 +185,7 @@ def test_required_fields_override():
 
     # Try to set the required_hash_fields property and expect a TypeError
     with pytest.raises(
-        TypeError,
-        match='"required_hash_fields" has allow_mutation set to False and cannot be assigned',
+        pydantic.ValidationError,
     ):
         synapse_instance.required_hash_fields = []
 


### PR DESCRIPTION
This updates several things:
* `synapse.dict()` ->` json.loads(synapse.json())`
* pydantic to 2.5.2 (latest version) with a massive overhaul
* fastapi to 0.105.0 (latest version)
* updates related synapse code to leverage these upgrades

This effectively increases the types that can be serialized over the bittensor network natively, e.g. `datetime`


One major bug that this fixes is the limited scope for what kind of objects can be serialized and sent over the wire. For example, `datetime` objects currently are not serializable because of calling `synapse.dict()`. The` synapse.json()` method calls an internal `pydantic` serialization routine which natively supports `datetime` objects. 