### PR TITLE
fix: Updates `btcli wallet balance --all` to get proper Wallet Name  &  Coldkey Address sets

### DIFF
--- a/bittensor/commands/wallets.py
+++ b/bittensor/commands/wallets.py
@@ -699,9 +699,11 @@ def _get_coldkey_ss58_addresses_for_path(path: str) -> List[str]:
         abspath = os.path.abspath(os.path.expanduser(dir_path))
         coldkey_files = []
 
-        for file in os.listdir(abspath):
-            coldkey_path = os.path.join(abspath, file, "coldkeypub.txt")
-            if os.path.exists(coldkey_path):
+        for dir in os.listdir(abspath):
+            coldkey_path = os.path.join(abspath, dir, "coldkeypub.txt")
+            if os.path.isdir(os.path.join(abspath, dir)) and os.path.exists(
+                coldkey_path
+            ):
                 coldkey_files.append(coldkey_path)
             else:
                 bittensor.logging.warning(

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -33,6 +33,7 @@ import bittensor
 from bittensor import Balance
 from bittensor.commands.delegates import _get_coldkey_wallets_for_path
 from bittensor.commands.identity import SetIdentityCommand
+from bittensor.commands.wallets import _get_coldkey_ss58_addresses_for_path
 from bittensor.mock import MockSubtensor
 from bittensor.wallet import wallet as Wallet
 from tests.helpers import (
@@ -2385,6 +2386,53 @@ def test_set_identity_command(
             # Assert
             mock_subtensor.update_identity.assert_called_once()
             assert mock_exit.call_count == 0
+
+
+TEST_DIR = "/tmp/test_bittensor_wallets"
+if not os.path.exists(TEST_DIR):
+    os.makedirs(TEST_DIR)
+
+
+@pytest.fixture
+def setup_files(tmp_path):
+    def _setup_files(files):
+        for file_path, content in files.items():
+            full_path = tmp_path / file_path
+            os.makedirs(full_path.parent, exist_ok=True)
+            with open(full_path, "w") as f:
+                f.write(content)
+        return tmp_path
+
+    return _setup_files
+
+
+@pytest.mark.parametrize(
+    "test_id, setup_data, expected",
+    [
+        # Error cases
+        ("error_case_nonexistent_dir", {"just_a_file.txt": ""}, []),
+    ],
+)
+def test_get_coldkey_ss58_addresses_for_path(
+    setup_files, test_id, setup_data, expected
+):
+    path = setup_files(setup_data)
+
+    # Arrange
+    # Setup done in setup_files fixture and parametrize
+
+    # Act
+    result = _get_coldkey_ss58_addresses_for_path(str(path))
+
+    # Assert
+    assert (
+        result == expected
+    ), f"Test ID: {test_id} failed. Expected {expected}, got {result}"
+
+
+# Cleanup after tests
+def teardown_module(module):
+    shutil.rmtree(TEST_DIR)
 
 
 if __name__ == "__main__":

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -18,6 +18,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
+import contextlib
 from copy import deepcopy
 import os
 import random
@@ -2432,7 +2433,8 @@ def test_get_coldkey_ss58_addresses_for_path(
 
 # Cleanup after tests
 def teardown_module(module):
-    shutil.rmtree(TEST_DIR)
+    with contextlib.suppress(FileNotFoundError):
+        shutil.rmtree(TEST_DIR)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Updates _get_coldkey_ss58_addresses_for_path to properly retrieve wallet dir sets