### PR TITLE
Drop python 3.8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,9 +279,6 @@ workflows:
   compatibility_checks:
     jobs:
       - check_compatibility:
-          python_version: "3.8"
-          name: check-compatibility-3.8
-      - check_compatibility:
           python_version: "3.9"
           name: check-compatibility-3.9
       - check_compatibility:
@@ -294,7 +291,7 @@ workflows:
   pr-requirements:
     jobs:
       - black:
-          python-version: "3.8.12"
+          python-version: "3.9.13"
       - build-and-test:
           matrix:
             parameters:
@@ -305,7 +302,7 @@ workflows:
       - lint-and-type-check:
           matrix:
             parameters:
-              python-version: ["3.8.12", "3.9.13", "3.10.6"]
+              python-version: ["3.9.13", "3.10.6", "3.11.4"]
           requires:
             - build-and-test
       #- coveralls:

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     include_package_data=True,
     author_email="",
     license="MIT",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=requirements,
     extras_require={
         "dev": extra_requirements_dev,
@@ -85,9 +85,9 @@ setup(
         # Pick your license as you wish
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
### Description of the Change

Drop Python 3.8 to encourage use of newer syntax and use of newest dependency versions.

Argument for this change:
* Python 3.8 is currently only receives security only patches, and hits complete End of Life in <5months https://devguide.python.org/versions/ .
* we can already see python 3.8 support eating away at devleopment time in PRs like #1888, and personally having created a number of PR for bittensor project I have also attest that number of time I had to change my code simply to support python 3.8
* multiple 3rd party packages stopped publishing wheels for python 3.8 already and this trend will only continue.
* seems like most subnets now run on 3.10 or newer. With Python 3.11 delivering a modest performance boost, this trend should be encouraged
* the potentially freed up effort can be redirect to officially support current newest stable Python 3.12 , which has been out for months already but has yet to be declared as officially support by bittensor package

```
pypistats python_minor bittensor -l
┌──────────┬─────────┬───────────┐
│ category │ percent │ downloads │
├──────────┼─────────┼───────────┤
│ 3.10     │  77.00% │    26,669 │
│ 3.11     │   7.27% │     2,519 │
│ 3.9      │   5.12% │     1,773 │
│ 3.12     │   3.67% │     1,272 │
│ 3.8      │   3.57% │     1,237 │
│ null     │   3.19% │     1,106 │
│ 3.13     │   0.07% │        24 │
│ 3.7      │   0.06% │        21 │
│ 3.6      │   0.03% │        11 │
│ 3.5      │   0.00% │         1 │
│ Total    │         │    34,633 │
└──────────┴─────────┴───────────┘

Date range: 2024-04-01 - 2024-04-30
```

### Alternate Designs

Leave Python 3.8 at the cost of CI and, more importantly, development time.

### Possible Drawbacks

The non-actively developed subnets or system will have to update to python 3.9, if they are still stuck 

### Verification Process

CI

### Release Notes

- Drop Python 3.8 support
