### PR TITLE
Fix: CVE-2024-26130 | vulnerability cryptography

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -4,7 +4,7 @@ ansible_vault==2.1.0
 backoff
 black==23.7.0
 colorama==0.4.6
-cryptography==42.0.0
+cryptography==42.0.5
 ddt==1.6.0
 fuzzywuzzy>=0.18.0
 fastapi==0.99.1

--- a/scripts/environments/apple_m1_environment.yml
+++ b/scripts/environments/apple_m1_environment.yml
@@ -136,7 +136,7 @@ dependencies:
       - click==8.1.3
       - colorama==0.4.6
       - commonmark==0.9.1
-      - cryptography==41.0.3
+      - cryptography==42.0.5
       - cytoolz==0.12.2
       - dataclasses-json==0.5.13
       - ddt==1.6.0


### PR DESCRIPTION
## Overview
Bumps `cryptography` to triage https://www.cve.org/CVERecord?id=CVE-2024-26130