### PR TITLE
Part 5 for refactoring bittensor/subtensor.py

### DIFF
--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -3364,7 +3364,7 @@ class subtensor:
         _result = self.query_subtensor("TotalHotkeyStake", block, [ss58_address])
         return (
             None
-            if not getattr(_result, "value", None)
+            if getattr(_result, "value", None) is None
             else Balance.from_rao(_result.value)
         )
 
@@ -3386,7 +3386,7 @@ class subtensor:
         _result = self.query_subtensor("TotalColdkeyStake", block, [ss58_address])
         return (
             None
-            if not getattr(_result, "value", None)
+            if getattr(_result, "value", None) is None
             else Balance.from_rao(_result.value)
         )
 
@@ -3409,7 +3409,7 @@ class subtensor:
         _result = self.query_subtensor("Stake", block, [hotkey_ss58, coldkey_ss58])
         return (
             None
-            if not getattr(_result, "value", None)
+            if getattr(_result, "value", None) is None
             else Balance.from_rao(_result.value)
         )
 
@@ -3448,7 +3448,7 @@ class subtensor:
         _result = self.query_subtensor("Owner", block, [hotkey_ss58])
         return (
             False
-            if not getattr(_result, "value", None)
+            if getattr(_result, "value", None) is None
             else _result.value != "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM"
         )
 
@@ -3470,7 +3470,7 @@ class subtensor:
         _result = self.query_subtensor("Owner", block, [hotkey_ss58])
         return (
             None
-            if not getattr(_result, "value", None)
+            if getattr(_result, "value", None) is None
             or not self.does_hotkey_exist(hotkey_ss58, block)
             else _result.value
         )
@@ -3565,7 +3565,7 @@ class subtensor:
         _result = self.query_subtensor("TotalIssuance", block)
         return (
             None
-            if not getattr(_result, "value", None)
+            if getattr(_result, "value", None) is None
             else Balance.from_rao(_result.value)
         )
 
@@ -3588,7 +3588,7 @@ class subtensor:
         _result = self.query_subtensor("TotalStake", block)
         return (
             None
-            if not getattr(_result, "value", None)
+            if getattr(_result, "value", None) is None
             else Balance.from_rao(_result.value)
         )
 
@@ -3734,7 +3734,7 @@ class subtensor:
         _result = self.query_subtensor("EmissionValues", block, [netuid])
         return (
             None
-            if not getattr(_result, "value", None)
+            if getattr(_result, "value", None) is None
             else Balance.from_rao(_result.value)
         )
 
@@ -3944,7 +3944,7 @@ class subtensor:
         _result = self.query_subtensor("Delegates", block, [hotkey_ss58])
         return (
             None
-            if not getattr(_result, "value", None)
+            if getattr(_result, "value", None) is None
             else U16_NORMALIZED_FLOAT(_result.value)
         )
 

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -3364,7 +3364,7 @@ class subtensor:
         _result = self.query_subtensor("TotalHotkeyStake", block, [ss58_address])
         return (
             None
-            if _result is None or not hasattr(_result, "value")
+            if not getattr(_result, "value", None)
             else Balance.from_rao(_result.value)
         )
 
@@ -3386,7 +3386,7 @@ class subtensor:
         _result = self.query_subtensor("TotalColdkeyStake", block, [ss58_address])
         return (
             None
-            if _result is None or not hasattr(_result, "value")
+            if not getattr(_result, "value", None)
             else Balance.from_rao(_result.value)
         )
 
@@ -3409,7 +3409,7 @@ class subtensor:
         _result = self.query_subtensor("Stake", block, [hotkey_ss58, coldkey_ss58])
         return (
             None
-            if _result is None or not hasattr(_result, "value")
+            if not getattr(_result, "value", None)
             else Balance.from_rao(_result.value)
         )
 
@@ -3448,7 +3448,7 @@ class subtensor:
         _result = self.query_subtensor("Owner", block, [hotkey_ss58])
         return (
             False
-            if not _result or not hasattr(_result, "value")
+            if not getattr(_result, "value", None)
             else _result.value != "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM"
         )
 
@@ -3470,8 +3470,7 @@ class subtensor:
         _result = self.query_subtensor("Owner", block, [hotkey_ss58])
         return (
             None
-            if not _result
-            or not hasattr(_result, "value")
+            if not getattr(_result, "value", None)
             or not self.does_hotkey_exist(hotkey_ss58, block)
             else _result.value
         )
@@ -3508,7 +3507,7 @@ class subtensor:
             )
         return None
 
-    # TODO: check if someone still use this method. bittensor not.
+    # It is used in subtensor in neuron_info, and serving
     def get_prometheus_info(
         self, netuid: int, hotkey_ss58: str, block: Optional[int] = None
     ) -> Optional[PrometheusInfo]:
@@ -3566,7 +3565,7 @@ class subtensor:
         _result = self.query_subtensor("TotalIssuance", block)
         return (
             None
-            if not _result or not hasattr(_result, "value")
+            if not getattr(_result, "value", None)
             else Balance.from_rao(_result.value)
         )
 
@@ -3589,7 +3588,7 @@ class subtensor:
         _result = self.query_subtensor("TotalStake", block)
         return (
             None
-            if _result is None or not hasattr(_result, "value")
+            if not getattr(_result, "value", None)
             else Balance.from_rao(_result.value)
         )
 
@@ -3634,9 +3633,7 @@ class subtensor:
         maintaining efficient and timely transaction processing.
         """
         _result = self.query_subtensor("TxRateLimit", block)
-        return (
-            None if _result is None or not hasattr(_result, "value") else _result.value
-        )
+        return getattr(_result, "value", None)
 
     ######################
     # Network Parameters #
@@ -3657,9 +3654,7 @@ class subtensor:
         enabling a deeper understanding of the network's structure and composition.
         """
         _result = self.query_subtensor("NetworksAdded", block, [netuid])
-        return (
-            False if _result is None or not hasattr(_result, "value") else _result.value
-        )
+        return getattr(_result, "value", False)
 
     def get_all_subnet_netuids(self, block: Optional[int] = None) -> List[int]:
         """
@@ -3695,9 +3690,7 @@ class subtensor:
         the extent of its decentralized infrastructure.
         """
         _result = self.query_subtensor("TotalNetworks", block)
