### PR TITLE
Chore: Updated dev requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
+aioresponses==0.7.6
 pytest==7.2.0
 pytest-mock==3.12.0
 pytest-split==0.8.0

--- a/tests/unit_tests/test_synapse.py
+++ b/tests/unit_tests/test_synapse.py
@@ -203,7 +203,7 @@ def test_required_fields_override():
 
 def test_default_instance_fields_dict_consistency():
     synapse_instance = bittensor.Synapse()
-    assert synapse_instance.dict() == {
+    assert synapse_instance.model_dump() == {
         "name": "Synapse",
         "timeout": 12.0,
         "total_size": 0,


### PR DESCRIPTION
- Adds `aioresponses` used in `conftest`
- Replaces .dict () based on https://github.com/opentensor/bittensor/pull/1945