### PR TITLE
Fix IP/Port packing issue

### DIFF
--- a/bittensor/chain_data.py
+++ b/bittensor/chain_data.py
@@ -255,10 +255,15 @@ class AxonInfo:
     @classmethod
     def from_neuron_info(cls, neuron_info: dict) -> "AxonInfo":
         """Converts a dictionary to an axon_info object."""
+
+        ip, port = net.unpack_encoded_ip_port(
+            neuron_info["axon_info"]["ip"], neuron_info["axon_info"]["port"]
+        )
+
         return cls(
             version=neuron_info["axon_info"]["version"],
-            ip=net.int_to_ip(int(neuron_info["axon_info"]["ip"])),
-            port=neuron_info["axon_info"]["port"],
+            ip=ip,
+            port=port,
             ip_type=neuron_info["axon_info"]["ip_type"],
             hotkey=neuron_info["hotkey"],
             coldkey=neuron_info["coldkey"],

--- a/bittensor/utils/networking.py
+++ b/bittensor/utils/networking.py
@@ -61,6 +61,26 @@ def ip_to_int(str_val: str) -> int:
     return int(netaddr.IPAddress(str_val))
 
 
+def unpack_encoded_ip_port(ip_str: str, port: int) -> tuple:
+    r"""Unpacks an encoded IP and port if they are encoded together.
+    Args:
+        ip_str (:type:`str`, `required`):
+            The encoded IP address string.
+        port (:type:`int`, `required`):
+            The port number.
+    Returns:
+        tuple: A tuple containing the IP address string and port number.
+    Raises:
+        netaddr.core.AddrFormatError (Exception):
+            Raised when the passed IP string is not a valid IP int value.
+    """
+    if port == 0:
+        port = ip_str & 0xFFFF
+        ip = ip_str >> 16
+        return int_to_ip(ip), port
+    return int_to_ip(ip_str), port
+
+
 def ip_version(str_val: str) -> int:
     r"""Returns the ip version (IPV4 or IPV6).
     arg:

--- a/tests/unit_tests/utils/test_networking.py
+++ b/tests/unit_tests/utils/test_networking.py
@@ -25,6 +25,14 @@ def test_int_to_ip_range():
         )
 
 
+def test_packed_ip_port_with_port_0():
+    """Test packing and unpacking IP and port."""
+    assert utils.networking.unpack_encoded_ip_port(184046647580618, 0) == (
+        "167.99.179.13",
+        6090,
+    )
+
+
 def test_int_to_ip4_max():
     """Test converting integer to maximum IPv4 address."""
     assert utils.networking.int_to_ip(4294967295) == "255.255.255.255"


### PR DESCRIPTION
### Bug

<!-- Link to the issue describing the bug that you're fixing. -->

### Description of the Change

The IP address and port are packed together from subtensor. When this happens we see as port being 0 on our end and need to extract the port from axon info, after extraction, the ip looks to be correct again. 

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions?
Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes
Credit to [dgagn](https://github.com/dgagn) 
with PR
https://github.com/opentensor/bittensor/pull/1962
