### PR TITLE
less verbose handled synapse exceptions

### DIFF
--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -942,8 +942,10 @@ def log_and_handle_error(
 ):
     if isinstance(exception, SynapseException):
         synapse = exception.synapse or synapse
-    # Display the traceback for user clarity.
-    bittensor.logging.trace(f"Forward exception: {traceback.format_exc()}")
+
+        bittensor.logging.trace(f"Forward handled exception: {exception}")
+    else:
+        bittensor.logging.trace(f"Forward exception: {traceback.format_exc()}")
 
     if synapse.axon is None:
         synapse.axon = bittensor.TerminalInfo()


### PR DESCRIPTION
The traceback being printed for expected exceptions is making logs less readable, and perhaps more importantly, possibly affective production service performance.

bittensor performs eager formatting of each of the logging message, and in this case, even `traceback.format_exc()` is used, which also has too lookup frames in stack, and open python code files etc to find the lines to print. This happens even if `trace` log level is disabled.

This patch prevents that from happening from explicitly thrown SynapseException subclasses, that is, e.g. `BlacklistedException` preventing additional load and log noise.
The unknown exceptions still have full stacktrace printed as before, as they are quite useful for debugging, but the exceptions thrown on purpose (SynapseException subclasses) don't need it.

This change is inspire by case presented by @cxmplex in https://github.com/opentensor/bittensor-subnet-template/pull/88