### PR TITLE
bittensor README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ### Internet-scale Neural Networks <!-- omit in toc -->
 
-[Discord](https://discord.gg/bittensor) • [Network](https://taostats.io/) • [Research](https://bittensor.com/whitepaper)
+[Discord]([https://discord.gg/bittensor](https://discord.gg/qasY3HA9F9) • [Network](https://taostats.io/) • [Research](https://bittensor.com/whitepaper)
 
 </div>
 


### PR DESCRIPTION
Updated the link to the Discord invite; it was pointing to an old invalid invite and I have edited the file to match the link that is on the main bittensor.com website.