### PR TITLE
Fix missing second return value

### DIFF
--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -1018,7 +1018,7 @@ class subtensor:
 
                 # We only wait here if we expect finalization.
                 if not wait_for_finalization and not wait_for_inclusion:
-                    return True
+                    return True, None
 
                 # process if registration successful, try again if pow is still valid
                 response.process_events()
@@ -1060,7 +1060,7 @@ class subtensor:
 
                 # We only wait here if we expect finalization.
                 if not wait_for_finalization and not wait_for_inclusion:
-                    return True
+                    return True, None
 
                 # process if registration successful, try again if pow is still valid
                 response.process_events()


### PR DESCRIPTION
Fixes the following error when doing burned_register with wait_for_finalization set to False

```
  File "/root/venv/lib/python3.10/site-packages/bittensor/subtensor.py", line 922, in burned_register
    return burned_register_extrinsic(
  File "/root/venv/lib/python3.10/site-packages/bittensor/extrinsics/registration.py", line 279, in burned_register_extrinsic
    success, err_msg = subtensor._do_burned_register(
TypeError: cannot unpack non-iterable bool object
```
