### PR TITLE
remove tests from package distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,12 @@
 # DEALINGS IN THE SOFTWARE.
 
 from setuptools import setup, find_packages
-from pkg_resources import parse_requirements
 from os import path
 from io import open
 import codecs
 import re
 import os
 import pathlib
-import subprocess
 
 
 def read_requirements(path):
@@ -68,7 +66,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/opentensor/bittensor",
     author="bittensor.com",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,
     author_email="",
     license="MIT",


### PR DESCRIPTION
### Bug

After `pip install bittensor` site-packages include:
```
.venv/lib/python3.11/site-packages/bittensor/*
.venv/lib/python3.11/site-packages/tests/helpers/*
.venv/lib/python3.11/site-packages/tests/integration_tests/*
.venv/lib/python3.11/site-packages/tests/unit_tests/*
```
i.e. `tests` are packaged as top-level package and may very well conflict with other python libs that made the same mistake.

### Description of the Change

- exclude tests from setuptools autodiscovery

### Alternate Designs

None.
Although at some point deprecated setup.py should be dropped in favor of pdm or more modern packaging tooling, the same error could be done with it as well.

### Possible Drawbacks

None I know of.
If someone wants tests, then they need test dependencies as well.

### Verification Process

```
# cleaned previous builds; without this some stuff can still be included even after the fix
python setup.py clean --all
rm -rf build dist *.egg-info

python setup.py bdist_wheel
python setup.py sdist
# examined output if tests/ are still added to .whl and tar

# tested `pip install ./dist/*.whl` and same with sdist to check if installation still works and `btcli` launches
```

### Release Notes

- Removed accidentally included `tests` package from Python dist package (i.e. PyPI package)