### PR TITLE
Fix: CVE-2024-24762 FastAPI

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -7,7 +7,7 @@ colorama==0.4.6
 cryptography==42.0.0
 ddt==1.6.0
 fuzzywuzzy>=0.18.0
-fastapi==0.99.1
+fastapi==0.110.1
 munch==2.5.0
 netaddr
 numpy

--- a/scripts/environments/apple_m1_environment.yml
+++ b/scripts/environments/apple_m1_environment.yml
@@ -149,7 +149,7 @@ dependencies:
       - eth-typing==3.4.0
       - eth-utils==2.2.0
       - exceptiongroup==1.1.2
-      - fastapi==0.99.1
+      - fastapi==0.110.1
       - filelock==3.12.2
       - fqdn==1.5.1
       - frozenlist==1.4.0


### PR DESCRIPTION
# Overview
Bumps fastapi to 0.110.1

https://www.cve.org/CVERecord?id=CVE-2024-24762