### PR TITLE
Add Pre-commit Checker in scripts. Helps reduce CI calls.

### DIFF
--- a/scripts/check_pre_submit.sh
+++ b/scripts/check_pre_submit.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # black checks formating
-echo ">>> Run the pre-submit format check with \`black .\`"
-black .
+echo ">>> Run the pre-submit format check with \`black .\`."
+python3 -m black --exclude '(env|venv|.eggs|.git)' .
 
-echo ">>> Run the pre-submit format check with \`mypy\`"
+echo ">>> Run the pre-submit format check with \`mypy\`."
 
 # mypy checks python versions compatibility
 versions=("3.9" "3.10" "3.11")
@@ -15,4 +15,4 @@ done
 
 # flake8 checks errors count in bittensor folder
 error_count=$(flake8 bittensor/ --count)
-echo ">>> Flake8 found ${error_count} errors"
+echo ">>> Flake8 found ${error_count} errors."

--- a/scripts/check_pre_submit.sh
+++ b/scripts/check_pre_submit.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# black checks formating
+echo ">>> Run the pre-submit format check with \`black .\`"
+black .
+
+echo ">>> Run the pre-submit format check with \`mypy\`"
+
+# mypy checks python versions compatibility
+versions=("3.9" "3.10" "3.11")
+for version in "${versions[@]}"; do
+    echo "Running mypy for Python $version..."
+    mypy --ignore-missing-imports bittensor/ --python-version="$version"
+done
+
+# flake8 checks errors count in bittensor folder
+error_count=$(flake8 bittensor/ --count)
+echo ">>> Flake8 found ${error_count} errors"


### PR DESCRIPTION
Running a pre-commit checker locally will help reduce CI pipeline runs and, consequently, financial costs.