### PR TITLE
Part 6 for refactoring bittensor/subtensor.py - class CamelCase

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -93,7 +93,6 @@ __networks__ = ["local", "finney", "test", "archive"]
 __finney_entrypoint__ = "wss://entrypoint-finney.opentensor.ai:443"
 
 __finney_test_entrypoint__ = "wss://test.finney.opentensor.ai:443/"
-__finney_test_entrypoint__ = "wss://test.finney.opentensor.ai:443/"
 
 __archive_entrypoint__ = "wss://archive.chain.opentensor.ai:443/"
 
@@ -234,9 +233,7 @@ from .errors import (
     UnstakeError,
 )
 
-from substrateinterface import Keypair
-
-_ = Keypair
+from substrateinterface import Keypair  # noqa: F401
 from .config import InvalidConfigFile, DefaultConfig, config, T
 from .keyfile import (
     serialized_keypair_to_keyfile_data,

--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -79,7 +79,7 @@ __blocktime__ = 12
 # Pip address for versioning
 __pipaddress__ = "https://pypi.org/pypi/bittensor/json"
 
-# Raw github url for delegates registry file
+# Raw GitHub url for delegates registry file
 __delegates_details_url__: str = "https://raw.githubusercontent.com/opentensor/bittensor-delegates/main/public/delegates.json"
 
 # Substrate ss58_format
@@ -92,6 +92,7 @@ __networks__ = ["local", "finney", "test", "archive"]
 
 __finney_entrypoint__ = "wss://entrypoint-finney.opentensor.ai:443"
 
+__finney_test_entrypoint__ = "wss://test.finney.opentensor.ai:443/"
 __finney_test_entrypoint__ = "wss://test.finney.opentensor.ai:443/"
 
 __archive_entrypoint__ = "wss://archive.chain.opentensor.ai:443/"
@@ -106,7 +107,7 @@ __tao_symbol__: str = chr(0x03C4)
 __rao_symbol__: str = chr(0x03C1)
 
 # Block Explorers map network to explorer url
-## Must all be polkadotjs explorer urls
+# Must all be polkadotjs explorer urls
 __network_explorer_map__ = {
     "opentensor": {
         "local": "https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fentrypoint-finney.opentensor.ai%3A443#/explorer",
@@ -233,7 +234,9 @@ from .errors import (
     UnstakeError,
 )
 
-from substrateinterface import Keypair as Keypair
+from substrateinterface import Keypair
+
+_ = Keypair
 from .config import InvalidConfigFile, DefaultConfig, config, T
 from .keyfile import (
     serialized_keypair_to_keyfile_data,
@@ -287,8 +290,14 @@ from .chain_data import (
     ProposalVoteData,
 )
 
+# Allows avoiding name spacing conflicts and continue access to the `subtensor` module with `subtensor_module` name
 from . import subtensor as subtensor_module
-from .subtensor import subtensor as subtensor
+
+# Double import allows using class `Subtensor` by referencing `bittensor.Subtensor` and `bittensor.subtensor`.
+# This will be available for a while until we remove reference `bittensor.subtensor`
+from .subtensor import Subtensor
+from .subtensor import Subtensor as subtensor
+
 from .cli import cli as cli, COMMANDS as ALL_COMMANDS
 from .btlogging import logging
 from .metagraph import metagraph as metagraph

--- a/bittensor/mock/subtensor_mock.py
+++ b/bittensor/mock/subtensor_mock.py
@@ -35,7 +35,7 @@ from ..chain_data import (
     AxonInfo,
 )
 from ..errors import ChainQueryError
-from ..subtensor import subtensor
+from ..subtensor import Subtensor
 from ..utils import RAOPERTAO, U16_NORMALIZED_FLOAT
 from ..utils.balance import Balance
 from ..utils.registration import POWSolution
@@ -196,7 +196,7 @@ class MockChainState(TypedDict):
     SubtensorModule: MockSubtensorState
 
 
-class MockSubtensor(subtensor):
+class MockSubtensor(Subtensor):
     """
     A Mock Subtensor class for running tests.
     This should mock only methods that make queries to the chain.

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -123,7 +123,7 @@ class ParamWithTypes(TypedDict):
     type: str  # ScaleType string of the parameter.
 
 
-class subtensor:
+class Subtensor:
     """
     The Subtensor class in Bittensor serves as a crucial interface for interacting with the Bittensor blockchain,
     facilitating a range of operations essential for the decentralized machine learning network.
@@ -223,11 +223,11 @@ class subtensor:
             network = None
 
         if config is None:
-            config = subtensor.config()
+            config = Subtensor.config()
         self.config = copy.deepcopy(config)  # type: ignore
 
         # Setup config.subtensor.network and config.subtensor.chain_endpoint
-        self.chain_endpoint, self.network = subtensor.setup_config(network, config)  # type: ignore
+        self.chain_endpoint, self.network = Subtensor.setup_config(network, config)  # type: ignore
 
         if (
             self.network == "finney"
@@ -304,7 +304,7 @@ class subtensor:
                 `subtensor.add_args` method.
         """
         parser = argparse.ArgumentParser()
-        subtensor.add_args(parser)
+        Subtensor.add_args(parser)
         return bittensor.config(parser, args=[])
 
     @classmethod
@@ -439,13 +439,13 @@ class subtensor:
             (
                 evaluated_network,
                 evaluated_endpoint,
-            ) = subtensor.determine_chain_endpoint_and_network(network)
+            ) = Subtensor.determine_chain_endpoint_and_network(network)
         else:
             if config.get("__is_set", {}).get("subtensor.chain_endpoint"):
                 (
                     evaluated_network,
                     evaluated_endpoint,
-                ) = subtensor.determine_chain_endpoint_and_network(
+                ) = Subtensor.determine_chain_endpoint_and_network(
                     config.subtensor.chain_endpoint
                 )
 
@@ -453,7 +453,7 @@ class subtensor:
                 (
                     evaluated_network,
                     evaluated_endpoint,
-                ) = subtensor.determine_chain_endpoint_and_network(
+                ) = Subtensor.determine_chain_endpoint_and_network(
                     config.subtensor.network
                 )
 
@@ -461,7 +461,7 @@ class subtensor:
                 (
                     evaluated_network,
                     evaluated_endpoint,
-                ) = subtensor.determine_chain_endpoint_and_network(
+                ) = Subtensor.determine_chain_endpoint_and_network(
                     config.subtensor.chain_endpoint
                 )
 
@@ -469,7 +469,7 @@ class subtensor:
                 (
                     evaluated_network,
                     evaluated_endpoint,
-                ) = subtensor.determine_chain_endpoint_and_network(
+                ) = Subtensor.determine_chain_endpoint_and_network(
                     config.subtensor.network
                 )
 
@@ -477,7 +477,7 @@ class subtensor:
                 (
                     evaluated_network,
                     evaluated_endpoint,
-                ) = subtensor.determine_chain_endpoint_and_network(
+                ) = Subtensor.determine_chain_endpoint_and_network(
                     bittensor.defaults.subtensor.network
                 )
 
@@ -5216,3 +5216,7 @@ class subtensor:
             )
 
         return name, description
+
+
+# TODO: remove this after fully migrate `bittensor.subtensor` to `bittensor.Subtensor` in `bittensor/__init__.py`
+subtensor = Subtensor

--- a/bittensor/utils/wallet_utils.py
+++ b/bittensor/utils/wallet_utils.py
@@ -8,7 +8,7 @@
 # the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
 # and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-# The above copyright notice and this permission notice shall be included in all copies or large portions of
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
 # the Software.
 
 # THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO

--- a/bittensor/utils/wallet_utils.py
+++ b/bittensor/utils/wallet_utils.py
@@ -8,7 +8,7 @@
 # the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
 # and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# The above copyright notice and this permission notice shall be included in all copies or large portions of
 # the Software.
 
 # THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
@@ -119,18 +119,18 @@ def create_identity_dict(
     Creates a dictionary with structure for identity extrinsic. Must fit within 64 bits.
 
     Args:
-    display (str): String to be converted and stored under 'display'.
-    legal (str): String to be converted and stored under 'legal'.
-    web (str): String to be converted and stored under 'web'.
-    riot (str): String to be converted and stored under 'riot'.
-    email (str): String to be converted and stored under 'email'.
-    pgp_fingerprint (str): String to be converted and stored under 'pgp_fingerprint'.
-    image (str): String to be converted and stored under 'image'.
-    info (str): String to be converted and stored under 'info'.
-    twitter (str): String to be converted and stored under 'twitter'.
+        display (str): String to be converted and stored under 'display'.
+        legal (str): String to be converted and stored under 'legal'.
+        web (str): String to be converted and stored under 'web'.
+        riot (str): String to be converted and stored under 'riot'.
+        email (str): String to be converted and stored under 'email'.
+        pgp_fingerprint (str): String to be converted and stored under 'pgp_fingerprint'.
+        image (str): String to be converted and stored under 'image'.
+        info (str): String to be converted and stored under 'info'.
+        twitter (str): String to be converted and stored under 'twitter'.
 
     Returns:
-    dict: A dictionary with the specified structure and byte string conversions.
+        dict: A dictionary with the specified structure and byte string conversions.
 
     Raises:
     ValueError: If pgp_fingerprint is not exactly 20 bytes long when encoded.

--- a/tests/integration_tests/test_cli_no_network.py
+++ b/tests/integration_tests/test_cli_no_network.py
@@ -1099,7 +1099,7 @@ class TestCLIDefaultsNoNetwork(unittest.TestCase):
         delegate_ss58 = _get_mock_coldkey(0)
         with patch("bittensor.commands.delegates.show_delegates"):
             with patch(
-                "bittensor.subtensor.subtensor.get_delegates",
+                "bittensor.subtensor.Subtensor.get_delegates",
                 return_value=[
                     bittensor.DelegateInfo(
                         hotkey_ss58=delegate_ss58,  # return delegate with mock coldkey
@@ -1186,7 +1186,7 @@ class TestCLIDefaultsNoNetwork(unittest.TestCase):
         delegate_ss58 = _get_mock_coldkey(0)
         with patch("bittensor.commands.delegates.show_delegates"):
             with patch(
-                "bittensor.subtensor.subtensor.get_delegates",
+                "bittensor.subtensor.Subtensor.get_delegates",
                 return_value=[
                     bittensor.DelegateInfo(
                         hotkey_ss58=delegate_ss58,  # return delegate with mock coldkey
@@ -1271,9 +1271,9 @@ class TestCLIDefaultsNoNetwork(unittest.TestCase):
 
         mock_proposal_hash = "mock_proposal_hash"
 
-        with patch("bittensor.subtensor.subtensor.is_senate_member", return_value=True):
+        with patch("bittensor.subtensor.Subtensor.is_senate_member", return_value=True):
             with patch(
-                "bittensor.subtensor.subtensor.get_vote_data",
+                "bittensor.subtensor.Subtensor.get_vote_data",
                 return_value={"index": 1},
             ):
                 # Patch command to exit early

--- a/tests/integration_tests/test_subtensor_integration.py
+++ b/tests/integration_tests/test_subtensor_integration.py
@@ -17,20 +17,17 @@
 # DEALINGS IN THE SOFTWARE.
 
 import random
-import socket
-import os
 import unittest
 from queue import Empty as QueueEmpty
 from unittest.mock import MagicMock, patch
-from types import SimpleNamespace
+
+import pytest
+from substrateinterface import Keypair
 
 import bittensor
 from bittensor.mock import MockSubtensor
-import pytest
 from bittensor.utils.balance import Balance
-from substrateinterface import Keypair
 from tests.helpers import (
-    _get_mock_hotkey,
     _get_mock_coldkey,
     MockConsole,
     _get_mock_keypair,
@@ -463,11 +460,8 @@ class TestSubtensor(unittest.TestCase):
                     mock_set_status.__exit__ = MagicMock(return_value=True)
 
                     # should return True
-                    assert (
-                        self.subtensor.register(
-                            wallet=wallet, netuid=3, num_processes=3, update_interval=5
-                        )
-                        == True
+                    assert self.subtensor.register(
+                        wallet=wallet, netuid=3, num_processes=3, update_interval=5
                     )
 
                 # calls until True and once again before exiting subtensor class

--- a/tests/unit_tests/extrinsics/test_delegation.py
+++ b/tests/unit_tests/extrinsics/test_delegation.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, patch
-from bittensor.subtensor import subtensor as Subtensor
+from bittensor.subtensor import Subtensor
 from bittensor.wallet import wallet as Wallet
 from bittensor.utils.balance import Balance
 from bittensor.extrinsics.delegation import (

--- a/tests/unit_tests/extrinsics/test_network.py
+++ b/tests/unit_tests/extrinsics/test_network.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, patch
-from bittensor.subtensor import subtensor as Subtensor
+from bittensor.subtensor import Subtensor
 from bittensor.wallet import wallet as Wallet
 from bittensor.extrinsics.network import (
     set_hyperparameter_extrinsic,

--- a/tests/unit_tests/extrinsics/test_prometheus.py
+++ b/tests/unit_tests/extrinsics/test_prometheus.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 import bittensor
-from bittensor.subtensor import subtensor as Subtensor
+from bittensor.subtensor import Subtensor
 from bittensor.wallet import wallet as Wallet
 from bittensor.extrinsics.prometheus import prometheus_extrinsic
 

--- a/tests/unit_tests/extrinsics/test_registration.py
+++ b/tests/unit_tests/extrinsics/test_registration.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, patch
-from bittensor.subtensor import subtensor as Subtensor
+from bittensor.subtensor import Subtensor
 from bittensor.wallet import wallet as Wallet
 from bittensor.utils.registration import POWSolution
 from bittensor.extrinsics.registration import (

--- a/tests/unit_tests/extrinsics/test_root.py
+++ b/tests/unit_tests/extrinsics/test_root.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, patch
-from bittensor.subtensor import subtensor as Subtensor
+from bittensor.subtensor import Subtensor
 from bittensor.extrinsics.root import (
     root_register_extrinsic,
     set_root_weights_extrinsic,

--- a/tests/unit_tests/extrinsics/test_serving.py
+++ b/tests/unit_tests/extrinsics/test_serving.py
@@ -1,7 +1,7 @@
 import pytest
 
 from unittest.mock import MagicMock, patch
-from bittensor.subtensor import subtensor as Subtensor
+from bittensor.subtensor import Subtensor
 from bittensor.wallet import wallet as Wallet
 from bittensor.axon import axon as Axon
 from bittensor.extrinsics.serving import (

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -26,7 +26,7 @@ import pytest
 # Application
 import bittensor
 from bittensor.subtensor import (
-    subtensor as Subtensor,
+    Subtensor,
     _logger,
     Balance,
     U16_NORMALIZED_FLOAT,


### PR DESCRIPTION
Since the refactoring of this module would turn into a large project, it was decided to divide it into several stages.

This is part 6: Renaming class 1 to comply with PEP8 and avoid namespace conflict. Refactor all references to the changed name.

Part 1 https://github.com/opentensor/bittensor/pull/1911
Part 2 https://github.com/opentensor/bittensor/pull/1913
Part 3 https://github.com/opentensor/bittensor/pull/1923
Part 4 https://github.com/opentensor/bittensor/pull/1931
Part 5 https://github.com/opentensor/bittensor/pull/1934