### PR TITLE
Warmfix/change decoder cacheing

### DIFF
--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -92,18 +92,18 @@ KEY_NONCE: Dict[str, int] = {}
 
 T = TypeVar("T")
 
-
 #######
-# Monkey patch in caching the get_decoder_class method
+# Monkey patch in caching the convert_type_string method
 #######
-if hasattr(RuntimeConfiguration, "get_decoder_class"):
-    original_get_decoder_class = RuntimeConfiguration.get_decoder_class
+if hasattr(RuntimeConfiguration, "convert_type_string"):
+    original_convert_type_string = RuntimeConfiguration.convert_type_string
 
     @functools.lru_cache(maxsize=None)
-    def cached_get_decoder_class(self, type_string):
-        return original_get_decoder_class(self, type_string)
+    def convert_type_string(cls, name):
+        return original_convert_type_string(cls, name)
 
-    RuntimeConfiguration.get_decoder_class = cached_get_decoder_class
+    RuntimeConfiguration.convert_type_string = convert_type_string
+
 
 #######
 


### PR DESCRIPTION
Changes the cacheing for the previously implemented `get_decoder_class` in #1834. While it was probably safe to do this, there are a handful of edge case scenarios in the overall configuration we may have overlooked. By changing the cached method `convert_type_string`, we avoid the potential edge cases that may result in serious issues down the line.

When submitting https://github.com/polkascan/py-scale-codec/pull/117, I discovered these. The utilisation of the `type_registry` means that we should not cache this method.

By cacheing `convert_type_string`, we ensure we do not accidentally run into any of these issues, though it does bring our speed improvements down by roughly ⅓ 😞 