### PR TITLE
Change extrinsic submission flow

### DIFF
--- a/bittensor/keyfile.py
+++ b/bittensor/keyfile.py
@@ -53,6 +53,7 @@ def serialized_keypair_to_keyfile_data(keypair: "bittensor.Keypair") -> bytes:
     json_data = {
         "accountId": "0x" + keypair.public_key.hex() if keypair.public_key else None,
         "publicKey": "0x" + keypair.public_key.hex() if keypair.public_key else None,
+        "privateKey": "0x" + keypair.private_key.hex() if keypair.private_key else None,
         "secretPhrase": keypair.mnemonic if keypair.mnemonic else None,
         "secretSeed": (
             "0x"
@@ -90,6 +91,7 @@ def deserialize_keypair_from_keyfile_data(keyfile_data: bytes) -> "bittensor.Key
             keyfile_dict = {
                 "accountId": None,
                 "publicKey": None,
+                "privateKey": None,
                 "secretPhrase": None,
                 "secretSeed": None,
                 "ss58Address": string_value,
@@ -104,9 +106,15 @@ def deserialize_keypair_from_keyfile_data(keyfile_data: bytes) -> "bittensor.Key
     if "secretSeed" in keyfile_dict and keyfile_dict["secretSeed"] is not None:
         return bittensor.Keypair.create_from_seed(keyfile_dict["secretSeed"])
 
-    if "secretPhrase" in keyfile_dict and keyfile_dict["secretPhrase"] is not None:
+    elif "secretPhrase" in keyfile_dict and keyfile_dict["secretPhrase"] is not None:
         return bittensor.Keypair.create_from_mnemonic(
             mnemonic=keyfile_dict["secretPhrase"]
+        )
+
+    elif keyfile_dict.get("privateKey", None) is not None:
+        # May have the above dict keys also, but we want to preserve the first two
+        return bittensor.Keypair.create_from_private_key(
+            keyfile_dict["privateKey"], ss58_format=bittensor.__ss58_format__
         )
 
     if "ss58Address" in keyfile_dict and keyfile_dict["ss58Address"] is not None:

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -4291,34 +4291,38 @@ class subtensor:
         wait_for_finalization: bool = False,
     ) -> bool:
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
-        def make_substrate_call_with_retry():
-            with self.substrate as substrate:
-                call = substrate.compose_call(
-                    call_module="SubtensorModule",
-                    call_function="remove_stake",
-                    call_params={
-                        "hotkey": delegate_ss58,
-                        "amount_unstaked": amount.rao,
-                    },
-                )
-                extrinsic = substrate.create_signed_extrinsic(
-                    call=call, keypair=wallet.coldkey
-                )
-                response = substrate.submit_extrinsic(
-                    extrinsic,
-                    wait_for_inclusion=wait_for_inclusion,
-                    wait_for_finalization=wait_for_finalization,
-                )
-                # We only wait here if we expect finalization.
-                if not wait_for_finalization and not wait_for_inclusion:
-                    return True
-                response.process_events()
-                if response.is_success:
-                    return True
-                else:
-                    raise StakeError(response.error_message)
+        def make_substrate_call_with_retry(substrate, extrinsic):
+            response = substrate.submit_extrinsic(
+                extrinsic,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+            )
+            # We only wait here if we expect finalization.
+            if not wait_for_finalization and not wait_for_inclusion:
+                return True
 
-        return make_substrate_call_with_retry()
+            # Otherwise continue with finalization.
+            response.process_events()
+            if response.is_success:
+                return True
+            else:
+                return StakeError(response.error_message)
+
+        with self.substrate as substrate:
+            call = substrate.compose_call(
+                call_module="SubtensorModule",
+                call_function="remove_stake",
+                call_params={
+                    "hotkey": delegate_ss58,
+                    "amount_unstaked": amount.rao,
+                },
+            )
+            extrinsic = substrate.create_signed_extrinsic(
+                call=call, keypair=wallet.coldkey
+            )
+            # Retry submission, but only create call once.
+            return make_substrate_call_with_retry(substrate, extrinsic)
+        
 
     def _do_nominate(
         self,

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -1004,39 +1004,38 @@ class subtensor:
         wait_for_finalization: bool = True,
     ) -> Tuple[bool, Optional[str]]:
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
-        def make_substrate_call_with_retry():
-            with self.substrate as substrate:
-                # create extrinsic call
-                call = substrate.compose_call(
-                    call_module="SubtensorModule",
-                    call_function="swap_hotkey",
-                    call_params={
-                        "hotkey": wallet.hotkey.ss58_address,
-                        "new_hotkey": new_wallet.hotkey.ss58_address,
-                    },
-                )
-                extrinsic = substrate.create_signed_extrinsic(
-                    call=call, keypair=wallet.coldkey
-                )
-                response = substrate.submit_extrinsic(
-                    extrinsic,
-                    wait_for_inclusion=wait_for_inclusion,
-                    wait_for_finalization=wait_for_finalization,
-                )
+        def make_substrate_call_with_retry(substrate, extrinsic):
+            response = substrate.submit_extrinsic(
+                extrinsic,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+            )
+            # We only wait here if we expect finalization.
+            if not wait_for_finalization and not wait_for_inclusion:
+                return True, None
 
-                # We only wait here if we expect finalization.
-                if not wait_for_finalization and not wait_for_inclusion:
-                    return True, None
+            # Otherwise continue with finalization.
+            response.process_events()
+            if response.is_success:
+                return True, None
+            else:
+                return False, response.error_message
 
-                # process if registration successful, try again if pow is still valid
-                response.process_events()
-                if not response.is_success:
-                    return False, response.error_message
-                # Successful registration
-                else:
-                    return True, None
+        with self.substrate as substrate:
+            call = substrate.compose_call(
+                call_module="SubtensorModule",
+                call_function="swap_hotkey",
+                call_params={
+                    "hotkey": wallet.hotkey.ss58_address,
+                    "new_hotkey": new_wallet.hotkey.ss58_address,
+                },
+            )
+            extrinsic = substrate.create_signed_extrinsic(
+                call=call, keypair=wallet.coldkey
+            )
+            # Retry submission, but only create call once.
+            return make_substrate_call_with_retry(substrate, extrinsic)
 
-        return make_substrate_call_with_retry()
 
     ##################
     #### Transfer ####

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -740,6 +740,7 @@ class subtensor:
         This method is vital for the dynamic weighting mechanism in Bittensor, where neurons adjust their
         trust in other neurons based on observed performance and contributions.
         """
+
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
         def make_substrate_call_with_retry(substrate, extrinsic):
             response = substrate.submit_extrinsic(
@@ -775,10 +776,9 @@ class subtensor:
                 keypair=wallet.hotkey,
                 era={"period": 5},
             )
-           
+
             # Retry submission, but only create call once.
             return make_substrate_call_with_retry(substrate, extrinsic)
-
 
     ######################
     #### Registration ####
@@ -952,6 +952,7 @@ class subtensor:
             success (bool): ``True`` if the extrinsic was included in a block.
             error (Optional[str]): ``None`` on success or not waiting for inclusion/finalization, otherwise the error message.
         """
+
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
         def make_substrate_call_with_retry(substrate, extrinsic):
             response = substrate.submit_extrinsic(
@@ -988,7 +989,6 @@ class subtensor:
             )
             # Retry submission, but only create call once.
             return make_substrate_call_with_retry(substrate, extrinsic)
-
 
     def _do_burned_register(
         self,
@@ -1030,7 +1030,6 @@ class subtensor:
             # Retry submission, but only create call once.
             return make_substrate_call_with_retry(substrate, extrinsic)
 
-
     def _do_swap_hotkey(
         self,
         wallet: "bittensor.wallet",
@@ -1070,7 +1069,6 @@ class subtensor:
             )
             # Retry submission, but only create call once.
             return make_substrate_call_with_retry(substrate, extrinsic)
-
 
     ##################
     #### Transfer ####
@@ -1417,6 +1415,7 @@ class subtensor:
         This function is crucial for initializing and announcing a neuron's Axon service on the network,
         enhancing the decentralized computation capabilities of Bittensor.
         """
+
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
         def make_substrate_call_with_retry(substrate, extrinsic):
             response = substrate.submit_extrinsic(
@@ -1482,6 +1481,7 @@ class subtensor:
             success (bool): ``True`` if serve prometheus was successful.
             error (:func:`Optional[str]`): Error message if serve prometheus failed, ``None`` otherwise.
         """
+
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
         def make_substrate_call_with_retry(substrate, extrinsic):
             response = substrate.submit_extrinsic(
@@ -1534,6 +1534,7 @@ class subtensor:
             success (bool): ``True`` if associate IPs was successful.
             error (:func:`Optional[str]`): Error message if associate IPs failed, None otherwise.
         """
+
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
         def make_substrate_call_with_retry(substrate, extrinsic):
             response = substrate.submit_extrinsic(
@@ -1566,7 +1567,6 @@ class subtensor:
             )
             # Retry submission, but only create call once.
             return make_substrate_call_with_retry(substrate, extrinsic)
-
 
     #################
     #### Staking ####
@@ -1667,6 +1667,7 @@ class subtensor:
         Raises:
             StakeError: If the extrinsic failed.
         """
+
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
         def make_substrate_call_with_retry(substrate, extrinsic):
             response = substrate.submit_extrinsic(
@@ -1795,6 +1796,7 @@ class subtensor:
         Raises:
             StakeError: If the extrinsic failed.
         """
+
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
         def make_substrate_call_with_retry(substrate, extrinsic):
             response = substrate.submit_extrinsic(
@@ -4281,7 +4283,6 @@ class subtensor:
             # Retry submission, but only create call once.
             return make_substrate_call_with_retry(substrate, extrinsic)
 
-
     def _do_undelegation(
         self,
         wallet: "bittensor.wallet",
@@ -4322,7 +4323,6 @@ class subtensor:
             )
             # Retry submission, but only create call once.
             return make_substrate_call_with_retry(substrate, extrinsic)
-        
 
     def _do_nominate(
         self,
@@ -4359,7 +4359,6 @@ class subtensor:
             )
             # Retry submission, but only create call once.
             return make_substrate_call_with_retry(substrate, extrinsic)
-
 
     ################
     #### Legacy ####

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -1795,34 +1795,35 @@ class subtensor:
         Raises:
             StakeError: If the extrinsic failed.
         """
-
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
-        def make_substrate_call_with_retry():
-            with self.substrate as substrate:
-                call = substrate.compose_call(
-                    call_module="SubtensorModule",
-                    call_function="remove_stake",
-                    call_params={"hotkey": hotkey_ss58, "amount_unstaked": amount.rao},
-                )
-                extrinsic = substrate.create_signed_extrinsic(
-                    call=call, keypair=wallet.coldkey
-                )
-                response = substrate.submit_extrinsic(
-                    extrinsic,
-                    wait_for_inclusion=wait_for_inclusion,
-                    wait_for_finalization=wait_for_finalization,
-                )
-                # We only wait here if we expect finalization.
-                if not wait_for_finalization and not wait_for_inclusion:
-                    return True
+        def make_substrate_call_with_retry(substrate, extrinsic):
+            response = substrate.submit_extrinsic(
+                extrinsic,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+            )
+            # We only wait here if we expect finalization.
+            if not wait_for_finalization and not wait_for_inclusion:
+                return True
 
-                response.process_events()
-                if response.is_success:
-                    return True
-                else:
-                    raise StakeError(response.error_message)
+            # Otherwise continue with finalization.
+            response.process_events()
+            if response.is_success:
+                return True
+            else:
+                return StakeError(response.error_message)
 
-        return make_substrate_call_with_retry()
+        with self.substrate as substrate:
+            call = substrate.compose_call(
+                call_module="SubtensorModule",
+                call_function="remove_stake",
+                call_params={"hotkey": hotkey_ss58, "amount_unstaked": amount.rao},
+            )
+            extrinsic = substrate.create_signed_extrinsic(
+                call=call, keypair=wallet.coldkey
+            )
+            # Retry submission, but only create call once.
+            return make_substrate_call_with_retry(substrate, extrinsic)
 
     ################
     #### Senate ####

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -1481,33 +1481,35 @@ class subtensor:
             success (bool): ``True`` if serve prometheus was successful.
             error (:func:`Optional[str]`): Error message if serve prometheus failed, ``None`` otherwise.
         """
-
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
-        def make_substrate_call_with_retry():
-            with self.substrate as substrate:
-                call = substrate.compose_call(
-                    call_module="SubtensorModule",
-                    call_function="serve_prometheus",
-                    call_params=call_params,
-                )
-                extrinsic = substrate.create_signed_extrinsic(
-                    call=call, keypair=wallet.hotkey
-                )
-                response = substrate.submit_extrinsic(
-                    extrinsic,
-                    wait_for_inclusion=wait_for_inclusion,
-                    wait_for_finalization=wait_for_finalization,
-                )
-                if wait_for_inclusion or wait_for_finalization:
-                    response.process_events()
-                    if response.is_success:
-                        return True, None
-                    else:
-                        return False, response.error_message
-                else:
-                    return True, None
+        def make_substrate_call_with_retry(substrate, extrinsic):
+            response = substrate.submit_extrinsic(
+                extrinsic,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+            )
+            # We only wait here if we expect finalization.
+            if not wait_for_finalization and not wait_for_inclusion:
+                return True, None
 
-        return make_substrate_call_with_retry()
+            # Otherwise continue with finalization.
+            response.process_events()
+            if response.is_success:
+                return True, None
+            else:
+                return False, response.error_message
+
+        with self.substrate as substrate:
+            call = substrate.compose_call(
+                call_module="SubtensorModule",
+                call_function="serve_prometheus",
+                call_params=call_params,
+            )
+            extrinsic = substrate.create_signed_extrinsic(
+                call=call, keypair=wallet.coldkey
+            )
+            # Retry submission, but only create call once.
+            return make_substrate_call_with_retry(substrate, extrinsic)
 
     def _do_associate_ips(
         self,

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -2117,36 +2117,34 @@ class subtensor:
         wait_for_finalization: bool = True,
     ) -> Tuple[bool, Optional[str]]:
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
-        def make_substrate_call_with_retry():
-            with self.substrate as substrate:
-                # create extrinsic call
-                call = substrate.compose_call(
-                    call_module="SubtensorModule",
-                    call_function="root_register",
-                    call_params={"hotkey": wallet.hotkey.ss58_address},
-                )
-                extrinsic = substrate.create_signed_extrinsic(
-                    call=call, keypair=wallet.coldkey
-                )
-                response = substrate.submit_extrinsic(
-                    extrinsic,
-                    wait_for_inclusion=wait_for_inclusion,
-                    wait_for_finalization=wait_for_finalization,
-                )
+        def make_substrate_call_with_retry(substrate, extrinsic):
+            response = substrate.submit_extrinsic(
+                extrinsic,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+            )
+            # We only wait here if we expect finalization.
+            if not wait_for_finalization and not wait_for_inclusion:
+                return True, None
 
-                # We only wait here if we expect finalization.
-                if not wait_for_finalization and not wait_for_inclusion:
-                    return True
+            # Otherwise continue with finalization.
+            response.process_events()
+            if response.is_success:
+                return True, None
+            else:
+                return False, response.error_message
 
-                # process if registration successful, try again if pow is still valid
-                response.process_events()
-                if not response.is_success:
-                    return False, response.error_message
-                # Successful registration
-                else:
-                    return True, None
-
-        return make_substrate_call_with_retry()
+        with self.substrate as substrate:
+            call = substrate.compose_call(
+                call_module="SubtensorModule",
+                call_function="root_register",
+                call_params={"hotkey": wallet.hotkey.ss58_address},
+            )
+            extrinsic = substrate.create_signed_extrinsic(
+                call=call, keypair=wallet.coldkey
+            )
+            # Retry submission, but only create call once.
+            return make_substrate_call_with_retry(substrate, extrinsic)
 
     def root_set_weights(
         self,

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -4252,31 +4252,35 @@ class subtensor:
         wait_for_finalization: bool = False,
     ) -> bool:
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
-        def make_substrate_call_with_retry():
-            with self.substrate as substrate:
-                call = substrate.compose_call(
-                    call_module="SubtensorModule",
-                    call_function="add_stake",
-                    call_params={"hotkey": delegate_ss58, "amount_staked": amount.rao},
-                )
-                extrinsic = substrate.create_signed_extrinsic(
-                    call=call, keypair=wallet.coldkey
-                )
-                response = substrate.submit_extrinsic(
-                    extrinsic,
-                    wait_for_inclusion=wait_for_inclusion,
-                    wait_for_finalization=wait_for_finalization,
-                )
-                # We only wait here if we expect finalization.
-                if not wait_for_finalization and not wait_for_inclusion:
-                    return True
-                response.process_events()
-                if response.is_success:
-                    return True
-                else:
-                    raise StakeError(response.error_message)
+        def make_substrate_call_with_retry(substrate, extrinsic):
+            response = substrate.submit_extrinsic(
+                extrinsic,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+            )
+            # We only wait here if we expect finalization.
+            if not wait_for_finalization and not wait_for_inclusion:
+                return True
 
-        return make_substrate_call_with_retry()
+            # Otherwise continue with finalization.
+            response.process_events()
+            if response.is_success:
+                return True
+            else:
+                return StakeError(response.error_message)
+
+        with self.substrate as substrate:
+            call = substrate.compose_call(
+                call_module="SubtensorModule",
+                call_function="add_stake",
+                call_params={"hotkey": delegate_ss58, "amount_staked": amount.rao},
+            )
+            extrinsic = substrate.create_signed_extrinsic(
+                call=call, keypair=wallet.coldkey
+            )
+            # Retry submission, but only create call once.
+            return make_substrate_call_with_retry(substrate, extrinsic)
+
 
     def _do_undelegation(
         self,

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -1534,36 +1534,39 @@ class subtensor:
             success (bool): ``True`` if associate IPs was successful.
             error (:func:`Optional[str]`): Error message if associate IPs failed, None otherwise.
         """
-
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
-        def make_substrate_call_with_retry():
-            with self.substrate as substrate:
-                call = substrate.compose_call(
-                    call_module="SubtensorModule",
-                    call_function="associate_ips",
-                    call_params={
-                        "ip_info_list": [ip_info.encode() for ip_info in ip_info_list],
-                        "netuid": netuid,
-                    },
-                )
-                extrinsic = substrate.create_signed_extrinsic(
-                    call=call, keypair=wallet.hotkey
-                )
-                response = substrate.submit_extrinsic(
-                    extrinsic,
-                    wait_for_inclusion=wait_for_inclusion,
-                    wait_for_finalization=wait_for_finalization,
-                )
-                if wait_for_inclusion or wait_for_finalization:
-                    response.process_events()
-                    if response.is_success:
-                        return True, None
-                    else:
-                        return False, response.error_message
-                else:
-                    return True, None
+        def make_substrate_call_with_retry(substrate, extrinsic):
+            response = substrate.submit_extrinsic(
+                extrinsic,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+            )
+            # We only wait here if we expect finalization.
+            if not wait_for_finalization and not wait_for_inclusion:
+                return True, None
 
-        return make_substrate_call_with_retry()
+            # Otherwise continue with finalization.
+            response.process_events()
+            if response.is_success:
+                return True, None
+            else:
+                return False, response.error_message
+
+        with self.substrate as substrate:
+            call = substrate.compose_call(
+                call_module="SubtensorModule",
+                call_function="associate_ips",
+                call_params={
+                    "ip_info_list": [ip_info.encode() for ip_info in ip_info_list],
+                    "netuid": netuid,
+                },
+            )
+            extrinsic = substrate.create_signed_extrinsic(
+                call=call, keypair=wallet.coldkey
+            )
+            # Retry submission, but only create call once.
+            return make_substrate_call_with_retry(substrate, extrinsic)
+
 
     #################
     #### Staking ####

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -1667,34 +1667,35 @@ class subtensor:
         Raises:
             StakeError: If the extrinsic failed.
         """
-
         @retry(delay=2, tries=3, backoff=2, max_delay=4)
-        def make_substrate_call_with_retry():
-            with self.substrate as substrate:
-                call = substrate.compose_call(
-                    call_module="SubtensorModule",
-                    call_function="add_stake",
-                    call_params={"hotkey": hotkey_ss58, "amount_staked": amount.rao},
-                )
-                extrinsic = substrate.create_signed_extrinsic(
-                    call=call, keypair=wallet.coldkey
-                )
-                response = substrate.submit_extrinsic(
-                    extrinsic,
-                    wait_for_inclusion=wait_for_inclusion,
-                    wait_for_finalization=wait_for_finalization,
-                )
-                # We only wait here if we expect finalization.
-                if not wait_for_finalization and not wait_for_inclusion:
-                    return True
+        def make_substrate_call_with_retry(substrate, extrinsic):
+            response = substrate.submit_extrinsic(
+                extrinsic,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+            )
+            # We only wait here if we expect finalization.
+            if not wait_for_finalization and not wait_for_inclusion:
+                return True
 
-                response.process_events()
-                if response.is_success:
-                    return True
-                else:
-                    raise StakeError(response.error_message)
+            # Otherwise continue with finalization.
+            response.process_events()
+            if response.is_success:
+                return True
+            else:
+                raise StakeError(response.error_message)
 
-        return make_substrate_call_with_retry()
+        with self.substrate as substrate:
+            call = substrate.compose_call(
+                call_module="SubtensorModule",
+                call_function="add_stake",
+                call_params={"hotkey": hotkey_ss58, "amount_staked": amount.rao},
+            )
+            extrinsic = substrate.create_signed_extrinsic(
+                call=call, keypair=wallet.coldkey
+            )
+            # Retry submission, but only create call once.
+            return make_substrate_call_with_retry(substrate, extrinsic)
 
     ###################
     #### Unstaking ####


### PR DESCRIPTION
This changes the flow of extrinsic submission.  
Currently, the flow suffers from a double-compose issue.  
Current flow if the submission has an exception 
(assume the initial submission is included in the chain, regardless of the client exception):
1. call `_do_transfer`
2. create new transfer extrinsic 
3. sign extrinsic using *new nonce*
4. submit extrinsic
5. ERROR!
6. retry from 2.
7. SUCCESS!

In the above example, now there have been 2 *valid* transfer extrinsics submitted (and included) to the chain
This is **bad**, this is a double-*send* by the Python API

This PR changes the flow to retry *only* the *submission* portion. (i.e., 6. retries from 4.)