### PR TITLE
fix error handling in blacklist processing

### DIFF
--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -1304,9 +1304,9 @@ class AxonMiddleware(BaseHTTPMiddleware):
                     if inspect.iscoroutinefunction(blacklist_fn)
                     else blacklist_fn(synapse)
                 )
-            except:
-                raise Exception("Error processing blacklist function")
-            
+            except Exception as e:
+                blacklisted, reason = True, f"Unhandled exception checking blacklist_fn [{e}], assuming True"
+
             if blacklisted:
                 # We log that the key or identifier is blacklisted.
                 bittensor.logging.trace(f"Blacklisted: {blacklisted}, {reason}")

--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -1297,11 +1297,16 @@ class AxonMiddleware(BaseHTTPMiddleware):
         if blacklist_fn:
             # We execute the blacklist checking function using the synapse instance as input.
             # If the function returns True, it means that the key or identifier is blacklisted.
-            blacklisted, reason = (
-                await blacklist_fn(synapse)
-                if inspect.iscoroutinefunction(blacklist_fn)
-                else blacklist_fn(synapse)
-            )
+            blacklisted, reason = None
+            try:
+                blacklisted, reason = (
+                    await blacklist_fn(synapse)
+                    if inspect.iscoroutinefunction(blacklist_fn)
+                    else blacklist_fn(synapse)
+                )
+            except:
+                raise Exception("Error processing blacklist function")
+            
             if blacklisted:
                 # We log that the key or identifier is blacklisted.
                 bittensor.logging.trace(f"Blacklisted: {blacklisted}, {reason}")


### PR DESCRIPTION
Currently, if attackers are able to cause an error in the blacklist function, as they can with the current subnet example code, this error will propagate downstream to here.

Please see my associated PR in the subnet example repository that addresses the default code having an exploitable line to force an error:

https://github.com/opentensor/bittensor-subnet-template/pull/88
