### PR TITLE
Updated error message and a test typo.

### DIFF
--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -4415,7 +4415,7 @@ class subtensor:
             result = make_substrate_call_with_retry()
         except scalecodec.exceptions.RemainingScaleBytesNotEmptyException:
             bittensor.logging.error(
-                "Your wallet it legacy formatted, you need to run btcli stake --ammount 0 to reformat it."
+                "Received a corrupted message. This likely points to an error with the network or subnet."
             )
             return Balance(1000)
         return Balance(result.value["data"]["free"])

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -177,7 +177,7 @@ def test_stake_multiple():
         # args, kwargs
         _, kwargs = mock_do_stake.call_args
 
-        assert kwargs["ammount"] == pytest.approx(
+        assert kwargs["amount"] == pytest.approx(
             mock_amount.rao, rel=1e9
         )  # delta of 1.0 TAO
 


### PR DESCRIPTION
Fixes #1867

Fixes an error message that claimed a corrupted message from the server was a legacy wallet. Also fixes a typo in a test.