-        return (
-            None if _result is None or not hasattr(_result, "value") else _result.value
-        )
+        return getattr(_result, "value", None)
 
     def get_subnet_modality(
         self, netuid: int, block: Optional[int] = None
@@ -3713,17 +3706,13 @@ class subtensor:
             Optional[int]: The value of the NetworkModality hyperparameter, or ``None`` if the subnetwork does not exist or the parameter is not found.
         """
         _result = self.query_subtensor("NetworkModality", block, [netuid])
-        return (
-            None if _result is None or not hasattr(_result, "value") else _result.value
-        )
+        return getattr(_result, "value", None)
 
     def get_subnet_connection_requirement(
         self, netuid_0: int, netuid_1: int, block: Optional[int] = None
     ) -> Optional[int]:
         _result = self.query_subtensor("NetworkConnect", block, [netuid_0, netuid_1])
-        if not hasattr(_result, "value") or _result is None:
-            return None
-        return _result.value
+        return getattr(_result, "value", None)
 
     def get_emission_value_by_subnet(
         self, netuid: int, block: Optional[int] = None
@@ -3745,7 +3734,7 @@ class subtensor:
         _result = self.query_subtensor("EmissionValues", block, [netuid])
         return (
             None
-            if _result is None or not hasattr(_result, "value")
+            if not getattr(_result, "value", None)
             else Balance.from_rao(_result.value)
         )
 
@@ -3819,9 +3808,8 @@ class subtensor:
             )
 
         json_body = make_substrate_call_with_retry()
-        result = json_body.get("result", None)
 
-        if not result:
+        if not (result := json_body.get("result", None)):
             return []
 
         return SubnetInfo.list_from_vec_u8(result)
@@ -3854,9 +3842,8 @@ class subtensor:
             )
 
         json_body = make_substrate_call_with_retry()
-        result = json_body.get("result", None)
 
-        if not result:
+        if not (result := json_body.get("result", None)):
             return None
 
         return SubnetInfo.from_vec_u8(result)
@@ -3913,7 +3900,7 @@ class subtensor:
         which can be important for decision-making and collaboration within the network.
         """
         _result = self.query_subtensor("SubnetOwner", block, [netuid])
-        return _result.value if _result and hasattr(_result, "value") else None
+        return getattr(_result, "value", None)
 
     ##############
     # Nomination #
@@ -3956,9 +3943,9 @@ class subtensor:
         """
         _result = self.query_subtensor("Delegates", block, [hotkey_ss58])
         return (
-            U16_NORMALIZED_FLOAT(_result.value)
-            if _result and hasattr(_result, "value")
-            else None
+            None
+            if not getattr(_result, "value", None)
+            else U16_NORMALIZED_FLOAT(_result.value)
         )
 
     def get_nominators_for_hotkey(
@@ -4016,9 +4003,8 @@ class subtensor:
 
         encoded_hotkey = ss58_to_vec_u8(hotkey_ss58)
         json_body = make_substrate_call_with_retry(encoded_hotkey)
-        result = json_body.get("result", None)
 
-        if not result:
+        if not (result := json_body.get("result", None)):
             return None
 
         return DelegateInfo.from_vec_u8(result)
@@ -4051,9 +4037,8 @@ class subtensor:
             )
 
         json_body = make_substrate_call_with_retry()
-        result = json_body.get("result", None)
 
-        if not result:
+        if not (result := json_body.get("result", None)):
             return []
 
         return [DelegateInfoLite(**d) for d in result]
@@ -4086,9 +4071,8 @@ class subtensor:
             )
 
         json_body = make_substrate_call_with_retry()
-        result = json_body.get("result", None)
 
-        if not result:
+        if not (result := json_body.get("result", None)):
             return []
 
         return DelegateInfo.list_from_vec_u8(result)
@@ -4125,9 +4109,8 @@ class subtensor:
 
         encoded_coldkey = ss58_to_vec_u8(coldkey_ss58)
         json_body = make_substrate_call_with_retry(encoded_coldkey)
-        result = json_body.get("result", None)
 
-        if not result:
+        if not (result := json_body.get("result", None)):
             return []
 
         return DelegateInfo.delegated_list_from_vec_u8(result)
@@ -4324,7 +4307,7 @@ class subtensor:
         operational and governance activities on a particular subnet.
         """
         _result = self.query_subtensor("Uids", block, [netuid, hotkey_ss58])
-        return _result.value if _result and hasattr(_result, "value") else None
+        return getattr(_result, "value", None)
 
     def get_all_uids_for_hotkey(
         self, hotkey_ss58: str, block: Optional[int] = None
@@ -4438,9 +4421,7 @@ class subtensor:
         subnet, particularly regarding its involvement in network validation and governance.
         """
         _result = self.query_subtensor("ValidatorPermit", block, [netuid, uid])
-        if not hasattr(_result, "value") or _result is None:
-            return None
-        return _result.value
+        return getattr(_result, "value", None)
 
     def neuron_for_wallet(
         self, wallet: "bittensor.wallet", netuid: int, block: Optional[int] = None
@@ -4499,9 +4480,8 @@ class subtensor:
             )
 
         json_body = make_substrate_call_with_retry()
-        result = json_body.get("result", None)
 
-        if not result:
+        if not (result := json_body.get("result", None)):
             # TODO: fix `Access to a protected member _null_neuron of a class` error when chane_data.py refactoring.
             return NeuronInfo._null_neuron()
 
@@ -5136,9 +5116,9 @@ class subtensor:
             return self.substrate.query_map(
                 module="System",
                 storage_function="Account",
-                block_hash=None
-                if block is None
-                else self.substrate.get_block_hash(block),
+                block_hash=(
+                    None if block is None else self.substrate.get_block_hash(block)
+                ),
             )
 
         result = make_substrate_call_with_retry()
@@ -5148,7 +5128,7 @@ class subtensor:
             return_dict[r[0].value] = bal
         return return_dict
 
-    # TODO: check with the teem if this is used anywhere outside. in bittensor no
+    # TODO: check with the team if this is used anywhere externally. not in bittensor
     @staticmethod
     def _null_neuron() -> NeuronInfo:
         neuron = NeuronInfo(

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -2741,10 +2741,11 @@ class subtensor:
         @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
         def make_substrate_call_with_retry() -> Dict[Any, Any]:
             block_hash = None if block is None else self.substrate.get_block_hash(block)
-            params = [method, data]
-            if block_hash:
-                params = params + [block_hash]
-            return self.substrate.rpc_request(method="state_call", params=params)
+
+            return self.substrate.rpc_request(
+                method="state_call",
+                params=[method, data, block_hash] if block_hash else [method, data],
+            )
 
         return make_substrate_call_with_retry()
 
@@ -3101,12 +3102,10 @@ class subtensor:
 
         Args:
             netuid (int): The unique identifier of the subnetwork.
-            block (Optional[int], optional): The block number to retrieve the parameter from. If ``None``, the latest
-                block is used. Default is ``None``.
+            block (Optional[int], optional): The block number to retrieve the parameter from. If ``None``, the latest block is used. Default is ``None``.
 
         Returns:
-            Optional[float]: The value of the ValidatorExcludeQuantile hyperparameter, or ``None`` if the subnetwork
-                does not exist or the parameter is not found.
+            Optional[float]: The value of the ValidatorExcludeQuantile hyperparameter, or ``None`` if the subnetwork does not exist or the parameter is not found.
         """
         call = self._get_hyperparameter(
             param_name="ValidatorExcludeQuantile", netuid=netuid, block=block
@@ -3658,9 +3657,9 @@ class subtensor:
         enabling a deeper understanding of the network's structure and composition.
         """
         _result = self.query_subtensor("NetworksAdded", block, [netuid])
-        if not hasattr(_result, "value") or _result is None:
-            return False
-        return _result.value
+        return (
+            False if _result is None or not hasattr(_result, "value") else _result.value
+        )
 
     def get_all_subnet_netuids(self, block: Optional[int] = None) -> List[int]:
         """
@@ -3675,14 +3674,12 @@ class subtensor:
         This function provides a comprehensive view of the subnets within the Bittensor network,
         offering insights into its diversity and scale.
         """
-        subnet_netuids = []
         result = self.query_map_subtensor("NetworksAdded", block)
-        if result.records:
-            for netuid, exists in result:
-                if exists:
-                    subnet_netuids.append(netuid.value)
-
-        return subnet_netuids
+        return (
+            []
+            if result is None or not hasattr(result, "records")
+            else [netuid.value for netuid, exists in result if exists]
+        )
 
     def get_total_subnets(self, block: Optional[int] = None) -> Optional[int]:
         """
@@ -3698,17 +3695,27 @@ class subtensor:
         the extent of its decentralized infrastructure.
         """
         _result = self.query_subtensor("TotalNetworks", block)
-        if not hasattr(_result, "value") or _result is None:
-            return None
-        return _result.value
+        return (
+            None if _result is None or not hasattr(_result, "value") else _result.value
+        )
 
     def get_subnet_modality(
         self, netuid: int, block: Optional[int] = None
     ) -> Optional[int]:
+        """
+        Returns the NetworkModality hyperparameter for a specific subnetwork.
+
+        Args:
+            netuid (int): The unique identifier of the subnetwork.
+            block (Optional[int], optional): The block number to retrieve the parameter from. If ``None``, the latest block is used. Default is ``None``.
+
+        Returns:
+            Optional[int]: The value of the NetworkModality hyperparameter, or ``None`` if the subnetwork does not exist or the parameter is not found.
+        """
         _result = self.query_subtensor("NetworkModality", block, [netuid])
-        if not hasattr(_result, "value") or _result is None:
-            return None
-        return _result.value
+        return (
+            None if _result is None or not hasattr(_result, "value") else _result.value
+        )
 
     def get_subnet_connection_requirement(
         self, netuid_0: int, netuid_1: int, block: Optional[int] = None
@@ -3736,9 +3743,11 @@ class subtensor:
         reward mechanisms within the subnet.
         """
         _result = self.query_subtensor("EmissionValues", block, [netuid])
-        if not hasattr(_result, "value") or _result is None:
-            return None
-        return Balance.from_rao(_result.value)
+        return (
+            None
+            if _result is None or not hasattr(_result, "value")
+            else Balance.from_rao(_result.value)
+        )
 
     def get_subnet_connection_requirements(
         self, netuid: int, block: Optional[int] = None
@@ -3758,10 +3767,11 @@ class subtensor:
         with specific subnets, ensuring compliance with their connection standards.
         """
         result = self.query_map_subtensor("NetworkConnect", block, [netuid])
-        if result.records:
-            return {str(tuple_[0].value): tuple_[1].value for tuple_ in result.records}
-        else:
-            return {}
+        return (
+            {str(netuid.value): exists.value for netuid, exists in result.records}
+            if result and hasattr(result, "records")
+            else {}
+        )
 
     def get_subnets(self, block: Optional[int] = None) -> List[int]:
         """
@@ -3777,14 +3787,12 @@ class subtensor:
         This function is valuable for understanding the network's structure and the diversity of subnets
         available for neuron participation and collaboration.
         """
-        subnets = []
         result = self.query_map_subtensor("NetworksAdded", block)
-        if result.records:
-            for network in result.records:
-                subnets.append(network[0].value)
-            return subnets
-        else:
-            return []
+        return (
+            [network[0].value for network in result.records]
+            if result and hasattr(result, "records")
+            else []
+        )
 
     def get_all_subnets_info(self, block: Optional[int] = None) -> List[SubnetInfo]:
         """
@@ -3804,18 +3812,16 @@ class subtensor:
         @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
         def make_substrate_call_with_retry():
             block_hash = None if block is None else self.substrate.get_block_hash(block)
-            params = []
-            if block_hash:
-                params = params + [block_hash]
+
             return self.substrate.rpc_request(
                 method="subnetInfo_getSubnetsInfo",  # custom rpc method
-                params=params,
+                params=[block_hash] if block_hash else [],
             )
 
         json_body = make_substrate_call_with_retry()
-        result = json_body["result"]
+        result = json_body.get("result", None)
 
-        if result in (None, []):
+        if not result:
             return []
 
         return SubnetInfo.list_from_vec_u8(result)
@@ -3841,18 +3847,16 @@ class subtensor:
         @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
         def make_substrate_call_with_retry():
             block_hash = None if block is None else self.substrate.get_block_hash(block)
-            params = [netuid]
-            if block_hash:
-                params = params + [block_hash]
+
             return self.substrate.rpc_request(
                 method="subnetInfo_getSubnetInfo",  # custom rpc method
-                params=params,
+                params=[netuid, block_hash] if block_hash else [netuid],
             )
 
         json_body = make_substrate_call_with_retry()
-        result = json_body["result"]
+        result = json_body.get("result", None)
 
-        if result in (None, []):
+        if not result:
             return None
 
         return SubnetInfo.from_vec_u8(result)
@@ -3877,17 +3881,17 @@ class subtensor:
         hex_bytes_result = self.query_runtime_api(
             runtime_api="SubnetInfoRuntimeApi",
             method="get_subnet_hyperparams",
-            params=[netuid],  # type: ignore
+            params=[netuid],
             block=block,
         )
 
         if hex_bytes_result is None:
             return []
 
-        if hex_bytes_result.startswith("0x"):  # type: ignore
-            bytes_result = bytes.fromhex(hex_bytes_result[2:])  # type: ignore
+        if hex_bytes_result.startswith("0x"):
+            bytes_result = bytes.fromhex(hex_bytes_result[2:])
         else:
-            bytes_result = bytes.fromhex(hex_bytes_result)  # type: ignore
+            bytes_result = bytes.fromhex(hex_bytes_result)
 
         return SubnetHyperparameters.from_vec_u8(bytes_result)  # type: ignore
 
@@ -3909,9 +3913,7 @@ class subtensor:
         which can be important for decision-making and collaboration within the network.
         """
         _result = self.query_subtensor("SubnetOwner", block, [netuid])
-        if not hasattr(_result, "value") or _result is None:
-            return None
-        return _result.value
+        return _result.value if _result and hasattr(_result, "value") else None
 
     ##############
     # Nomination #
@@ -3953,9 +3955,11 @@ class subtensor:
         the distribution of rewards among neurons and their nominators.
         """
         _result = self.query_subtensor("Delegates", block, [hotkey_ss58])
-        if not hasattr(_result, "value") or _result is None:
-            return None
-        return U16_NORMALIZED_FLOAT(_result.value)
+        return (
+            U16_NORMALIZED_FLOAT(_result.value)
+            if _result and hasattr(_result, "value")
+            else None
+        )
 
     def get_nominators_for_hotkey(
         self, hotkey_ss58: str, block: Optional[int] = None
@@ -3969,17 +3973,17 @@ class subtensor:
             block (Optional[int], optional): The blockchain block number for the query.
 
         Returns:
-           Union[List[Tuple[str, Balance]], int]: A list of tuples containing each nominator's address and staked amount
-            or 0.
+           Union[List[Tuple[str, Balance]], int]: A list of tuples containing each nominator's address and staked amount or 0.
 
         This function provides insights into the neuron's support network within the Bittensor ecosystem,
         indicating its trust and collaboration relationships.
         """
         result = self.query_map_subtensor("Stake", block, [hotkey_ss58])
-        if result.records:
-            return [(record[0].value, record[1].value) for record in result.records]
-        else:
-            return 0
+        return (
+            [(record[0].value, record[1].value) for record in result.records]
+            if result and hasattr(result, "records")
+            else 0
+        )
 
     def get_delegate_by_hotkey(
         self, hotkey_ss58: str, block: Optional[int] = None
@@ -4002,19 +4006,19 @@ class subtensor:
         @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
         def make_substrate_call_with_retry(encoded_hotkey_: List[int]):
             block_hash = None if block is None else self.substrate.get_block_hash(block)
-            params = [encoded_hotkey_]
-            if block_hash:
-                params = params + [block_hash]
+
             return self.substrate.rpc_request(
                 method="delegateInfo_getDelegate",  # custom rpc method
-                params=params,
+                params=[encoded_hotkey_, block_hash]
+                if block_hash
+                else [encoded_hotkey_],
             )
 
         encoded_hotkey = ss58_to_vec_u8(hotkey_ss58)
         json_body = make_substrate_call_with_retry(encoded_hotkey)
-        result = json_body["result"]
+        result = json_body.get("result", None)
 
-        if result in (None, []):
+        if not result:
             return None
 
         return DelegateInfo.from_vec_u8(result)
@@ -4040,18 +4044,16 @@ class subtensor:
         @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
         def make_substrate_call_with_retry():
             block_hash = None if block is None else self.substrate.get_block_hash(block)
-            params = []
-            if block_hash:
-                params.extend([block_hash])
+
             return self.substrate.rpc_request(
                 method="delegateInfo_getDelegatesLite",  # custom rpc method
-                params=params,
+                params=[block_hash] if block_hash else [],
             )
 
         json_body = make_substrate_call_with_retry()
-        result = json_body["result"]
+        result = json_body.get("result", None)
 
-        if result in (None, []):
+        if not result:
             return []
 
         return [DelegateInfoLite(**d) for d in result]
@@ -4077,18 +4079,16 @@ class subtensor:
         @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
         def make_substrate_call_with_retry():
             block_hash = None if block is None else self.substrate.get_block_hash(block)
-            params = []
-            if block_hash:
-                params.extend([block_hash])
+
             return self.substrate.rpc_request(
                 method="delegateInfo_getDelegates",  # custom rpc method
-                params=params,
+                params=[block_hash] if block_hash else [],
             )
 
         json_body = make_substrate_call_with_retry()
-        result = json_body["result"]
+        result = json_body.get("result", None)
 
-        if result in (None, []):
+        if not result:
             return []
 
         return DelegateInfo.list_from_vec_u8(result)
@@ -4115,19 +4115,19 @@ class subtensor:
         @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
         def make_substrate_call_with_retry(encoded_coldkey_: List[int]):
             block_hash = None if block is None else self.substrate.get_block_hash(block)
-            params = [encoded_coldkey_]
-            if block_hash:
-                params = params + [block_hash]
+
             return self.substrate.rpc_request(
-                method="delegateInfo_getDelegated",  # custom rpc method
-                params=params,
+                method="delegateInfo_getDelegated",
+                params=[block_hash, encoded_coldkey_]
+                if block_hash
+                else [encoded_coldkey_],
             )
 
         encoded_coldkey = ss58_to_vec_u8(coldkey_ss58)
         json_body = make_substrate_call_with_retry(encoded_coldkey)
-        result = json_body["result"]
+        result = json_body.get("result", None)
 
-        if result in (None, []):
+        if not result:
             return []
 
         return DelegateInfo.delegated_list_from_vec_u8(result)
@@ -4213,7 +4213,19 @@ class subtensor:
 
     def get_minimum_required_stake(
         self,
-    ):
+    ) -> Balance:
+        """
+        Returns the minimum required stake for nominators in the Subtensor network.
+
+        This method retries the substrate call up to three times with exponential backoff in case of failures.
+
+        Returns:
+            Balance: The minimum required stake as a Balance object.
+
+        Raises:
+            Exception: If the substrate call fails after the maximum number of retries.
+        """
+
         @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
         def make_substrate_call_with_retry():
             return self.substrate.query(
@@ -4312,9 +4324,7 @@ class subtensor:
         operational and governance activities on a particular subnet.
         """
         _result = self.query_subtensor("Uids", block, [netuid, hotkey_ss58])
-        if not hasattr(_result, "value") or _result is None:
-            return None
-        return _result.value
+        return _result.value if _result and hasattr(_result, "value") else None
 
     def get_all_uids_for_hotkey(
         self, hotkey_ss58: str, block: Optional[int] = None
@@ -4355,7 +4365,11 @@ class subtensor:
             List[int]: A list of netuids where the neuron is a member.
         """
         result = self.query_map_subtensor("IsNetworkMember", block, [hotkey_ss58])
-        return [record[0].value for record in result.records if record[1]]
+        return (
+            [record[0].value for record in result.records if record[1]]
+            if result and hasattr(result, "records")
+            else []
+        )
 
     def get_neuron_for_pubkey_and_subnet(
         self, hotkey_ss58: str, netuid: int, block: Optional[int] = None
@@ -4384,7 +4398,7 @@ class subtensor:
 
     def get_all_neurons_for_pubkey(
         self, hotkey_ss58: str, block: Optional[int] = None
-    ) -> Optional[List[NeuronInfo]]:
+    ) -> List[NeuronInfo]:
         """
         Retrieves information about all neuron instances associated with a given public key (hotkey ``SS58``
         address) across different subnets of the Bittensor network. This function aggregates neuron data
@@ -4402,7 +4416,7 @@ class subtensor:
         """
         netuids = self.get_netuids_for_hotkey(hotkey_ss58, block)
         uids = [self.get_uid_for_hotkey_on_subnet(hotkey_ss58, net) for net in netuids]
-        return [self.neuron_for_uid(uid, net) for uid, net in list(zip(uids, netuids))]  # type: ignore
+        return [self.neuron_for_uid(uid, net) for uid, net in list(zip(uids, netuids))]
 
     def neuron_has_validator_permit(
         self, uid: int, netuid: int, block: Optional[int] = None
@@ -4453,7 +4467,7 @@ class subtensor:
 
     def neuron_for_uid(
         self, uid: Optional[int], netuid: int, block: Optional[int] = None
-    ) -> Optional[NeuronInfo]:
+    ) -> NeuronInfo:
         """
         Retrieves detailed information about a specific neuron identified by its unique identifier (UID)
         within a specified subnet (netuid) of the Bittensor network. This function provides a comprehensive
@@ -4465,12 +4479,13 @@ class subtensor:
             block (Optional[int], optional): The blockchain block number for the query.
 
         Returns:
-            Optional[NeuronInfo]: Detailed information about the neuron if found, ``None`` otherwise.
+            NeuronInfo: Detailed information about the neuron if found, ``None`` otherwise.
 
         This function is crucial for analyzing individual neurons' contributions and status within a specific
         subnet, offering insights into their roles in the network's consensus and validation mechanisms.
         """
         if uid is None:
+            # TODO: fix `Access to a protected member _null_neuron of a class` error when chane_data.py refactoring.
             return NeuronInfo._null_neuron()
 
         @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
@@ -4484,9 +4499,10 @@ class subtensor:
             )
 
         json_body = make_substrate_call_with_retry()
-        result = json_body["result"]
+        result = json_body.get("result", None)
 
-        if result in (None, []):
+        if not result:
+            # TODO: fix `Access to a protected member _null_neuron of a class` error when chane_data.py refactoring.
             return NeuronInfo._null_neuron()
 
         return NeuronInfo.from_vec_u8(result)
@@ -4542,6 +4558,7 @@ class subtensor:
         subnet without the need for comprehensive data retrieval.
         """
         if uid is None:
+            # TODO: fix `Access to a protected member _null_neuron of a class` error when chane_data.py refactoring.
             return NeuronInfoLite._null_neuron()
 
         hex_bytes_result = self.query_runtime_api(
@@ -4555,6 +4572,7 @@ class subtensor:
         )
 
         if hex_bytes_result is None:
+            # TODO: fix `Access to a protected member _null_neuron of a class` error when chane_data.py refactoring.
             return NeuronInfoLite._null_neuron()
 
         if hex_bytes_result.startswith("0x"):
@@ -4786,6 +4804,23 @@ class subtensor:
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
     ) -> bool:
+        """
+        Delegates a specified amount of stake to a delegate's hotkey.
+
+        This method sends a transaction to add stake to a delegate's hotkey and retries the call up to three times
+        with exponential backoff in case of failures.
+
+        Args:
+            wallet (bittensor.wallet): The wallet from which the stake will be delegated.
+            delegate_ss58 (str): The SS58 address of the delegate's hotkey.
+            amount (Balance): The amount of stake to be delegated.
+            wait_for_inclusion (bool, optional): Whether to wait for the transaction to be included in a block. Default is ``True``.
+            wait_for_finalization (bool, optional): Whether to wait for the transaction to be finalized. Default is ``False``.
+
+        Returns:
+            bool: ``True`` if the delegation is successful, ``False`` otherwise.
+        """
+
         @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
         def make_substrate_call_with_retry():
             call = self.substrate.compose_call(
@@ -4820,6 +4855,23 @@ class subtensor:
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
     ) -> bool:
+        """
+        Removes a specified amount of stake from a delegate's hotkey.
+
+        This method sends a transaction to remove stake from a delegate's hotkey and retries the call up to three times
+        with exponential backoff in case of failures.
+
+        Args:
+            wallet (bittensor.wallet): The wallet from which the stake will be removed.
+            delegate_ss58 (str): The SS58 address of the delegate's hotkey.
+            amount (Balance): The amount of stake to be removed.
+            wait_for_inclusion (bool, optional): Whether to wait for the transaction to be included in a block. Default is ``True``.
+            wait_for_finalization (bool, optional): Whether to wait for the transaction to be finalized. Default is ``False``.
+
+        Returns:
+            bool: ``True`` if the undelegation is successful, ``False`` otherwise.
+        """
+
         @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
         def make_substrate_call_with_retry():
             call = self.substrate.compose_call(
@@ -4855,6 +4907,21 @@ class subtensor:
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
     ) -> bool:
+        """
+        Nominates the wallet's hotkey to become a delegate.
+
+        This method sends a transaction to nominate the wallet's hotkey to become a delegate and retries the call up to
+        three times with exponential backoff in case of failures.
+
+        Args:
+            wallet (bittensor.wallet): The wallet whose hotkey will be nominated.
+            wait_for_inclusion (bool, optional): Whether to wait for the transaction to be included in a block. Default is ``True``.
+            wait_for_finalization (bool, optional): Whether to wait for the transaction to be finalized. Default is ``False``.
+
+        Returns:
+            bool: ``True`` if the nomination is successful, ``False`` otherwise.
+        """
+
         @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
         def make_substrate_call_with_retry():
             call = self.substrate.compose_call(
@@ -4889,6 +4956,23 @@ class subtensor:
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
     ) -> bool:
+        """
+        Increases the take rate for a delegate's hotkey.
+
+        This method sends a transaction to increase the take rate for a delegate's hotkey and retries the call up to
+        three times with exponential backoff in case of failures.
+
+        Args:
+            wallet (bittensor.wallet): The wallet from which the transaction will be signed.
+            hotkey_ss58 (str): The SS58 address of the delegate's hotkey.
+            take (int): The new take rate to be set.
+            wait_for_inclusion (bool, optional): Whether to wait for the transaction to be included in a block. Default is ``True``.
+            wait_for_finalization (bool, optional): Whether to wait for the transaction to be finalized. Default is ``False``.
+
+        Returns:
+            bool: ``True`` if the take rate increase is successful, ``False`` otherwise.
+        """
+
         @retry(delay=1, tries=3, backoff=2, max_delay=4)
         def make_substrate_call_with_retry():
             with self.substrate as substrate:
@@ -4927,6 +5011,23 @@ class subtensor:
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
     ) -> bool:
+        """
+        Decreases the take rate for a delegate's hotkey.
+
+        This method sends a transaction to decrease the take rate for a delegate's hotkey and retries the call up to
+        three times with exponential backoff in case of failures.
+
+        Args:
+            wallet (bittensor.wallet): The wallet from which the transaction will be signed.
+            hotkey_ss58 (str): The SS58 address of the delegate's hotkey.
+            take (int): The new take rate to be set.
+            wait_for_inclusion (bool, optional): Whether to wait for the transaction to be included in a block. Default is ``True``.
+            wait_for_finalization (bool, optional): Whether to wait for the transaction to be finalized. Default is ``False``.
+
+        Returns:
+            bool: ``True`` if the take rate decrease is successful, ``False`` otherwise.
+        """
+
         @retry(delay=1, tries=3, backoff=2, max_delay=4)
         def make_substrate_call_with_retry():
             with self.substrate as substrate:
@@ -5035,9 +5136,9 @@ class subtensor:
             return self.substrate.query_map(
                 module="System",
                 storage_function="Account",
-                block_hash=(
-                    None if block is None else self.substrate.get_block_hash(block)
-                ),
+                block_hash=None
+                if block is None
+                else self.substrate.get_block_hash(block),
             )
 
         result = make_substrate_call_with_retry()
@@ -5047,6 +5148,7 @@ class subtensor:
             return_dict[r[0].value] = bal
         return return_dict
 
+    # TODO: check with the teem if this is used anywhere outside. in bittensor no
     @staticmethod
     def _null_neuron() -> NeuronInfo:
         neuron = NeuronInfo(
@@ -5092,8 +5194,15 @@ class subtensor:
         return self.substrate.get_block_hash(block_id=block_id)
 
     def get_error_info_by_index(self, error_index: int) -> Tuple[str, str]:
-        """Returns the error name and description from the Subtensor error list."""
+        """
+        Returns the error name and description from the Subtensor error list.
 
+        Args:
+            error_index (int): The index of the error to retrieve.
+
+        Returns:
+            Tuple[str, str]: A tuple containing the error name and description from substrate metadata. If the error index is not found, returns ("Unknown Error", "") and logs a warning.
+        """
         unknown_error = ("Unknown Error", "")
 
         if not self._subtensor_errors:

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -29,7 +29,6 @@ from bittensor.subtensor import (
     subtensor as Subtensor,
     _logger,
     Balance,
-    U16_NORMALIZED_FLOAT,
 )
 from bittensor import subtensor_module
 
@@ -419,7 +418,7 @@ def test_hyper_parameter_success_calls(
     subtensor._get_hyperparameter.assert_called_once_with(
         block=707, netuid=7, param_name=param_name
     )
-    # if we change the methods logic in the future we have to be make sure tha returned type is correct
+    # if we change the methods logic in the future we have to be make sure the returned type is correct
     assert isinstance(result, expected_result_type)
 
     # Special cases
@@ -456,7 +455,7 @@ def test_blocks_since_last_update_success_calls(subtensor, mocker):
         param_name="LastUpdate", netuid=7
     )
     assert result == 1
-    # if we change the methods logic in the future we have to be make sure tha returned type is correct
+    # if we change the methods logic in the future we have to be make sure the returned type is correct
     assert isinstance(result, int)
 
 
@@ -472,7 +471,7 @@ def test_weights_rate_limit_success_calls(subtensor, mocker):
     subtensor._get_hyperparameter.assert_called_once_with(
         param_name="WeightsSetRateLimit", netuid=7
     )
-    # if we change the methods logic in the future we have to be make sure tha returned type is correct
+    # if we change the methods logic in the future we have to be make sure the returned type is correct
     assert isinstance(result, int)
 
 
@@ -497,7 +496,7 @@ def test_get_total_stake_for_hotkey_success(subtensor, mocker):
         "TotalHotkeyStake", None, [fake_ss58_address]
     )
     spy_balance_from_rao.assert_called_once()
-    # if we change the methods logic in the future we have to be make sure tha returned type is correct
+    # if we change the methods logic in the future we have to be make sure the returned type is correct
     assert isinstance(result, Balance)
 
 
@@ -516,7 +515,7 @@ def test_get_total_stake_for_hotkey_not_result(subtensor, mocker):
         "TotalHotkeyStake", None, [fake_ss58_address]
     )
     spy_balance_from_rao.assert_not_called()
-    # if we change the methods logic in the future we have to be make sure tha returned type is correct
+    # if we change the methods logic in the future we have to be make sure the returned type is correct
     assert isinstance(result, type(None))
 
 
@@ -535,7 +534,7 @@ def test_get_total_stake_for_hotkey_not_value(subtensor, mocker):
         "TotalHotkeyStake", None, [fake_ss58_address]
     )
     spy_balance_from_rao.assert_not_called()
-    # if we change the methods logic in the future we have to be make sure tha returned type is correct
+    # if we change the methods logic in the future we have to be make sure the returned type is correct
     assert isinstance(subtensor.query_subtensor.return_value, object)
     assert not hasattr(result, "value")
 
@@ -556,7 +555,7 @@ def test_get_total_stake_for_coldkey_success(subtensor, mocker):
         "TotalColdkeyStake", None, [fake_ss58_address]
     )
     spy_balance_from_rao.assert_called_once()
-    # if we change the methods logic in the future we have to be make sure tha returned type is correct
+    # if we change the methods logic in the future we have to be make sure the returned type is correct
     assert isinstance(result, Balance)
 
 
@@ -575,7 +574,7 @@ def test_get_total_stake_for_coldkey_not_result(subtensor, mocker):
         "TotalColdkeyStake", None, [fake_ss58_address]
     )
     spy_balance_from_rao.assert_not_called()
