### PR TITLE
Revert Axon IP decoding changes

### DIFF
--- a/bittensor/chain_data.py
+++ b/bittensor/chain_data.py
@@ -283,13 +283,10 @@ class AxonInfo:
         Returns:
             instance (AxonInfo): An instance of AxonInfo created from the dictionary.
         """
-        ip, port = net.unpack_encoded_ip_port(
-            neuron_info["axon_info"]["ip"], neuron_info["axon_info"]["port"]
-        )
         return cls(
             version=neuron_info["axon_info"]["version"],
-            ip=ip,
-            port=port,
+            ip=net.int_to_ip(int(neuron_info["axon_info"]["ip"])),
+            port=neuron_info["axon_info"]["port"],
             ip_type=neuron_info["axon_info"]["ip_type"],
             hotkey=neuron_info["hotkey"],
             coldkey=neuron_info["coldkey"],

--- a/bittensor/utils/networking.py
+++ b/bittensor/utils/networking.py
@@ -43,28 +43,6 @@ def int_to_ip(int_val: int) -> str:
     return str(netaddr.IPAddress(int_val))
 
 
-def unpack_encoded_ip_port(ip_str: str, port: int) -> tuple:
-    r"""Unpacks an encoded IP and port if they are encoded together.
-    Args:
-        ip_str (:type:`str`, `required`):
-            The encoded IP address string.
-        port (:type:`int`, `required`):
-            The port number.
-
-    Returns:
-        tuple: A tuple containing the IP address string and port number.
-
-    Raises:
-        netaddr.core.AddrFormatError (Exception):
-            Raised when the passed IP string is not a valid IP int value.
-    """
-    if ip_str < (1 << 128) + (1 << 16) and port == 0:
-        port = ip_str & 0xFFFF
-        ip = ip_str >> 16
-        return int_to_ip(ip), port
-    return int_to_ip(ip_str), port
-
-
 def ip_to_int(str_val: str) -> int:
     r"""Maps an ip-string to a unique integer.
     arg:

--- a/tests/unit_tests/utils/test_networking.py
+++ b/tests/unit_tests/utils/test_networking.py
@@ -25,14 +25,6 @@ def test_int_to_ip_range():
         )
 
 
-def test_packed_ip_port():
-    """Test packing and unpacking IP and port."""
-    assert utils.networking.unpack_encoded_ip_port(184046647580618, 0) == (
-        "167.99.179.13",
-        6090,
-    )
-
-
 def test_int_to_ip4_max():
     """Test converting integer to maximum IPv4 address."""
     assert utils.networking.int_to_ip(4294967295) == "255.255.255.255"


### PR DESCRIPTION
Reverts #1962 (d88a743) in favour of opentensor/subtensor/pull/512

See opentensor/subtensor/pull/512 for context

Depends on: opentensor/subtensor/pull/512