### PR TITLE
Feature/prompt set identity on btcli/phil

### DIFF
--- a/bittensor/commands/delegates.py
+++ b/bittensor/commands/delegates.py
@@ -27,6 +27,7 @@ from rich.console import Text
 from tqdm import tqdm
 from substrateinterface.exceptions import SubstrateRequestException
 from .utils import get_delegates_details, DelegatesDetails
+from .identity import SetIdentityCommand
 from . import defaults
 
 import os
@@ -647,6 +648,19 @@ class NominateCommand:
                     subtensor.network
                 )
             )
+
+            # Prompt use to set identity on chain.
+            do_set_identity = Prompt.ask(
+                f"Subnetwork registered successfully. Would you like to set your identity? [y/n]",
+                choices=["y", "n"],
+            )
+
+            if do_set_identity.lower() == "y":
+                subtensor.close()
+                config = cli.config.copy()
+                SetIdentityCommand.check_config(config)
+                cli.config = config
+                SetIdentityCommand.run(cli)
 
     @staticmethod
     def add_args(parser: argparse.ArgumentParser):

--- a/bittensor/commands/delegates.py
+++ b/bittensor/commands/delegates.py
@@ -650,17 +650,18 @@ class NominateCommand:
             )
 
             # Prompt use to set identity on chain.
-            do_set_identity = Prompt.ask(
-                f"Subnetwork registered successfully. Would you like to set your identity? [y/n]",
-                choices=["y", "n"],
-            )
+            if not cli.config.no_prompt:
+                do_set_identity = Prompt.ask(
+                    f"Subnetwork registered successfully. Would you like to set your identity? [y/n]",
+                    choices=["y", "n"],
+                )
 
-            if do_set_identity.lower() == "y":
-                subtensor.close()
-                config = cli.config.copy()
-                SetIdentityCommand.check_config(config)
-                cli.config = config
-                SetIdentityCommand.run(cli)
+                if do_set_identity.lower() == "y":
+                    subtensor.close()
+                    config = cli.config.copy()
+                    SetIdentityCommand.check_config(config)
+                    cli.config = config
+                    SetIdentityCommand.run(cli)
 
     @staticmethod
     def add_args(parser: argparse.ArgumentParser):

--- a/bittensor/commands/network.py
+++ b/bittensor/commands/network.py
@@ -89,12 +89,11 @@ class RegisterSubnetworkCommand:
                 choices=["y", "n"],
             )
 
-            config = cli.config.copy()
-            cli.config = config
-
             if do_set_identity.lower() == "y":
                 subtensor.close()
+                config = cli.config.copy()
                 SetIdentityCommand.check_config(config)
+                cli.config = config
                 SetIdentityCommand.run(cli)
 
     @classmethod

--- a/bittensor/commands/network.py
+++ b/bittensor/commands/network.py
@@ -22,6 +22,7 @@ from rich.prompt import Prompt
 from rich.table import Table
 from typing import List, Optional, Dict
 from .utils import get_delegates_details, DelegatesDetails, check_netuid_set
+from .identity import SetIdentityCommand
 
 console = bittensor.__console__
 
@@ -75,11 +76,26 @@ class RegisterSubnetworkCommand:
     def _run(cli: "bittensor.cli", subtensor: "bittensor.subtensor"):
         r"""Register a subnetwork"""
         wallet = bittensor.wallet(config=cli.config)
+
         # Call register command.
-        subtensor.register_subnetwork(
+        success = subtensor.register_subnetwork(
             wallet=wallet,
             prompt=not cli.config.no_prompt,
         )
+        if success:
+            # Prompt for user to set identity.
+            do_set_identity = Prompt.ask(
+                f"Subnetwork registered successfully. Would you like to set your identity? [y/n]",
+                choices=["y", "n"],
+            )
+
+            config = cli.config.copy()
+            cli.config = config
+
+            if do_set_identity.lower() == "y":
+                subtensor.close()
+                SetIdentityCommand.check_config(config)
+                SetIdentityCommand.run(cli)
 
     @classmethod
     def check_config(cls, config: "bittensor.config"):

--- a/bittensor/commands/network.py
+++ b/bittensor/commands/network.py
@@ -82,7 +82,7 @@ class RegisterSubnetworkCommand:
             wallet=wallet,
             prompt=not cli.config.no_prompt,
         )
-        if success:
+        if success and not cli.config.no_prompt:
             # Prompt for user to set identity.
             do_set_identity = Prompt.ask(
                 f"Subnetwork registered successfully. Would you like to set your identity? [y/n]",


### PR DESCRIPTION
This adds 2 feature requests:
* Registering subnets prompts user to add identity which is stored on chain
* Allow delegates to add identity information on the chain