### PR TITLE
fix PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,62 +1,59 @@
-name: Bug Fix Contribution
-description: Use this template when contributing a bug fix.
-labels: [bug, pull request]
+<!--
 
-body:
-  - type: markdown
-    attributes:
-      value: |
-        ### Requirements for Contributing a Bug Fix
+### Requirements for Contributing a Bug Fix
 
-        * Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
-        * The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
-        * The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
-        * After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.
+* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+* The pull request must only fix an existing bug. To contribute other changes, you must use a different template.
+* The pull request must update the test suite to demonstrate the changed functionality.
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
 
-  - type: input
-    id: bug
-    attributes:
-      label: Identify the Bug
-      description: Link to the issue describing the bug that you're fixing.
-    validations:
-      required: true
+-->
 
-  - type: textarea
-    id: change
-    attributes:
-      label: Description of the Change
-      description: We must be able to understand the design of your change from this description.
-    validations:
-      required: true
+### Bug
 
-  - type: textarea
-    id: alternate
-    attributes:
-      label: Alternate Designs
-      description: Explain what other alternates were considered and why the proposed version was selected.
-    validations:
-      required: false
+<!-- Link to the issue describing the bug that you're fixing. -->
 
-  - type: textarea
-    id: drawbacks
-    attributes:
-      label: Possible Drawbacks
-      description: What are the possible side-effects or negative impacts of the code change?
-    validations:
-      required: false
+### Description of the Change
 
-  - type: textarea
-    id: verification
-    attributes:
-      label: Verification Process
-      description: What process did you follow to verify that the change has not introduced any regressions?
-    validations:
-      required: true
+<!--
 
-  - type: input
-    id: release-notes
-    attributes:
-      label: Release Notes
-      description: Please describe the changes in a single line that explains this improvement in terms that a user can understand.
-    validations:
-      required: true
+We must be able to understand the design of your change from this description.
+If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
+Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+
+-->
+
+### Alternate Designs
+
+<!-- Explain what other alternates were considered and why the proposed version was selected -->
+
+### Possible Drawbacks
+
+<!-- What are the possible side-effects or negative impacts of the code change? -->
+
+### Verification Process
+
+<!--
+
+What process did you follow to verify that the change has not introduced any regressions?
+Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
+
+-->
+
+### Release Notes
+
+<!--
+
+Please describe the changes in a single line that explains this improvement in
+terms that a user can understand. This text will be used in release notes.
+
+If this change is not user-facing or notable enough to be included in release notes
+you may use the strings "Not applicable" or "N/A" here.
+
+Examples:
+
+- The GitHub package now allows you to add co-authors to commits.
+- Fixed an issue where multiple cursors did not work in a file with a single line.
+- Increased the performance of searching and replacing across a whole project.
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/feature_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_change.md
@@ -2,24 +2,8 @@
 
 * Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 * The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
-* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
-* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.
-
-### Issue or RFC Endorsed by Atom's Maintainers
-
-<!--
-
-Link to the issue or RFC that your change relates to. This must be one of the following:
-
-* An open issue with the `help-wanted` label
-* An open issue with the `triaged` label
-* An RFC with "accepted" status
-
-To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements
-
-To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.
-
--->
+* The pull request must update the test suite to exercise the updated functionality.
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
 
 ### Description of the Change
 
