### PR TITLE
Add in check for minimum stake for unstaking

### DIFF
--- a/bittensor/extrinsics/unstaking.py
+++ b/bittensor/extrinsics/unstaking.py
@@ -134,6 +134,15 @@ def unstake_extrinsic(
         )
         return False
 
+    # This is a hard-coded value but should not be in the future. It is currently 0.1 TAO but will change to 1
+    # Hopefully soon, the get_nominator_min_required_stake fn will be exposed for rpc call
+    min_req_stake: float = 0.1  # TAO
+    if min_req_stake > unstaking_balance > 0:
+        bittensor.__console__.print(
+            f":cross_mark: [red]Unstaking balance of {unstaking_balance} less than minimum of {min_req_stake} TAO[/red]"
+        )
+        return False
+
     # Ask before moving on.
     if prompt:
         if not Confirm.ask(


### PR DESCRIPTION
Fixes #1828

Adds a check to ensure that the unstaked balance is greater than or equal to the minimum, or 0.