### PR TITLE
[bug fix] Fix import json

### DIFF
--- a/bittensor/keyfile.py
+++ b/bittensor/keyfile.py
@@ -53,6 +53,7 @@ def serialized_keypair_to_keyfile_data(keypair: "bittensor.Keypair") -> bytes:
     json_data = {
         "accountId": "0x" + keypair.public_key.hex() if keypair.public_key else None,
         "publicKey": "0x" + keypair.public_key.hex() if keypair.public_key else None,
+        "privateKey": "0x" + keypair.private_key.hex() if keypair.private_key else None,
         "secretPhrase": keypair.mnemonic if keypair.mnemonic else None,
         "secretSeed": (
             "0x"
@@ -90,6 +91,7 @@ def deserialize_keypair_from_keyfile_data(keyfile_data: bytes) -> "bittensor.Key
             keyfile_dict = {
                 "accountId": None,
                 "publicKey": None,
+                "privateKey": None,
                 "secretPhrase": None,
                 "secretSeed": None,
                 "ss58Address": string_value,
@@ -104,9 +106,15 @@ def deserialize_keypair_from_keyfile_data(keyfile_data: bytes) -> "bittensor.Key
     if "secretSeed" in keyfile_dict and keyfile_dict["secretSeed"] is not None:
         return bittensor.Keypair.create_from_seed(keyfile_dict["secretSeed"])
 
-    if "secretPhrase" in keyfile_dict and keyfile_dict["secretPhrase"] is not None:
+    elif "secretPhrase" in keyfile_dict and keyfile_dict["secretPhrase"] is not None:
         return bittensor.Keypair.create_from_mnemonic(
             mnemonic=keyfile_dict["secretPhrase"]
+        )
+
+    elif keyfile_dict.get("privateKey", None) is not None:
+        # May have the above dict keys also, but we want to preserve the first two
+        return bittensor.Keypair.create_from_private_key(
+            keyfile_dict["privateKey"], ss58_format=bittensor.__ss58_format__
         )
 
     if "ss58Address" in keyfile_dict and keyfile_dict["ss58Address"] is not None:

--- a/tests/unit_tests/test_keyfile.py
+++ b/tests/unit_tests/test_keyfile.py
@@ -432,8 +432,11 @@ def test_legacy_coldkey(keyfile_setup_teardown):
     assert keyfile.keyfile_data == keyfile_data
     keyfile.encrypt(password="this is the fake password")
     keyfile.decrypt(password="this is the fake password")
-    keypair_bytes = b'{"accountId": "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f", "publicKey": "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f", "secretPhrase": null, "secretSeed": null, "ss58Address": "5DD26kC2kxajmwfbbZmVmxhrY9VeeyR1Gpzy9i8wxLUg6zxm"}'
-    assert keyfile.keyfile_data == keypair_bytes
+    expected_decryption = {"accountId": "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f", "publicKey": "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f", "privateKey": None, "secretPhrase": None, "secretSeed": None, "ss58Address": "5DD26kC2kxajmwfbbZmVmxhrY9VeeyR1Gpzy9i8wxLUg6zxm"}
+    for key, value in expected_decryption.items():
+        value_str = f'"{value}"' if value is not None else "null"
+        assert f'\"{key}\": {value_str}'.encode() in keyfile.keyfile_data
+    
     assert (
         keyfile.get_keypair().ss58_address
         == "5DD26kC2kxajmwfbbZmVmxhrY9VeeyR1Gpzy9i8wxLUg6zxm"

--- a/tests/unit_tests/test_keyfile.py
+++ b/tests/unit_tests/test_keyfile.py
@@ -432,11 +432,18 @@ def test_legacy_coldkey(keyfile_setup_teardown):
     assert keyfile.keyfile_data == keyfile_data
     keyfile.encrypt(password="this is the fake password")
     keyfile.decrypt(password="this is the fake password")
-    expected_decryption = {"accountId": "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f", "publicKey": "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f", "privateKey": None, "secretPhrase": None, "secretSeed": None, "ss58Address": "5DD26kC2kxajmwfbbZmVmxhrY9VeeyR1Gpzy9i8wxLUg6zxm"}
+    expected_decryption = {
+        "accountId": "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f",
+        "publicKey": "0x32939b6abc4d81f02dff04d2b8d1d01cc8e71c5e4c7492e4fa6a238cdca3512f",
+        "privateKey": None,
+        "secretPhrase": None,
+        "secretSeed": None,
+        "ss58Address": "5DD26kC2kxajmwfbbZmVmxhrY9VeeyR1Gpzy9i8wxLUg6zxm",
+    }
     for key, value in expected_decryption.items():
         value_str = f'"{value}"' if value is not None else "null"
-        assert f'\"{key}\": {value_str}'.encode() in keyfile.keyfile_data
-    
+        assert f'"{key}": {value_str}'.encode() in keyfile.keyfile_data
+
     assert (
         keyfile.get_keypair().ss58_address
         == "5DD26kC2kxajmwfbbZmVmxhrY9VeeyR1Gpzy9i8wxLUg6zxm"


### PR DESCRIPTION
This fixes the import from json exort functionality.

This may have been caused by a change in `substrate-interface`, but this new fix should support future changes given it uses `Keypair.private_key`.