@@ -56,7 +40,7 @@ Describe the actions you performed (including buttons you clicked, text you type
 <!--
 
 Please describe the changes in a single line that explains this improvement in
-terms that a user can understand. This text will be used in Atom's release notes.
+terms that a user can understand. This text will be used in release notes.
 
 If this change is not user-facing or notable enough to be included in release notes
 you may use the strings "Not applicable" or "N/A" here.

--- a/.github/PULL_REQUEST_TEMPLATE/performance_improvement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/performance_improvement.md
@@ -1,8 +1,8 @@
 ### Requirements for Contributing a Performance Improvement
 
 * Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
-* The pull request must only affect performance of existing functionality. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
-* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.
+* The pull request must only affect performance of existing functionality
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
 
 ### Description of the Change
 
@@ -41,7 +41,7 @@ What process did you follow to verify that the change has not introduced any reg
 <!--
 
 Please describe the changes in a single line that explains this improvement in
-terms that a user can understand.  This text will be used in Atom's release notes.
+terms that a user can understand.  This text will be used in release notes.
 
 If this change is not user-facing or notable enough to be included in release notes
 you may use the strings "Not applicable" or "N/A" here.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,9 +1,0 @@
-Welcome! Please follow the steps below to tell us about your contribution.
-
-1. Copy the correct template for your contribution
-  - 🐛 Are you fixing a bug? Copy the template from <https://bit.ly/atom-bugfix-pr>
-  - 📈 Are you improving performance? Copy the template from <https://bit.ly/atom-perf-pr>
-  - 💻 Are you changing functionality? Copy the template from <https://bit.ly/atom-behavior-pr>
-2. Replace this text with the contents of the template
-3. Fill in all sections of the template
-4. Click "Create pull request"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+Welcome!
+
+Due to [GitHub limitations](https://github.com/orgs/community/discussions/4620),
+please switch to **Preview** for links to render properly.
+
+Please choose the right template for your pull request:
+
+- 🐛 Are you fixing a bug? [Bug fix](?template=bug_fix.md)
+- 📈 Are you improving performance? [Performance improvement](?template=performance_improvement.md)
+- 💻 Are you changing functionality? [Feature change](?template=feature_change.md)

--- a/contrib/CONTRIBUTING.md
+++ b/contrib/CONTRIBUTING.md
@@ -230,7 +230,7 @@ For a more detailed description of the review process, see the [Code Review Guid
 
 This section guides you through submitting a bug report for Bittensor. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
 
-When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](https://bit.ly/atom-bugfix-pr), the information it asks for helps us resolve issues faster.
+When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report).
 
 > **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
 
@@ -242,7 +242,7 @@ When you are creating a bug report, please [include as many details as possible]
 
 #### How Do I Submit A (Good) Bug Report?
 
-Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). You can find Bittensor's issues [here](https://github.com/opentensor/bittensor/issues). After you've determined which repository ([Bittensor](https://github.com/opentensor/bittensor) or [subtensor](https://github.com/opentensor/subtensor)) your bug is related to, create an issue on that repository and provide the following information by filling in [the template](https://bit.ly/atom-bugfix-pr).
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). You can find Bittensor's issues [here](https://github.com/opentensor/bittensor/issues). After you've determined which repository ([Bittensor](https://github.com/opentensor/bittensor) or [subtensor](https://github.com/opentensor/subtensor)) your bug is related to, create an issue on that repository.
 
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
@@ -275,7 +275,7 @@ Include details about your configuration and environment:
 
 This section guides you through submitting an enhancement suggestion for Bittensor, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
-When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion). Fill in [the template](https://bit.ly/atom-behavior-pr), including the steps that you imagine you would take if the feature you're requesting existed.
+When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion).
 
 #### Before Submitting An Enhancement Suggestion
 


### PR DESCRIPTION
### Identify the Bug

No GH Issue to link.

The problem was that Contributing instruction stipulate using PR templates which do not work and in multiple places refer to Atom project.

### Description of the Change

- Removed mentions of Atom project from Contrib instructions
- Fixed bug fix template
- Fixed default PR template, so now it serves as a template switcher

### Alternate Designs

Throw the whole thing out - but that since PR templates can be helpful I rejected this idea.

### Possible Drawbacks

No drawbacks over the present, broken state.

### Verification Process

I have tested PR creation process on my fork
Example: https://github.com/mjurbanski-reef/bittensor/compare/master...backend-developers-ltd:bittensor:pydantic-v2-walkback?template=bug_fix.md

### Release Notes

- Fixed GitHub PR templates