### PR TITLE
Add a custom hotkey in the env variable

### DIFF
--- a/bittensor/wallet.py
+++ b/bittensor/wallet.py
@@ -142,7 +142,7 @@ class wallet:
         prefix_str = "" if prefix == None else prefix + "."
         try:
             default_name = os.getenv("BT_WALLET_NAME") or "default"
-            default_hotkey = os.getenv("BT_WALLET_NAME") or "default"
+            default_hotkey = os.getenv("BT_WALLET_HOTKEY") or os.getenv("BT_WALLET_NAME") or "default"
             default_path = os.getenv("BT_WALLET_PATH") or "~/.bittensor/wallets/"
             parser.add_argument(
                 "--no_prompt",


### PR DESCRIPTION
### Description of the Change

I made a local modification to customize the name of the wallet hotkey and thought it would benefit others. I think this change is great because it provides flexibility. I use environment variables for many things, including my custom registrar.

### Possible Drawbacks

There are no drawbacks. The system defaults to the original behavior if the `BT_WALLET_HOTKEY` environment variable is not set, so users will not be affected.

### Verification Process

The change was verified through manual testing.

### Release Notes

- Introduced an environment variable that allows users to specify the hotkey differently from the coldkey.