### PR TITLE
Fix: SNYK-PYTHON-CERTIFI-5805047 | Vulnerability Certifi

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -3,6 +3,7 @@ ansible==6.7.0
 ansible_vault==2.1.0
 backoff
 black==23.7.0
+certifi==2024.2.2
 colorama==0.4.6
 cryptography==42.0.5
 ddt==1.6.0

--- a/scripts/environments/apple_m1_environment.yml
+++ b/scripts/environments/apple_m1_environment.yml
@@ -130,7 +130,7 @@ dependencies:
       - backoff==2.1.0
       - blinker==1.6.2
       - cachetools==4.2.4
-      - certifi==2023.7.22
+      - certifi==2024.2.2
       - cfgv==3.4.0
       - chardet==3.0.4
       - click==8.1.3


### PR DESCRIPTION
Bumps `Certifi` version: https://security.snyk.io/vuln/SNYK-PYTHON-CERTIFI-5805047