### PR TITLE
Change: console.error => console.print

### DIFF
--- a/bittensor/extrinsics/registration.py
+++ b/bittensor/extrinsics/registration.py
@@ -112,7 +112,7 @@ def register_extrinsic(
         if cuda:
             if not torch.cuda.is_available():
                 if prompt:
-                    bittensor.__console__.error("CUDA is not available.")
+                    bittensor.__console__.print("CUDA is not available.")
                 return False
             pow_result: Optional[POWSolution] = create_pow(
                 subtensor,
@@ -396,7 +396,7 @@ def run_faucet_extrinsic(
                 if cuda:
                     if not torch.cuda.is_available():
                         if prompt:
-                            bittensor.__console__.error("CUDA is not available.")
+                            bittensor.__console__.print("CUDA is not available.")
                         return False
                     pow_result: Optional[POWSolution] = create_pow(
                         subtensor,


### PR DESCRIPTION
Change `__console__.error` to `__console__.print` as there is no error attribute of Console.

Welcome!

Due to [GitHub limitations](https://github.com/orgs/community/discussions/4620),
please switch to **Preview** for links to render properly.

Please choose the right template for your pull request:

- 🐛 Are you fixing a bug? [Bug fix](?template=bug_fix.md)
- 📈 Are you improving performance? [Performance improvement](?template=performance_improvement.md)
- 💻 Are you changing functionality? [Feature change](?template=feature_change.md)
