### PR TITLE
close synchronosuly on __del__

### DIFF
--- a/bittensor/dendrite.py
+++ b/bittensor/dendrite.py
@@ -814,4 +814,4 @@ class dendrite(torch.nn.Module):
             # ... some operations ...
             del dendrite  # This will implicitly invoke the __del__ method and close the session.
         """
-        asyncio.run(self.aclose_session())
+        self.close_session()


### PR DESCRIPTION
Misleading Error only occurs in python` 3.11`:
```bash
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /example.py:4 in <module>                                                                        │
│                                                                                                  │
│    1 import torch                                                                                │
│    2 import bittensor as bt                                                                      │
│    3 dendrite = bt.dendrite( )                                                                   │
│ ❱  4 raise Exception('Raise random exception.')                                                  │
│    5                                                                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
Exception: Raise random exception.
Exception ignored in: <function dendrite.__del__ at 0x29bcb7600>
Traceback (most recent call last):
  File ".../bittensor/dendrite.py", line 815, in __del__
TypeError: 'NoneType' object is not callable
```

Actually caused by `dendrite.aclosesession not awaited` under the hood.

Fixed by simply using synchronous `dendrite.closesession()` in `__del__` desctructor.