### PR TITLE
add url to wallet transfer history

### DIFF
--- a/bittensor/commands/wallets.py
+++ b/bittensor/commands/wallets.py
@@ -947,7 +947,8 @@ def create_transfer_history_table(transfers):
 
     table = Table(show_footer=False)
     # Define the column names
-    column_names = ["Id", "From", "To", "Amount (Tao)", "Extrinsic Id", "Block Number"]
+    column_names = ["Id", "From", "To", "Amount (Tao)", "Extrinsic Id", "Block Number", "URL (taostats)"]
+    taostats_url_base = "https://x.taostats.io/extrinsic"
 
     # Create a table
     table = Table(show_footer=False)
@@ -983,6 +984,7 @@ def create_transfer_history_table(transfers):
             f"{tao_amount:.3f}",
             str(item["extrinsicId"]),
             item["blockNumber"],
+            f"{taostats_url_base}/{item['blockNumber']}-{item['extrinsicId']}",
         )
     table.add_row()
     table.show_footer = True


### PR DESCRIPTION
This is a simple PR that adds taostats URL link for each transfer to the `btcli wallet history` command. I found this to be useful so wanted to share :)