### PR TITLE
Tests/extend coverage

### DIFF
--- a/bittensor/extrinsics/registration.py
+++ b/bittensor/extrinsics/registration.py
@@ -325,10 +325,6 @@ class MaxAttemptsException(Exception):
     pass
 
 
-class MaxAttemptedException(Exception):
-    pass
-
-
 def run_faucet_extrinsic(
     subtensor: "bittensor.subtensor",
     wallet: "bittensor.wallet",

--- a/bittensor/extrinsics/registration.py
+++ b/bittensor/extrinsics/registration.py
@@ -325,6 +325,10 @@ class MaxAttemptsException(Exception):
     pass
 
 
+class MaxAttemptedException(Exception):
+    pass
+
+
 def run_faucet_extrinsic(
     subtensor: "bittensor.subtensor",
     wallet: "bittensor.wallet",

--- a/tests/unit_tests/extrinsics/test_network.py
+++ b/tests/unit_tests/extrinsics/test_network.py
@@ -1,0 +1,92 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from bittensor.subtensor import subtensor as Subtensor
+from bittensor.wallet import wallet as Wallet
+
+
+# Mock the bittensor and related modules to avoid real network calls and wallet operations
+@pytest.fixture
+def mock_subtensor():
+    subtensor = MagicMock(spec=Subtensor)
+    subtensor.get_balance.return_value = 100
+    subtensor.get_subnet_burn_cost.return_value = 10
+    return subtensor
+
+
+@pytest.fixture
+def mock_wallet():
+    wallet = MagicMock(spec=Wallet)
+    wallet.coldkeypub.ss58_address = "fake_address"
+    wallet.coldkey = MagicMock()
+    return wallet
+
+
+@pytest.mark.parametrize(
+    "test_id, wait_for_inclusion, wait_for_finalization, prompt, expected",
+    [
+        ("happy-path-01", False, True, False, True),
+        ("happy-path-02", True, False, False, True),
+        ("happy-path-03", False, False, False, True),
+        ("happy-path-04", True, True, False, True),
+    ],
+)
+def test_register_subnetwork_extrinsic_happy_path(
+    mock_subtensor,
+    mock_wallet,
+    test_id,
+    wait_for_inclusion,
+    wait_for_finalization,
+    prompt,
+    expected,
+):
+    # Arrange
+    mock_subtensor.substrate = MagicMock(
+        get_block_hash=MagicMock(return_value="0x" + "0" * 64),
+        submit_extrinsic=MagicMock(),
+    )
+    mock_subtensor.substrate.submit_extrinsic.return_value.is_success = True
+
+    # Act
+    from bittensor.extrinsics.network import register_subnetwork_extrinsic
+
+    result = register_subnetwork_extrinsic(
+        mock_subtensor, mock_wallet, wait_for_inclusion, wait_for_finalization, prompt
+    )
+
+    # Assert
+    assert result == expected
+
+
+# Edge cases
+@pytest.mark.parametrize(
+    "test_id, balance, burn_cost, prompt_input, expected",
+    [
+        ("edge-case-01", 0, 10, False, False),  # Balance is zero
+        ("edge-case-02", 10, 10, False, False),  # Balance equals burn cost
+        ("edge-case-03", 9, 10, False, False),  # Balance less than burn cost
+        ("edge-case-04", 100, 10, True, True),  # User declines prompt
+    ],
+)
+def test_register_subnetwork_extrinsic_edge_cases(
+    mock_subtensor,
+    mock_wallet,
+    test_id,
+    balance,
+    burn_cost,
+    prompt_input,
+    expected,
+    monkeypatch,
+):
+    # Arrange
+    mock_subtensor.get_balance.return_value = balance
+    mock_subtensor.get_subnet_burn_cost.return_value = burn_cost
+    monkeypatch.setattr("rich.prompt.Confirm.ask", lambda x: prompt_input)
+    mock_subtensor.substrate = MagicMock()
+
+    # Act
+    from bittensor.extrinsics.network import register_subnetwork_extrinsic
+
+    result = register_subnetwork_extrinsic(mock_subtensor, mock_wallet, prompt=True)
+
+    # Assert
+    assert result == expected

--- a/tests/unit_tests/extrinsics/test_prometheus.py
+++ b/tests/unit_tests/extrinsics/test_prometheus.py
@@ -1,0 +1,154 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import bittensor
+from bittensor.subtensor import subtensor as Subtensor
+from bittensor.wallet import wallet as Wallet
+from bittensor.extrinsics.prometheus import prometheus_extrinsic
+
+
+# Mocking the bittensor and networking modules
+@pytest.fixture
+def mock_bittensor():
+    with patch("bittensor.subtensor") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_wallet():
+    with patch("bittensor.wallet") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_net():
+    with patch("bittensor.utils.networking") as mock:
+        yield mock
+
+
+@pytest.mark.parametrize(
+    "ip, port, netuid, wait_for_inclusion, wait_for_finalization, expected_result, test_id",
+    [
+        (None, 9221, 0, False, True, True, "happy-path-default-ip"),
+        ("192.168.0.1", 9221, 0, False, True, True, "happy-path-custom-ip"),
+        (None, 9221, 0, True, False, True, "happy-path-wait-for-inclusion"),
+        (None, 9221, 0, False, False, True, "happy-path-no-waiting"),
+    ],
+)
+def test_prometheus_extrinsic_happy_path(
+    mock_bittensor,
+    mock_wallet,
+    mock_net,
+    ip,
+    port,
+    netuid,
+    wait_for_inclusion,
+    wait_for_finalization,
+    expected_result,
+    test_id,
+):
+    # Arrange
+    subtensor = MagicMock(spec=Subtensor)
+    subtensor.network = "test_network"
+    wallet = MagicMock(spec=Wallet)
+    mock_net.get_external_ip.return_value = "192.168.0.1"
+    mock_net.ip_to_int.return_value = 3232235521  # IP in integer form
+    mock_net.ip_version.return_value = 4
+    neuron = MagicMock()
+    neuron.is_null = False
+    neuron.prometheus_info.version = bittensor.__version_as_int__
+    neuron.prometheus_info.ip = 3232235521
+    neuron.prometheus_info.port = port
+    neuron.prometheus_info.ip_type = 4
+    subtensor.get_neuron_for_pubkey_and_subnet.return_value = neuron
+    subtensor._do_serve_prometheus.return_value = (True, None)
+
+    # Act
+    result = prometheus_extrinsic(
+        subtensor=subtensor,
+        wallet=wallet,
+        ip=ip,
+        port=port,
+        netuid=netuid,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+    )
+
+    # Assert
+    assert result == expected_result, f"Test ID: {test_id}"
+
+
+# Edge cases
+@pytest.mark.parametrize(
+    "ip, port, netuid, test_id",
+    [
+        ("0.0.0.0", 0, 0, "edge-case-min-values"),
+        ("255.255.255.255", 65535, 2147483647, "edge-case-max-values"),
+    ],
+)
+def test_prometheus_extrinsic_edge_cases(
+    mock_bittensor, mock_wallet, mock_net, ip, port, netuid, test_id
+):
+    # Arrange
+    subtensor = MagicMock(spec=Subtensor)
+    subtensor.network = "test_network"
+    wallet = MagicMock(spec=Wallet)
+    mock_net.get_external_ip.return_value = ip
+    mock_net.ip_to_int.return_value = 3232235521  # IP in integer form
+    mock_net.ip_version.return_value = 4
+    neuron = MagicMock()
+    neuron.is_null = True
+    subtensor.get_neuron_for_pubkey_and_subnet.return_value = neuron
+    subtensor._do_serve_prometheus.return_value = (True, None)
+
+    # Act
+    result = prometheus_extrinsic(
+        subtensor=subtensor,
+        wallet=wallet,
+        ip=ip,
+        port=port,
+        netuid=netuid,
+        wait_for_inclusion=False,
+        wait_for_finalization=True,
+    )
+
+    # Assert
+    assert result == True, f"Test ID: {test_id}"
+
+
+# Error cases
+@pytest.mark.parametrize(
+    "ip, port, netuid, exception, test_id",
+    [
+        (
+            None,
+            9221,
+            0,
+            RuntimeError("Unable to attain your external ip."),
+            "error-case-no-external-ip",
+        ),
+    ],
+)
+def test_prometheus_extrinsic_error_cases(
+    mock_bittensor, mock_wallet, mock_net, ip, port, netuid, exception, test_id
+):
+    # Arrange
+    subtensor = MagicMock(spec=Subtensor)
+    subtensor.network = "test_network"
+    wallet = MagicMock(spec=Wallet)
+    mock_net.get_external_ip.side_effect = exception
+    neuron = MagicMock()
+    neuron.is_null = True
+    subtensor.get_neuron_for_pubkey_and_subnet.return_value = neuron
+    subtensor._do_serve_prometheus.return_value = (True,)
+
+    # Act & Assert
+    with pytest.raises(ValueError):
+        prometheus_extrinsic(
+            subtensor=subtensor,
+            wallet=wallet,
+            ip=ip,
+            port=port,
+            netuid=netuid,
+            wait_for_inclusion=False,
+            wait_for_finalization=True,
+        )

--- a/tests/unit_tests/extrinsics/test_registration.py
+++ b/tests/unit_tests/extrinsics/test_registration.py
@@ -1,0 +1,170 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from bittensor.subtensor import subtensor as Subtensor
+from bittensor.wallet import wallet as Wallet
+from bittensor.utils.registration import POWSolution
+from bittensor.extrinsics.registration import (
+    MaxSuccessException,
+    MaxAttemptsException,
+)
+
+
+# Mocking external dependencies
+@pytest.fixture
+def mock_subtensor():
+    mock = MagicMock(spec=Subtensor)
+    mock.network = "mock_network"
+    mock.substrate = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def mock_wallet():
+    mock = MagicMock(spec=Wallet)
+    mock.coldkeypub.ss58_address = "mock_address"
+    return mock
+
+
+@pytest.fixture
+def mock_pow_solution():
+    mock = MagicMock(spec=POWSolution)
+    mock.block_number = 123
+    mock.nonce = 456
+    mock.seal = [0, 1, 2, 3]
+    mock.is_stale.return_value = False
+    return mock
+
+
+@pytest.mark.parametrize(
+    "wait_for_inclusion,wait_for_finalization,prompt,cuda,dev_id,tpb,num_processes,update_interval,log_verbose,expected",
+    [
+        (
+            False,
+            True,
+            False,
+            False,
+            0,
+            256,
+            None,
+            None,
+            False,
+            True,
+        ),
+        (True, False, False, True, [0], 256, 1, 100, True, False),
+        (False, False, False, True, 1, 512, 2, 200, False, False),
+    ],
+    ids=["happy-path-1", "happy-path-2", "happy-path-3"],
+)
+@pytest.mark.skip(reason="Waiting for fix to MaxAttemptedException")
+def test_run_faucet_extrinsic_happy_path(
+    mock_subtensor,
+    mock_wallet,
+    mock_pow_solution,
+    wait_for_inclusion,
+    wait_for_finalization,
+    prompt,
+    cuda,
+    dev_id,
+    tpb,
+    num_processes,
+    update_interval,
+    log_verbose,
+    expected,
+):
+    with patch(
+        "bittensor.utils.registration.create_pow", return_value=mock_pow_solution
+    ) as mock_create_pow, patch("rich.prompt.Confirm.ask", return_value=True):
+        from bittensor.extrinsics.registration import run_faucet_extrinsic
+
+        # Arrange
+        mock_subtensor.get_balance.return_value = 100
+        mock_subtensor.substrate.submit_extrinsic.return_value.is_success = True
+
+        # Act
+        result = run_faucet_extrinsic(
+            subtensor=mock_subtensor,
+            wallet=mock_wallet,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            prompt=prompt,
+            cuda=cuda,
+            dev_id=dev_id,
+            tpb=tpb,
+            num_processes=num_processes,
+            update_interval=update_interval,
+            log_verbose=log_verbose,
+        )
+
+        # Assert
+        assert result == expected
+        mock_subtensor.get_balance.assert_called_with("mock_address")
+        mock_subtensor.substrate.submit_extrinsic.assert_called()
+
+
+@pytest.mark.parametrize(
+    "cuda,torch_cuda_available,prompt_response,expected",
+    [
+        (
+            True,
+            False,
+            False,
+            False,
+        ),  # ID: edge-case-1: CUDA required but not available, user declines prompt
+        (
+            True,
+            False,
+            True,
+            False,
+        ),  # ID: edge-case-2: CUDA required but not available, user accepts prompt but fails due to CUDA unavailability
+    ],
+    ids=["edge-case-1", "edge-case-2"],
+)
+def test_run_faucet_extrinsic_edge_cases(
+    mock_subtensor, mock_wallet, cuda, torch_cuda_available, prompt_response, expected
+):
+    with patch("torch.cuda.is_available", return_value=torch_cuda_available), patch(
+        "rich.prompt.Confirm.ask", return_value=prompt_response
+    ):
+        from bittensor.extrinsics.registration import run_faucet_extrinsic
+
+        # Act
+        result = run_faucet_extrinsic(
+            subtensor=mock_subtensor, wallet=mock_wallet, cuda=cuda
+        )
+
+        # Assert
+        assert result == expected
+
+
+@pytest.mark.parametrize(
+    "exception,expected",
+    [
+        (KeyboardInterrupt, (True, "Done")),  # ID: error-1: User interrupts the process
+        (
+            MaxSuccessException,
+            (True, "Max successes reached: 3"),
+        ),  # ID: error-2: Maximum successes reached
+        (
+            MaxAttemptsException,
+            (False, "Max attempts reached: 3"),
+        ),  # ID: error-3: Maximum attempts reached
+    ],
+    ids=["error-1", "error-2", "error-3"],
+)
+@pytest.mark.skip(reason="Waiting for fix to MaxAttemptedException")
+def test_run_faucet_extrinsic_error_cases(
+    mock_subtensor, mock_wallet, mock_pow_solution, exception, expected
+):
+    with patch(
+        "bittensor.utils.registration.create_pow",
+        side_effect=[mock_pow_solution, exception],
+    ):
+        from bittensor.extrinsics.registration import run_faucet_extrinsic
+
+        # Act
+        result = run_faucet_extrinsic(
+            subtensor=mock_subtensor, wallet=mock_wallet, max_allowed_attempts=3
+        )
+
+        # Assert
+        assert result == expected

--- a/tests/unit_tests/extrinsics/test_senate.py
+++ b/tests/unit_tests/extrinsics/test_senate.py
@@ -67,7 +67,6 @@ def test_register_senate_extrinsic(
     ) as mock_submit_extrinsic, patch.object(
         mock_wallet, "is_senate_member", return_value=is_registered
     ):
-
         # Act
         result = register_senate_extrinsic(
             subtensor=mock_subtensor,

--- a/tests/unit_tests/extrinsics/test_senate.py
+++ b/tests/unit_tests/extrinsics/test_senate.py
@@ -1,0 +1,81 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from bittensor import subtensor, wallet
+from bittensor.extrinsics.senate import register_senate_extrinsic
+
+
+# Mocking external dependencies
+@pytest.fixture
+def mock_subtensor():
+    mock = MagicMock(spec=subtensor)
+    mock.substrate = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def mock_wallet():
+    mock = MagicMock(spec=wallet)
+    mock.coldkey = MagicMock()
+    mock.hotkey = MagicMock()
+    mock.hotkey.ss58_address = "fake_hotkey_address"
+    mock.is_senate_member = None
+    return mock
+
+
+# Parametrized test cases
+@pytest.mark.parametrize(
+    "wait_for_inclusion,wait_for_finalization,prompt,response_success,is_registered,expected_result, test_id",
+    [
+        # Happy path tests
+        (False, True, False, True, True, True, "happy-path-finalization-true"),
+        (True, False, False, True, True, True, "happy-path-inclusion-true"),
+        (False, False, False, True, True, True, "happy-path-no_wait"),
+        # Edge cases
+        (True, True, False, True, True, True, "edge-both-waits-true"),
+        # Error cases
+        (False, True, False, False, False, None, "error-finalization-failed"),
+        (True, False, False, False, False, None, "error-inclusion-failed"),
+        (False, True, True, True, False, False, "error-prompt-declined"),
+    ],
+)
+def test_register_senate_extrinsic(
+    mock_subtensor,
+    mock_wallet,
+    wait_for_inclusion,
+    wait_for_finalization,
+    prompt,
+    response_success,
+    is_registered,
+    expected_result,
+    test_id,
+):
+    # Arrange
+    with patch(
+        "bittensor.extrinsics.senate.Confirm.ask", return_value=not prompt
+    ), patch("bittensor.extrinsics.senate.time.sleep"), patch.object(
+        mock_subtensor.substrate, "compose_call"
+    ), patch.object(
+        mock_subtensor.substrate, "create_signed_extrinsic"
+    ), patch.object(
+        mock_subtensor.substrate,
+        "submit_extrinsic",
+        return_value=MagicMock(
+            is_success=response_success,
+            process_events=MagicMock(),
+            error_message="error",
+        ),
+    ) as mock_submit_extrinsic, patch.object(
+        mock_wallet, "is_senate_member", return_value=is_registered
+    ):
+
+        # Act
+        result = register_senate_extrinsic(
+            subtensor=mock_subtensor,
+            wallet=mock_wallet,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            prompt=prompt,
+        )
+
+        # Assert
+        assert result == expected_result, f"Test ID: {test_id}"

--- a/tests/unit_tests/extrinsics/test_serving.py
+++ b/tests/unit_tests/extrinsics/test_serving.py
@@ -1,0 +1,223 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from bittensor.subtensor import subtensor as Subtensor
+from bittensor.wallet import wallet as Wallet
+from bittensor.extrinsics.serving import serve_extrinsic
+
+
+@pytest.fixture
+def mock_subtensor():
+    mock_subtensor = MagicMock(spec=Subtensor)
+    mock_subtensor.network = "test_network"
+    return mock_subtensor
+
+
+@pytest.fixture
+def mock_wallet():
+    wallet = MagicMock(spec=Wallet)
+    wallet.hotkey.ss58_address = "hotkey_address"
+    wallet.coldkeypub.ss58_address = "coldkey_address"
+    return wallet
+
+
+@pytest.mark.parametrize(
+    "ip,port,protocol,netuid,placeholder1,placeholder2,wait_for_inclusion,wait_for_finalization,prompt,expected,test_id,",
+    [
+        (
+            "192.168.1.1",
+            9221,
+            1,
+            0,
+            0,
+            0,
+            False,
+            True,
+            False,
+            True,
+            "happy-path-no-wait",
+        ),
+        (
+            "192.168.1.2",
+            9222,
+            2,
+            1,
+            1,
+            1,
+            True,
+            False,
+            False,
+            True,
+            "happy-path-wait-for-inclusion",
+        ),
+        (
+            "192.168.1.3",
+            9223,
+            3,
+            2,
+            2,
+            2,
+            False,
+            True,
+            True,
+            True,
+            "happy-path-wait-for-finalization-and-prompt",
+        ),
+    ],
+    ids=[
+        "happy-path-no-wait",
+        "happy-path-wait-for-inclusion",
+        "happy-path-wait-for-finalization-and-prompt",
+    ],
+)
+def test_serve_extrinsic_happy_path(
+    mock_subtensor,
+    mock_wallet,
+    ip,
+    port,
+    protocol,
+    netuid,
+    placeholder1,
+    placeholder2,
+    wait_for_inclusion,
+    wait_for_finalization,
+    prompt,
+    expected,
+    test_id,
+):
+    # Arrange
+    mock_subtensor._do_serve_axon.return_value = (True, "")
+    with patch("bittensor.extrinsics.serving.Confirm.ask", return_value=True):
+
+        # Act
+        result = serve_extrinsic(
+            mock_subtensor,
+            mock_wallet,
+            ip,
+            port,
+            protocol,
+            netuid,
+            placeholder1,
+            placeholder2,
+            wait_for_inclusion,
+            wait_for_finalization,
+            prompt,
+        )
+
+        # Assert
+        assert result == expected, f"Test ID: {test_id}"
+
+
+# Various edge cases
+@pytest.mark.parametrize(
+    "ip,port,protocol,netuid,placeholder1,placeholder2,wait_for_inclusion,wait_for_finalization,prompt,expected,test_id,",
+    [
+        (
+            "192.168.1.4",
+            9224,
+            4,
+            3,
+            3,
+            3,
+            True,
+            True,
+            False,
+            True,
+            "edge_case_max_values",
+        ),
+    ],
+    ids=["edge-case-max-values"],
+)
+def test_serve_extrinsic_edge_cases(
+    mock_subtensor,
+    mock_wallet,
+    ip,
+    port,
+    protocol,
+    netuid,
+    placeholder1,
+    placeholder2,
+    wait_for_inclusion,
+    wait_for_finalization,
+    prompt,
+    expected,
+    test_id,
+):
+    # Arrange
+    mock_subtensor._do_serve_axon.return_value = (True, "")
+    with patch("bittensor.extrinsics.serving.Confirm.ask", return_value=True):
+
+        # Act
+        result = serve_extrinsic(
+            mock_subtensor,
+            mock_wallet,
+            ip,
+            port,
+            protocol,
+            netuid,
+            placeholder1,
+            placeholder2,
+            wait_for_inclusion,
+            wait_for_finalization,
+            prompt,
+        )
+
+        # Assert
+        assert result == expected
+
+
+# Various error cases
+@pytest.mark.parametrize(
+    "ip,port,protocol,netuid,placeholder1,placeholder2,wait_for_inclusion,wait_for_finalization,prompt,expected_error_message,test_id,",
+    [
+        (
+            "192.168.1.5",
+            9225,
+            5,
+            4,
+            4,
+            4,
+            True,
+            True,
+            False,
+            False,
+            "error-case-failed-serve",
+        ),
+    ],
+    ids=["error-case-failed-serve"],
+)
+def test_serve_extrinsic_error_cases(
+    mock_subtensor,
+    mock_wallet,
+    ip,
+    port,
+    protocol,
+    netuid,
+    placeholder1,
+    placeholder2,
+    wait_for_inclusion,
+    wait_for_finalization,
+    prompt,
+    expected_error_message,
+    test_id,
+):
+    # Arrange
+    mock_subtensor._do_serve_axon.return_value = (False, "Error serving axon")
+    with patch("bittensor.extrinsics.serving.Confirm.ask", return_value=True):
+
+        # Act
+        result = serve_extrinsic(
+            mock_subtensor,
+            mock_wallet,
+            ip,
+            port,
+            protocol,
+            netuid,
+            placeholder1,
+            placeholder2,
+            wait_for_inclusion,
+            wait_for_finalization,
+            prompt,
+        )
+
+        # Assert
+        assert result == expected_error_message

--- a/tests/unit_tests/extrinsics/test_serving.py
+++ b/tests/unit_tests/extrinsics/test_serving.py
@@ -87,7 +87,6 @@ def test_serve_extrinsic_happy_path(
     # Arrange
     mock_subtensor._do_serve_axon.return_value = (True, "")
     with patch("bittensor.extrinsics.serving.Confirm.ask", return_value=True):
-
         # Act
         result = serve_extrinsic(
             mock_subtensor,
@@ -145,7 +144,6 @@ def test_serve_extrinsic_edge_cases(
     # Arrange
     mock_subtensor._do_serve_axon.return_value = (True, "")
     with patch("bittensor.extrinsics.serving.Confirm.ask", return_value=True):
-
         # Act
         result = serve_extrinsic(
             mock_subtensor,
@@ -203,7 +201,6 @@ def test_serve_extrinsic_error_cases(
     # Arrange
     mock_subtensor._do_serve_axon.return_value = (False, "Error serving axon")
     with patch("bittensor.extrinsics.serving.Confirm.ask", return_value=True):
-
         # Act
         result = serve_extrinsic(
             mock_subtensor,

--- a/tests/unit_tests/utils/test_networking.py
+++ b/tests/unit_tests/utils/test_networking.py
@@ -4,7 +4,7 @@ import pytest
 import requests
 import unittest.mock as mock
 from bittensor import utils
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock
 
 
 # Test conversion functions for IPv4


### PR DESCRIPTION
coverage extended to extrinsics & increases global coverage 65% -> 66% (higher once skipped tests enabled)

Able to remove skip once https://github.com/opentensor/bittensor/pull/1696 is in `master`