### PR TITLE
Tests: Extends test coverage on Registration methods

### DIFF
--- a/bittensor/extrinsics/registration.py
+++ b/bittensor/extrinsics/registration.py
@@ -288,7 +288,7 @@ def burned_register_extrinsic(
                 ":cross_mark: [red]Failed[/red]: error:{}".format(err_msg)
             )
             time.sleep(0.5)
-
+            return False
         # Successful registration, final check for neuron and pubkey
         else:
             bittensor.__console__.print(":satellite: Checking Balance...")
@@ -315,6 +315,7 @@ def burned_register_extrinsic(
                 bittensor.__console__.print(
                     ":cross_mark: [red]Unknown error. Neuron not found.[/red]"
                 )
+                return False
 
 
 class MaxSuccessException(Exception):
@@ -499,8 +500,10 @@ def swap_hotkey_extrinsic(
                 ":cross_mark: [red]Failed[/red]: error:{}".format(err_msg)
             )
             time.sleep(0.5)
+            return False
 
         else:
             bittensor.__console__.print(
                 f"Hotkey {wallet.hotkey} swapped for new hotkey: {new_wallet.hotkey}"
             )
+            return True

--- a/tests/unit_tests/extrinsics/test_registration.py
+++ b/tests/unit_tests/extrinsics/test_registration.py
@@ -335,9 +335,7 @@ def test_register_extrinsic_without_pow(
         )
 
         # Assert
-        assert (
-            result == expected_result
-        ), f"Test failed for test_id: {test_id}"
+        assert result == expected_result, f"Test failed for test_id: {test_id}"
 
 
 @pytest.mark.parametrize(
@@ -404,6 +402,4 @@ def test_register_extrinsic_with_pow(
         )
 
         # Assert
-        assert (
-            result == expected_result
-        ), f"Test failed for test_id: {test_id}"
+        assert result == expected_result, f"Test failed for test_id: {test_id}"

--- a/tests/unit_tests/extrinsics/test_registration.py
+++ b/tests/unit_tests/extrinsics/test_registration.py
@@ -337,7 +337,7 @@ def test_register_extrinsic_without_pow(
         # Assert
         assert (
             result == expected_result
-        ), f"Test {test_id} failed. Expected {expected_result}, got {result}"
+        ), f"Test failed for test_id: {test_id}"
 
 
 @pytest.mark.parametrize(
@@ -406,4 +406,4 @@ def test_register_extrinsic_with_pow(
         # Assert
         assert (
             result == expected_result
-        ), f"Test {test_id} failed. Expected {expected_result}, got {result}"
+        ), f"Test failed for test_id: {test_id}"

--- a/tests/unit_tests/extrinsics/test_registration.py
+++ b/tests/unit_tests/extrinsics/test_registration.py
@@ -6,6 +6,9 @@ from bittensor.utils.registration import POWSolution
 from bittensor.extrinsics.registration import (
     MaxSuccessException,
     MaxAttemptsException,
+    swap_hotkey_extrinsic,
+    burned_register_extrinsic,
+    register_extrinsic,
 )
 
 
@@ -21,7 +24,10 @@ def mock_subtensor():
 @pytest.fixture
 def mock_wallet():
     mock = MagicMock(spec=Wallet)
-    mock.coldkeypub.ss58_address = "mock_address"
+    mock.coldkeypub.ss58_address = "mock_coldkey_address"
+    mock.coldkey = MagicMock()
+    mock.hotkey = MagicMock()
+    mock.hotkey.ss58_address = "fake_ss58_address"
     return mock
 
 
@@ -32,6 +38,15 @@ def mock_pow_solution():
     mock.nonce = 456
     mock.seal = [0, 1, 2, 3]
     mock.is_stale.return_value = False
+    return mock
+
+
+@pytest.fixture
+def mock_new_wallet():
+    mock = MagicMock(spec=Wallet)
+    mock.coldkeypub.ss58_address = "mock_coldkey_address"
+    mock.coldkey = MagicMock()
+    mock.hotkey = MagicMock()
     return mock
 
 
@@ -168,3 +183,235 @@ def test_run_faucet_extrinsic_error_cases(
 
         # Assert
         assert result == expected
+
+
+@pytest.mark.parametrize(
+    "wait_for_inclusion, wait_for_finalization, prompt, swap_success, prompt_response, expected_result, test_id",
+    [
+        # Happy paths
+        (False, True, False, True, None, True, "happy-path-finalization-true"),
+        (True, False, False, True, None, True, "happy-path-inclusion-true"),
+        (True, True, False, True, None, True, "edge-both-waits-true"),
+        # Error paths
+        (False, True, False, False, None, False, "swap_failed"),
+        (False, True, True, True, False, False, "error-prompt-declined"),
+    ],
+)
+def test_swap_hotkey_extrinsic(
+    mock_subtensor,
+    mock_wallet,
+    mock_new_wallet,
+    wait_for_inclusion,
+    wait_for_finalization,
+    prompt,
+    swap_success,
+    prompt_response,
+    expected_result,
+    test_id,
+):
+    # Arrange
+    with patch.object(
+        mock_subtensor,
+        "_do_swap_hotkey",
+        return_value=(swap_success, "Mock error message"),
+    ):
+        with patch(
+            "rich.prompt.Confirm.ask", return_value=prompt_response
+        ) as mock_confirm:
+            # Act
+            result = swap_hotkey_extrinsic(
+                subtensor=mock_subtensor,
+                wallet=mock_wallet,
+                new_wallet=mock_new_wallet,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+                prompt=prompt,
+            )
+
+            # Assert
+            assert result == expected_result, f"Test failed for test_id: {test_id}"
+
+            if prompt:
+                mock_confirm.assert_called_once()
+            else:
+                mock_confirm.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "subnet_exists, neuron_is_null, recycle_success, prompt, prompt_response, is_registered, expected_result, test_id",
+    [
+        # Happy paths
+        (True, False, None, False, None, None, True, "neuron-not-null"),
+        (True, True, True, True, True, True, True, "happy-path-wallet-registered"),
+        # Error paths
+        (False, True, False, False, None, None, False, "subnet-non-existence"),
+        (True, True, True, True, False, None, False, "prompt-declined"),
+        (True, True, False, True, True, False, False, "error-path-recycling-failed"),
+        (True, True, True, True, True, False, False, "error-path-not-registered"),
+    ],
+)
+def test_burned_register_extrinsic(
+    mock_subtensor,
+    mock_wallet,
+    subnet_exists,
+    neuron_is_null,
+    recycle_success,
+    prompt,
+    prompt_response,
+    is_registered,
+    expected_result,
+    test_id,
+):
+    # Arrange
+    with patch.object(
+        mock_subtensor, "subnet_exists", return_value=subnet_exists
+    ), patch.object(
+        mock_subtensor,
+        "get_neuron_for_pubkey_and_subnet",
+        return_value=MagicMock(is_null=neuron_is_null),
+    ), patch.object(
+        mock_subtensor,
+        "_do_burned_register",
+        return_value=(recycle_success, "Mock error message"),
+    ), patch.object(
+        mock_subtensor, "is_hotkey_registered", return_value=is_registered
+    ), patch(
+        "rich.prompt.Confirm.ask", return_value=prompt_response
+    ) as mock_confirm:
+        # Act
+        result = burned_register_extrinsic(
+            subtensor=mock_subtensor, wallet=mock_wallet, netuid=123, prompt=True
+        )
+
+        # Assert
+        assert result == expected_result, f"Test failed for test_id: {test_id}"
+
+        if prompt:
+            mock_confirm.assert_called_once()
+        else:
+            mock_confirm.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "subnet_exists, neuron_is_null, prompt, prompt_response, cuda_available, expected_result, test_id",
+    [
+        (False, True, True, True, True, False, "subnet-does-not-exist"),
+        (True, False, True, True, True, True, "neuron-already-registered"),
+        (True, True, True, False, True, False, "user-declines-prompt"),
+        (True, True, False, None, False, False, "cuda-unavailable"),
+    ],
+)
+def test_register_extrinsic_without_pow(
+    mock_subtensor,
+    mock_wallet,
+    subnet_exists,
+    neuron_is_null,
+    prompt,
+    prompt_response,
+    cuda_available,
+    expected_result,
+    test_id,
+):
+    # Arrange
+    with patch.object(
+        mock_subtensor, "subnet_exists", return_value=subnet_exists
+    ), patch.object(
+        mock_subtensor,
+        "get_neuron_for_pubkey_and_subnet",
+        return_value=MagicMock(is_null=neuron_is_null),
+    ), patch(
+        "rich.prompt.Confirm.ask", return_value=prompt_response
+    ), patch(
+        "torch.cuda.is_available", return_value=cuda_available
+    ):
+        # Act
+        result = register_extrinsic(
+            subtensor=mock_subtensor,
+            wallet=mock_wallet,
+            netuid=123,
+            wait_for_inclusion=True,
+            wait_for_finalization=True,
+            prompt=prompt,
+            max_allowed_attempts=3,
+            output_in_place=True,
+            cuda=True,
+            dev_id=0,
+            tpb=256,
+            num_processes=None,
+            update_interval=None,
+            log_verbose=False,
+        )
+
+        # Assert
+        assert (
+            result == expected_result
+        ), f"Test {test_id} failed. Expected {expected_result}, got {result}"
+
+
+@pytest.mark.parametrize(
+    "pow_success, pow_stale, registration_success, cuda, hotkey_registered, expected_result, test_id",
+    [
+        (True, False, True, False, False, True, "successful-with-valid-pow"),
+        (True, False, True, True, False, True, "successful-with-valid-cuda-pow"),
+        # Pow failed but key was registered already
+        (False, False, False, False, True, True, "hotkey-registered"),
+        # Pow was a success but registration failed with error 'key already registered'
+        (True, False, False, False, False, True, "registration-fail-key-registered"),
+    ],
+)
+def test_register_extrinsic_with_pow(
+    mock_subtensor,
+    mock_wallet,
+    mock_pow_solution,
+    pow_success,
+    pow_stale,
+    registration_success,
+    cuda,
+    hotkey_registered,
+    expected_result,
+    test_id,
+):
+    # Arrange
+    with patch(
+        "bittensor.utils.registration._solve_for_difficulty_fast",
+        return_value=mock_pow_solution if pow_success else None,
+    ), patch(
+        "bittensor.utils.registration._solve_for_difficulty_fast_cuda",
+        return_value=mock_pow_solution if pow_success else None,
+    ), patch.object(
+        mock_subtensor,
+        "_do_pow_register",
+        return_value=(registration_success, "key is already registered"),
+    ), patch(
+        "torch.cuda.is_available", return_value=cuda
+    ):
+        # Act
+        if pow_success:
+            mock_pow_solution.is_stale.return_value = pow_stale
+
+        if not pow_success and hotkey_registered:
+            mock_subtensor.is_hotkey_registered = MagicMock(
+                return_value=hotkey_registered
+            )
+
+        result = register_extrinsic(
+            subtensor=mock_subtensor,
+            wallet=mock_wallet,
+            netuid=123,
+            wait_for_inclusion=True,
+            wait_for_finalization=True,
+            prompt=False,
+            max_allowed_attempts=3,
+            output_in_place=True,
+            cuda=cuda,
+            dev_id=0,
+            tpb=256,
+            num_processes=None,
+            update_interval=None,
+            log_verbose=False,
+        )
+
+        # Assert
+        assert (
+            result == expected_result
+        ), f"Test {test_id} failed. Expected {expected_result}, got {result}"


### PR DESCRIPTION
Extends test coverage in registration methods:

- swap_hotkey_extrinsic
- register_extrinsic_with_pow
- register_extrinsic_without_pow

Enabled tests for:

- run_faucet_extrinsic

Test coverage: 50% to 89%