### PR TITLE
fix: sufix runtime error

### DIFF
--- a/bittensor/extrinsics/delegation.py
+++ b/bittensor/extrinsics/delegation.py
@@ -409,7 +409,7 @@ def decrease_take_extrinsic(
                 )
                 bittensor.logging.success(
                     prefix="Decrease Delegate Take",
-                    sufix="<green>Finalized: </green>" + str(success),
+                    suffix="<green>Finalized: </green>" + str(success),
                 )
 
             return success
@@ -419,7 +419,7 @@ def decrease_take_extrinsic(
                 ":cross_mark: [red]Failed[/red]: error:{}".format(e)
             )
             bittensor.logging.warning(
-                prefix="Set weights", sufix="<red>Failed: </red>" + str(e)
+                prefix="Set weights", suffix="<red>Failed: </red>" + str(e)
             )
 
     return False
@@ -469,7 +469,7 @@ def increase_take_extrinsic(
                 )
                 bittensor.logging.success(
                     prefix="Increase Delegate Take",
-                    sufix="<green>Finalized: </green>" + str(success),
+                    suffix="<green>Finalized: </green>" + str(success),
                 )
 
             return success
@@ -479,14 +479,14 @@ def increase_take_extrinsic(
                 ":cross_mark: [red]Failed[/red]: error:{}".format(e)
             )
             bittensor.logging.warning(
-                prefix="Set weights", sufix="<red>Failed: </red>" + str(e)
+                prefix="Set weights", suffix="<red>Failed: </red>" + str(e)
             )
         except TakeError as e:
             bittensor.__console__.print(
                 ":cross_mark: [red]Failed[/red]: error:{}".format(e)
             )
             bittensor.logging.warning(
-                prefix="Set weights", sufix="<red>Failed: </red>" + str(e)
+                prefix="Set weights", suffix="<red>Failed: </red>" + str(e)
             )
 
     return False


### PR DESCRIPTION
Typo in suffix causes runtime crash when performing delegation commands  