-    # if we change the methods logic in the future we have to be make sure tha returned type is correct
+    # if we change the methods logic in the future we have to be make sure the returned type is correct
     assert isinstance(result, type(None))
 
 
@@ -594,7 +593,7 @@ def test_get_total_stake_for_coldkey_not_value(subtensor, mocker):
         "TotalColdkeyStake", None, [fake_ss58_address]
     )
     spy_balance_from_rao.assert_not_called()
-    # if we change the methods logic in the future we have to be make sure tha returned type is correct
+    # if we change the methods logic in the future we have to be make sure the returned type is correct
     assert isinstance(subtensor.query_subtensor.return_value, object)
     assert not hasattr(result, "value")
 
@@ -1212,7 +1211,9 @@ def test_serving_rate_limit_success(mocker, subtensor):
     # Asserts
     assert result is not None
     assert result == int(rate_limit_value)
-    # subtensor._get_hyperparameter.assert_called_once_with("ServingRateLimit", netuid=netuid, block=block)
+    subtensor._get_hyperparameter.assert_called_once_with(
+        param_name="ServingRateLimit", netuid=netuid, block=block
+    )
 
 
 def test_serving_rate_limit_no_data(mocker, subtensor):
@@ -2178,6 +2179,3 @@ def test_get_delegate_take_no_data(mocker, subtensor):
     subtensor.query_subtensor.assert_called_once_with("Delegates", block, [hotkey_ss58])
     spy_u16_normalized_float.assert_not_called()
     assert result is None
