### PR TITLE
Contrib: Compatibility for releasing through macOS

### DIFF
--- a/contrib/RELEASE_GUIDELINES.md
+++ b/contrib/RELEASE_GUIDELINES.md
@@ -11,6 +11,12 @@ The release manager will need the right permissions for:
 
 If you are new in this role, ask for the proper setup you need to run this process manually.
 
+## Pre-requisites for macOS
+Releasing through macOS will require these additional packages:
+  - jq `brew install jq`
+  - gnu-sed `brew install gnu-sed`
+Use `add_notes_changelog_macos.sh` instead of `add_notes_changelog.sh` when using macOS
+
 ## Process of release
 
 1. Create a branch called `release/VERSION`, having VERSION with the version to release.
@@ -19,6 +25,7 @@ If you are new in this role, ask for the proper setup you need to run this proce
   1. Update the version executing:`./scripts/release/versioning.sh --update UPDATE_TYPE`
     1. **UPDATE_TYPE** could be *major*, *minor* or *patch*.
   1. Add release notes to CHANGELOG executing: `./scripts/release/add_notes_changelog.sh -A -V NEW_VERSION -P PREVIOUS_TAG -T GH_ACCESS_TOKEN`
+  For macOS, execute: `./scripts/release/add_notes_changelog_macos.sh -A -V NEW_VERSION -P PREVIOUS_TAG -T GH_ACCESS_TOKEN`
     1. **NEW_VERSION**: e.g.: 3.6.4
     1. **PREVIOUS_TAG**: e.g.: v3.6.3
     1. **GH_ACCESS_TOKEN**: A github [personal access token](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) you need. 

--- a/scripts/release/add_notes_changelog_macos.sh
+++ b/scripts/release/add_notes_changelog_macos.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+####
+# Utils
+####
+source ${BASH_SOURCE%/*}/utils.sh
+source ${BASH_SOURCE%/*}/github_utils.sh
+###
+
+# 1. Get options
+
+## Defaults
+APPLY="false"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -A|--apply)
+      APPLY="true"
+      shift # past argument
+      ;;
+    -P|--previous-version-tag)
+      PREV_TAG_VERSION="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -V|--version)
+      VERSION="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -T|--github-token)
+      GITHUB_TOKEN="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -B|--release-branch)
+      RELEASE_BRANCH="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1") # save positional arg
+      shift # past argument
+      ;;
+  esac
+done
+
+if [[ -z $GITHUB_TOKEN && $APPLY == "true" ]]; then
+  echo_error "Github token required (-T, --github-token)"
+  exit 1
+fi
+
+if [[ -z $PREV_TAG_VERSION ]]; then
+  echo_error "Previous version tag required (-P, --previous-version-tag)"
+  exit 1
+fi
+
+if [[ -z $VERSION ]]; then
+  echo_error "Version to release required (-V, --version)"
+  exit 1
+fi
+
+if [[ -z $RELEASE_BRANCH ]]; then
+  echo_warning "Release branch not specified with (-B, --release-branch) assuming: release/$VERSION"
+  RELEASE_BRANCH=release/$VERSION
+fi
+
+DATE=$(date +"%Y-%m-%d")
+RELEASE_NAME="$VERSION / $DATE"
+TAG_NAME=v$VERSION
+PREV_TAG_NAME=v$PREV_TAG_VERSION
+
+# 2.2. Generate release notes
+if [[ $APPLY == "true" ]]; then
+  echo_info "Generating Github release notes"
+  RESPONSE=$(generate_github_release_notes_for_changelog $GITHUB_TOKEN)
+  DESCRIPTION=$(echo $RESPONSE | jq '.body' | tail -1 | gsed "s/\"//g")
+
+  if [ $(echo $RESPONSE | jq '.body' | wc -l) -eq 1 ]; then
+    if [ $(echo $RESPONSE | jq '.' | grep 'documentation_url' | wc -l) -gt 0 ]; then
+      echo_error "Something went wrong generating Github release notes"
+      echo $RESPONSE | jq --slurp '.[0]'
+      exit 1
+    fi
+  
+    if [ $(echo $RESPONSE | jq '.type' | grep 'error' | wc -l) -gt 0 ]; then
+      echo_error "Something went wrong generating Github release notes"
+      echo $RESPONSE | jq --slurp '.[1]'
+      exit 1
+    fi
+  fi
+else
+  echo_warning "Dry run execution. Not generating Github release notes"
+fi
+
+if [[ $APPLY == "true" ]]; then
+  echo_info "Adding release notes to CHANGELOG.md"
+  gsed -i "2 i\\\n## $RELEASE_NAME" CHANGELOG.md
+  gsed -i "4 i\\\n$DESCRIPTION\n" CHANGELOG.md
+else
+  echo_warning "Dry run execution. Not adding release notes to CHANGELOG.md"
+fi


### PR DESCRIPTION
- Updates additional requirements for releases through macOS
- Adds script for release-notes for macOS systems

**WIP**: Checking why json parsing is failing when system tries to generate an official release (not tags)