-
-
-# `get_delegate_by_hotkey` tests

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -30,7 +30,6 @@ from bittensor.subtensor import (
     _logger,
     Balance,
     U16_NORMALIZED_FLOAT,
-    U64_NORMALIZED_FLOAT,
 )
 from bittensor import subtensor_module
 
@@ -1318,3 +1317,867 @@ def test_tx_rate_limit_no_block(mocker, subtensor):
 ############################
 # Network Parameters tests #
 ############################
+
+
+# `subnet_exists` tests
+def test_subnet_exists_success(mocker, subtensor):
+    """Test subnet_exists returns True when subnet exists."""
+    # Prep
+    netuid = 1
+    block = 123
+    mock_result = mocker.MagicMock(value=True)
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.subnet_exists(netuid, block)
+
+    # Asserts
+    assert result is True
+    subtensor.query_subtensor.assert_called_once_with("NetworksAdded", block, [netuid])
+
+
+def test_subnet_exists_no_data(mocker, subtensor):
+    """Test subnet_exists returns False when no subnet information is found."""
+    # Prep
+    netuid = 1
+    block = 123
+    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+
+    # Call
+    result = subtensor.subnet_exists(netuid, block)
+
+    # Asserts
+    assert result is False
+    subtensor.query_subtensor.assert_called_once_with("NetworksAdded", block, [netuid])
+
+
+def test_subnet_exists_no_value_attribute(mocker, subtensor):
+    """Test subnet_exists returns False when result has no value attribute."""
+    # Prep
+    netuid = 1
+    block = 123
+    mock_result = mocker.MagicMock()
+    del mock_result.value
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.subnet_exists(netuid, block)
+
+    # Asserts
+    assert result is False
+    subtensor.query_subtensor.assert_called_once_with("NetworksAdded", block, [netuid])
+
+
+def test_subnet_exists_no_block(mocker, subtensor):
+    """Test subnet_exists with no block specified."""
+    # Prep
+    netuid = 1
+    mock_result = mocker.MagicMock(value=True)
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.subnet_exists(netuid)
+
+    # Asserts
+    assert result is True
+    subtensor.query_subtensor.assert_called_once_with("NetworksAdded", None, [netuid])
+
+
+# `get_all_subnet_netuids` tests
+def test_get_all_subnet_netuids_success(mocker, subtensor):
+    """Test get_all_subnet_netuids returns correct list when netuid information is found."""
+    # Prep
+    block = 123
+    mock_netuid1 = mocker.MagicMock(value=1)
+    mock_netuid2 = mocker.MagicMock(value=2)
+    mock_result = mocker.MagicMock()
+    mock_result.records = True
+    mock_result.__iter__.return_value = [(mock_netuid1, True), (mock_netuid2, True)]
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_all_subnet_netuids(block)
+
+    # Asserts
+    assert result == [1, 2]
+    subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", block)
+
+
+def test_get_all_subnet_netuids_no_data(mocker, subtensor):
+    """Test get_all_subnet_netuids returns empty list when no netuid information is found."""
+    # Prep
+    block = 123
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=None)
+
+    # Call
+    result = subtensor.get_all_subnet_netuids(block)
+
+    # Asserts
+    assert result == []
+    subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", block)
+
+
+def test_get_all_subnet_netuids_no_records_attribute(mocker, subtensor):
+    """Test get_all_subnet_netuids returns empty list when result has no records attribute."""
+    # Prep
+    block = 123
+    mock_result = mocker.MagicMock()
+    del mock_result.records
+    mock_result.__iter__.return_value = []
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_all_subnet_netuids(block)
+
+    # Asserts
+    assert result == []
+    subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", block)
+
+
+def test_get_all_subnet_netuids_no_block(mocker, subtensor):
+    """Test get_all_subnet_netuids with no block specified."""
+    # Prep
+    mock_netuid1 = mocker.MagicMock(value=1)
+    mock_netuid2 = mocker.MagicMock(value=2)
+    mock_result = mocker.MagicMock()
+    mock_result.records = True
+    mock_result.__iter__.return_value = [(mock_netuid1, True), (mock_netuid2, True)]
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_all_subnet_netuids()
+
+    # Asserts
+    assert result == [1, 2]
+    subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", None)
+
+
+# `get_total_subnets` tests
+def test_get_total_subnets_success(mocker, subtensor):
+    """Test get_total_subnets returns correct data when total subnet information is found."""
+    # Prep
+    block = 123
+    total_subnets_value = 10
+    mock_result = mocker.MagicMock(value=total_subnets_value)
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_total_subnets(block)
+
+    # Asserts
+    assert result is not None
+    assert result == total_subnets_value
+    subtensor.query_subtensor.assert_called_once_with("TotalNetworks", block)
+
+
+def test_get_total_subnets_no_data(mocker, subtensor):
+    """Test get_total_subnets returns None when no total subnet information is found."""
+    # Prep
+    block = 123
+    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+
+    # Call
+    result = subtensor.get_total_subnets(block)
+
+    # Asserts
+    assert result is None
+    subtensor.query_subtensor.assert_called_once_with("TotalNetworks", block)
+
+
+def test_get_total_subnets_no_value_attribute(mocker, subtensor):
+    """Test get_total_subnets returns None when result has no value attribute."""
+    # Prep
+    block = 123
+    mock_result = mocker.MagicMock()
+    del mock_result.value  # Simulating a missing value attribute
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_total_subnets(block)
+
+    # Asserts
+    assert result is None
+    subtensor.query_subtensor.assert_called_once_with("TotalNetworks", block)
+
+
+def test_get_total_subnets_no_block(mocker, subtensor):
+    """Test get_total_subnets with no block specified."""
+    # Prep
+    total_subnets_value = 10
+    mock_result = mocker.MagicMock(value=total_subnets_value)
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_total_subnets()
+
+    # Asserts
+    assert result is not None
+    assert result == total_subnets_value
+    subtensor.query_subtensor.assert_called_once_with("TotalNetworks", None)
+
+
+# `get_subnet_modality` tests
+def test_get_subnet_modality_success(mocker, subtensor):
+    """Test get_subnet_modality returns correct data when modality information is found."""
+    # Prep
+    netuid = 1
+    block = 123
+    modality_value = 42
+    mock_result = mocker.MagicMock(value=modality_value)
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnet_modality(netuid, block)
+
+    # Asserts
+    assert result is not None
+    assert result == modality_value
+    subtensor.query_subtensor.assert_called_once_with(
+        "NetworkModality", block, [netuid]
+    )
+
+
+def test_get_subnet_modality_no_data(mocker, subtensor):
+    """Test get_subnet_modality returns None when no modality information is found."""
+    # Prep
+    netuid = 1
+    block = 123
+    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+
+    # Call
+    result = subtensor.get_subnet_modality(netuid, block)
+
+    # Asserts
+    assert result is None
+    subtensor.query_subtensor.assert_called_once_with(
+        "NetworkModality", block, [netuid]
+    )
+
+
+def test_get_subnet_modality_no_value_attribute(mocker, subtensor):
+    """Test get_subnet_modality returns None when result has no value attribute."""
+    # Prep
+    netuid = 1
+    block = 123
+    mock_result = mocker.MagicMock()
+    del mock_result.value  # Simulating a missing value attribute
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnet_modality(netuid, block)
+
+    # Asserts
+    assert result is None
+    subtensor.query_subtensor.assert_called_once_with(
+        "NetworkModality", block, [netuid]
+    )
+
+
+def test_get_subnet_modality_no_block_specified(mocker, subtensor):
+    """Test get_subnet_modality with no block specified."""
+    # Prep
+    netuid = 1
+    modality_value = 42
+    mock_result = mocker.MagicMock(value=modality_value)
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnet_modality(netuid)
+
+    # Asserts
+    assert result is not None
+    assert result == modality_value
+    subtensor.query_subtensor.assert_called_once_with("NetworkModality", None, [netuid])
+
+
+# `get_emission_value_by_subnet` tests
+def test_get_emission_value_by_subnet_success(mocker, subtensor):
+    """Test get_emission_value_by_subnet returns correct data when emission value is found."""
+    # Prep
+    netuid = 1
+    block = 123
+    emission_value = 1000
+    mock_result = mocker.MagicMock(value=emission_value)
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    spy_balance_from_rao = mocker.spy(Balance, "from_rao")
+
+    # Call
+    result = subtensor.get_emission_value_by_subnet(netuid, block)
+
+    # Asserts
+    assert result is not None
+    subtensor.query_subtensor.assert_called_once_with("EmissionValues", block, [netuid])
+    spy_balance_from_rao.assert_called_once_with(emission_value)
+    assert result == Balance.from_rao(emission_value)
+
+
+def test_get_emission_value_by_subnet_no_data(mocker, subtensor):
+    """Test get_emission_value_by_subnet returns None when no emission value is found."""
+    # Prep
+    netuid = 1
+    block = 123
+    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+    spy_balance_from_rao = mocker.spy(Balance, "from_rao")
+
+    # Call
+    result = subtensor.get_emission_value_by_subnet(netuid, block)
+
+    # Asserts
+    assert result is None
+    subtensor.query_subtensor.assert_called_once_with("EmissionValues", block, [netuid])
+    spy_balance_from_rao.assert_not_called()
+
+
+def test_get_emission_value_by_subnet_no_value_attribute(mocker, subtensor):
+    """Test get_emission_value_by_subnet returns None when result has no value attribute."""
+    # Prep
+    netuid = 1
+    block = 123
+    mock_result = mocker.MagicMock()
+    del mock_result.value  # Simulating a missing value attribute
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    spy_balance_from_rao = mocker.spy(Balance, "from_rao")
+
+    # Call
+    result = subtensor.get_emission_value_by_subnet(netuid, block)
+
+    # Asserts
+    assert result is None
+    subtensor.query_subtensor.assert_called_once_with("EmissionValues", block, [netuid])
+    spy_balance_from_rao.assert_not_called()
+
+
+def test_get_emission_value_by_subnet_no_block_specified(mocker, subtensor):
+    """Test get_emission_value_by_subnet with no block specified."""
+    # Prep
+    netuid = 1
+    emission_value = 1000
+    mock_result = mocker.MagicMock(value=emission_value)
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    spy_balance_from_rao = mocker.spy(Balance, "from_rao")
+
+    # Call
+    result = subtensor.get_emission_value_by_subnet(netuid)
+
+    # Asserts
+    assert result is not None
+    subtensor.query_subtensor.assert_called_once_with("EmissionValues", None, [netuid])
+    spy_balance_from_rao.assert_called_once_with(emission_value)
+    assert result == Balance.from_rao(emission_value)
+
+
+# `get_subnet_connection_requirements` tests
+def test_get_subnet_connection_requirements_success(mocker, subtensor):
+    """Test get_subnet_connection_requirements returns correct data when requirements are found."""
+    # Prep
+    netuid = 1
+    block = 123
+    mock_tuple1 = (mocker.MagicMock(value="requirement1"), mocker.MagicMock(value=10))
+    mock_tuple2 = (mocker.MagicMock(value="requirement2"), mocker.MagicMock(value=20))
+    mock_result = mocker.MagicMock()
+    mock_result.records = [mock_tuple1, mock_tuple2]
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnet_connection_requirements(netuid, block)
+
+    # Asserts
+    assert result == {"requirement1": 10, "requirement2": 20}
+    subtensor.query_map_subtensor.assert_called_once_with(
+        "NetworkConnect", block, [netuid]
+    )
+
+
+def test_get_subnet_connection_requirements_no_data(mocker, subtensor):
+    """Test get_subnet_connection_requirements returns empty dict when no data is found."""
+    # Prep
+    netuid = 1
+    block = 123
+    mock_result = mocker.MagicMock()
+    mock_result.records = []
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnet_connection_requirements(netuid, block)
+
+    # Asserts
+    assert result == {}
+    subtensor.query_map_subtensor.assert_called_once_with(
+        "NetworkConnect", block, [netuid]
+    )
+
+
+def test_get_subnet_connection_requirements_no_records_attribute(mocker, subtensor):
+    """Test get_subnet_connection_requirements returns empty dict when result has no records attribute."""
+    # Prep
+    netuid = 1
+    block = 123
+    mock_result = mocker.MagicMock()
+    del mock_result.records  # Simulating a missing records attribute
+
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnet_connection_requirements(netuid, block)
+
+    # Asserts
+    assert result == {}
+    subtensor.query_map_subtensor.assert_called_once_with(
+        "NetworkConnect", block, [netuid]
+    )
+
+
+def test_get_subnet_connection_requirements_no_block_specified(mocker, subtensor):
+    """Test get_subnet_connection_requirements with no block specified."""
+    # Prep
+    netuid = 1
+    mock_tuple1 = (mocker.MagicMock(value="requirement1"), mocker.MagicMock(value=10))
+    mock_tuple2 = (mocker.MagicMock(value="requirement2"), mocker.MagicMock(value=20))
+    mock_result = mocker.MagicMock()
+    mock_result.records = [mock_tuple1, mock_tuple2]
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnet_connection_requirements(netuid)
+
+    # Asserts
+    assert result == {"requirement1": 10, "requirement2": 20}
+    subtensor.query_map_subtensor.assert_called_once_with(
+        "NetworkConnect", None, [netuid]
+    )
+
+
+# `get_subnets` tests
+def test_get_subnets_success(mocker, subtensor):
+    """Test get_subnets returns correct list when subnet information is found."""
+    # Prep
+    block = 123
+    mock_netuid1 = mocker.MagicMock(value=1)
+    mock_netuid2 = mocker.MagicMock(value=2)
+    mock_result = mocker.MagicMock()
+    mock_result.records = [(mock_netuid1, True), (mock_netuid2, True)]
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnets(block)
+
+    # Asserts
+    assert result == [1, 2]
+    subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", block)
+
+
+def test_get_subnets_no_data(mocker, subtensor):
+    """Test get_subnets returns empty list when no subnet information is found."""
+    # Prep
+    block = 123
+    mock_result = mocker.MagicMock()
+    mock_result.records = []
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnets(block)
+
+    # Asserts
+    assert result == []
+    subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", block)
+
+
+def test_get_subnets_no_records_attribute(mocker, subtensor):
+    """Test get_subnets returns empty list when result has no records attribute."""
+    # Prep
+    block = 123
+    mock_result = mocker.MagicMock()
+    del mock_result.records  # Simulating a missing records attribute
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnets(block)
+
+    # Asserts
+    assert result == []
+    subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", block)
+
+
+def test_get_subnets_no_block_specified(mocker, subtensor):
+    """Test get_subnets with no block specified."""
+    # Prep
+    mock_netuid1 = mocker.MagicMock(value=1)
+    mock_netuid2 = mocker.MagicMock(value=2)
+    mock_result = mocker.MagicMock()
+    mock_result.records = [(mock_netuid1, True), (mock_netuid2, True)]
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnets()
+
+    # Asserts
+    assert result == [1, 2]
+    subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", None)
+
+
+# `get_all_subnets_info` tests
+def test_get_all_subnets_info_success(mocker, subtensor):
+    """Test get_all_subnets_info returns correct data when subnet information is found."""
+    # Prep
+    block = 123
+    subnet_data = [1, 2, 3]  # Mocked response data
+    mocker.patch.object(
+        subtensor.substrate, "get_block_hash", return_value="mock_block_hash"
+    )
+    mock_response = {"result": subnet_data}
+    mocker.patch.object(subtensor.substrate, "rpc_request", return_value=mock_response)
+    mocker.patch.object(
+        subtensor_module.SubnetInfo,
+        "list_from_vec_u8",
+        return_value="list_from_vec_u80",
+    )
+
+    # Call
+    result = subtensor.get_all_subnets_info(block)
+
+    # Asserts
+    subtensor.substrate.get_block_hash.assert_called_once_with(block)
+    subtensor.substrate.rpc_request.assert_called_once_with(
+        method="subnetInfo_getSubnetsInfo", params=["mock_block_hash"]
+    )
+    subtensor_module.SubnetInfo.list_from_vec_u8.assert_called_once_with(subnet_data)
+
+
+@pytest.mark.parametrize("result_", [[], None])
+def test_get_all_subnets_info_no_data(mocker, subtensor, result_):
+    """Test get_all_subnets_info returns empty list when no subnet information is found."""
+    # Prep
+    block = 123
+    mocker.patch.object(
+        subtensor.substrate, "get_block_hash", return_value="mock_block_hash"
+    )
+    mock_response = {"result": result_}
+    mocker.patch.object(subtensor.substrate, "rpc_request", return_value=mock_response)
+    mocker.patch.object(subtensor_module.SubnetInfo, "list_from_vec_u8")
+
+    # Call
+    result = subtensor.get_all_subnets_info(block)
+
+    # Asserts
+    assert result == []
+    subtensor.substrate.get_block_hash.assert_called_once_with(block)
+    subtensor.substrate.rpc_request.assert_called_once_with(
+        method="subnetInfo_getSubnetsInfo", params=["mock_block_hash"]
+    )
+    subtensor_module.SubnetInfo.list_from_vec_u8.assert_not_called()
+
+
+def test_get_all_subnets_info_retry(mocker, subtensor):
+    """Test get_all_subnets_info retries on failure."""
+    # Prep
+    block = 123
+    subnet_data = [1, 2, 3]
+    mocker.patch.object(
+        subtensor.substrate, "get_block_hash", return_value="mock_block_hash"
+    )
+    mock_response = {"result": subnet_data}
+    mock_rpc_request = mocker.patch.object(
+        subtensor.substrate,
+        "rpc_request",
+        side_effect=[Exception, Exception, mock_response],
+    )
+    mocker.patch.object(
+        subtensor_module.SubnetInfo, "list_from_vec_u8", return_value=["some_data"]
+    )
+
+    # Call
+    result = subtensor.get_all_subnets_info(block)
+
+    # Asserts
+    subtensor.substrate.get_block_hash.assert_called_with(block)
+    assert mock_rpc_request.call_count == 3
+    subtensor_module.SubnetInfo.list_from_vec_u8.assert_called_once_with(subnet_data)
+    assert result == ["some_data"]
+
+
+# `get_subnet_info` tests
+def test_get_subnet_info_success(mocker, subtensor):
+    """Test get_subnet_info returns correct data when subnet information is found."""
+    # Prep
+    netuid = 1
+    block = 123
+    subnet_data = [1, 2, 3]
+    mocker.patch.object(
+        subtensor.substrate, "get_block_hash", return_value="mock_block_hash"
+    )
+    mock_response = {"result": subnet_data}
+    mocker.patch.object(subtensor.substrate, "rpc_request", return_value=mock_response)
+    mocker.patch.object(
+        subtensor_module.SubnetInfo, "from_vec_u8", return_value=["from_vec_u8"]
+    )
+
+    # Call
+    result = subtensor.get_subnet_info(netuid, block)
+
+    # Asserts
+    subtensor.substrate.get_block_hash.assert_called_once_with(block)
+    subtensor.substrate.rpc_request.assert_called_once_with(
+        method="subnetInfo_getSubnetInfo", params=[netuid, "mock_block_hash"]
+    )
+    subtensor_module.SubnetInfo.from_vec_u8.assert_called_once_with(subnet_data)
+
+
+@pytest.mark.parametrize("result_", [None, {}])
+def test_get_subnet_info_no_data(mocker, subtensor, result_):
+    """Test get_subnet_info returns None when no subnet information is found."""
+    # Prep
+    netuid = 1
+    block = 123
+    mocker.patch.object(
+        subtensor.substrate, "get_block_hash", return_value="mock_block_hash"
+    )
+    mock_response = {"result": result_}
+    mocker.patch.object(subtensor.substrate, "rpc_request", return_value=mock_response)
+    mocker.patch.object(subtensor_module.SubnetInfo, "from_vec_u8")
+
+    # Call
+    result = subtensor.get_subnet_info(netuid, block)
+
+    # Asserts
+    assert result is None
+    subtensor.substrate.get_block_hash.assert_called_once_with(block)
+    subtensor.substrate.rpc_request.assert_called_once_with(
+        method="subnetInfo_getSubnetInfo", params=[netuid, "mock_block_hash"]
+    )
+    subtensor_module.SubnetInfo.from_vec_u8.assert_not_called()
+
+
+def test_get_subnet_info_retry(mocker, subtensor):
+    """Test get_subnet_info retries on failure."""
+    # Prep
+    netuid = 1
+    block = 123
+    subnet_data = [1, 2, 3]
+    mocker.patch.object(
+        subtensor.substrate, "get_block_hash", return_value="mock_block_hash"
+    )
+    mock_response = {"result": subnet_data}
+    mock_rpc_request = mocker.patch.object(
+        subtensor.substrate,
+        "rpc_request",
+        side_effect=[Exception, Exception, mock_response],
+    )
+    mocker.patch.object(
+        subtensor_module.SubnetInfo, "from_vec_u8", return_value=["from_vec_u8"]
+    )
+
+    # Call
+    result = subtensor.get_subnet_info(netuid, block)
+
+    # Asserts
+    subtensor.substrate.get_block_hash.assert_called_with(block)
+    assert mock_rpc_request.call_count == 3
+    subtensor_module.SubnetInfo.from_vec_u8.assert_called_once_with(subnet_data)
+
+
+# `get_subnet_hyperparameters` tests
+def test_get_subnet_hyperparameters_success(mocker, subtensor):
+    """Test get_subnet_hyperparameters returns correct data when hyperparameters are found."""
+    # Prep
+    netuid = 1
+    block = 123
+    hex_bytes_result = "0x010203"
+    bytes_result = bytes.fromhex(hex_bytes_result[2:])
+    mocker.patch.object(subtensor, "query_runtime_api", return_value=hex_bytes_result)
+    mocker.patch.object(
+        subtensor_module.SubnetHyperparameters,
+        "from_vec_u8",
+        return_value=["from_vec_u8"],
+    )
+
+    # Call
+    result = subtensor.get_subnet_hyperparameters(netuid, block)
+
+    # Asserts
+    subtensor.query_runtime_api.assert_called_once_with(
+        runtime_api="SubnetInfoRuntimeApi",
+        method="get_subnet_hyperparams",
+        params=[netuid],
+        block=block,
+    )
+    subtensor_module.SubnetHyperparameters.from_vec_u8.assert_called_once_with(
+        bytes_result
+    )
+
+
+def test_get_subnet_hyperparameters_no_data(mocker, subtensor):
+    """Test get_subnet_hyperparameters returns empty list when no data is found."""
+    # Prep
+    netuid = 1
+    block = 123
+    mocker.patch.object(subtensor, "query_runtime_api", return_value=None)
+    mocker.patch.object(subtensor_module.SubnetHyperparameters, "from_vec_u8")
+
+    # Call
+    result = subtensor.get_subnet_hyperparameters(netuid, block)
+
+    # Asserts
+    assert result == []
+    subtensor.query_runtime_api.assert_called_once_with(
+        runtime_api="SubnetInfoRuntimeApi",
+        method="get_subnet_hyperparams",
+        params=[netuid],
+        block=block,
+    )
+    subtensor_module.SubnetHyperparameters.from_vec_u8.assert_not_called()
+
+
+def test_get_subnet_hyperparameters_hex_without_prefix(mocker, subtensor):
+    """Test get_subnet_hyperparameters correctly processes hex string without '0x' prefix."""
+    # Prep
+    netuid = 1
+    block = 123
+    hex_bytes_result = "010203"
+    bytes_result = bytes.fromhex(hex_bytes_result)
+    mocker.patch.object(subtensor, "query_runtime_api", return_value=hex_bytes_result)
+    mocker.patch.object(subtensor_module.SubnetHyperparameters, "from_vec_u8")
+
+    # Call
+    result = subtensor.get_subnet_hyperparameters(netuid, block)
+
+    # Asserts
+    subtensor.query_runtime_api.assert_called_once_with(
+        runtime_api="SubnetInfoRuntimeApi",
+        method="get_subnet_hyperparams",
+        params=[netuid],
+        block=block,
+    )
+    subtensor_module.SubnetHyperparameters.from_vec_u8.assert_called_once_with(
+        bytes_result
+    )
+
+
+# `get_subnet_owner` tests
+def test_get_subnet_owner_success(mocker, subtensor):
+    """Test get_subnet_owner returns correct data when owner information is found."""
+    # Prep
+    netuid = 1
+    block = 123
+    owner_address = "5F3sa2TJAWMqDhXG6jhV4N8ko9rXPM6twz9mG9m3rrgq3xiJ"
+    mock_result = mocker.MagicMock(value=owner_address)
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnet_owner(netuid, block)
+
+    # Asserts
+    subtensor.query_subtensor.assert_called_once_with("SubnetOwner", block, [netuid])
+    assert result == owner_address
+
+
+def test_get_subnet_owner_no_data(mocker, subtensor):
+    """Test get_subnet_owner returns None when no owner information is found."""
+    # Prep
+    netuid = 1
+    block = 123
+    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+
+    # Call
+    result = subtensor.get_subnet_owner(netuid, block)
+
+    # Asserts
+    subtensor.query_subtensor.assert_called_once_with("SubnetOwner", block, [netuid])
+    assert result is None
+
+
+def test_get_subnet_owner_no_value_attribute(mocker, subtensor):
+    """Test get_subnet_owner returns None when result has no value attribute."""
+    # Prep
+    netuid = 1
+    block = 123
+    mock_result = mocker.MagicMock()
+    del mock_result.value  # Simulating a missing value attribute
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnet_owner(netuid, block)
+
+    # Asserts
+    subtensor.query_subtensor.assert_called_once_with("SubnetOwner", block, [netuid])
+    assert result is None
+
+
+####################
+# Nomination tests #
+####################
+
+
+# `is_hotkey_delegate` tests
+def test_is_hotkey_delegate_success(mocker, subtensor):
+    """Test is_hotkey_delegate returns True when hotkey is a delegate."""
+    # Prep
+    hotkey_ss58 = "hotkey_ss58"
+    block = 123
+    mock_delegates = [
+        mocker.MagicMock(hotkey_ss58=hotkey_ss58),
+        mocker.MagicMock(hotkey_ss58="hotkey_ss583"),
+    ]
+    mocker.patch.object(subtensor, "get_delegates", return_value=mock_delegates)
+
+    # Call
+    result = subtensor.is_hotkey_delegate(hotkey_ss58, block)
+
+    # Asserts
+    subtensor.get_delegates.assert_called_once_with(block=block)
+    assert result is True
+
+
+def test_is_hotkey_delegate_not_found(mocker, subtensor):
+    """Test is_hotkey_delegate returns False when hotkey is not a delegate."""
+    # Prep
+    hotkey_ss58 = "hotkey_ss58"
+    block = 123
+    mock_delegates = [mocker.MagicMock(hotkey_ss58="hotkey_ss583")]
+    mocker.patch.object(subtensor, "get_delegates", return_value=mock_delegates)
+
+    # Call
+    result = subtensor.is_hotkey_delegate(hotkey_ss58, block)
+
+    # Asserts
+    subtensor.get_delegates.assert_called_once_with(block=block)
+    assert result is False
+
+
+# `get_delegate_take` tests
+def test_get_delegate_take_success(mocker, subtensor):
+    """Test get_delegate_take returns correct data when delegate take is found."""
+    # Prep
+    hotkey_ss58 = "hotkey_ss58"
+    block = 123
+    delegate_take_value = 32768
+    mock_result = mocker.MagicMock(value=delegate_take_value)
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    spy_u16_normalized_float = mocker.spy(subtensor_module, "U16_NORMALIZED_FLOAT")
+
+    # Call
+    subtensor.get_delegate_take(hotkey_ss58, block)
+
+    # Asserts
+    subtensor.query_subtensor.assert_called_once_with("Delegates", block, [hotkey_ss58])
+    spy_u16_normalized_float.assert_called_once_with(delegate_take_value)
+
+
+def test_get_delegate_take_no_data(mocker, subtensor):
+    """Test get_delegate_take returns None when no delegate take is found."""
+    # Prep
+    hotkey_ss58 = "hotkey_ss58"
+    block = 123
+    delegate_take_value = 32768
+    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+    spy_u16_normalized_float = mocker.spy(subtensor_module, "U16_NORMALIZED_FLOAT")
+
+    # Call
+    result = subtensor.get_delegate_take(hotkey_ss58, block)
+
+    # Asserts
+    subtensor.query_subtensor.assert_called_once_with("Delegates", block, [hotkey_ss58])
+    spy_u16_normalized_float.assert_not_called()
+    assert result is None
+
+
+# `get_delegate_by_hotkey` tests


### PR DESCRIPTION
Since the refactoring of this module would turn into a large project, it was decided to divide it into several stages.

This is part 5: current part affects everything in this document except of renaming class `subtensor` according to the CamelCase rule.

Test coverage improved.

Part 1 https://github.com/opentensor/bittensor/pull/1911
Part 2 https://github.com/opentensor/bittensor/pull/1913
Part 3 https://github.com/opentensor/bittensor/pull/1923
Part 4 https://github.com/opentensor/bittensor/pull/1931