### PR TITLE
fix __version_as_int__ for >10 minor/patch release vers (resolves #1982)

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -42,12 +42,15 @@ if (NEST_ASYNCIO_ENV := os.getenv("NEST_ASYNCIO")) in ("1", None):
 # Bittensor code and protocol version.
 __version__ = "7.0.0"
 
-version_split = __version__.split(".")
-__version_as_int__: int = (
-    (100 * int(version_split[0]))
-    + (10 * int(version_split[1]))
-    + (1 * int(version_split[2]))
+_version_split = __version__.split(".")
+__version_info__ = tuple(map(int, _version_split))
+_version_int_base = 1000
+assert max(__version_info__) < _version_int_base
+
+__version_as_int__: int = sum(
+    e * (_version_int_base**i) for i, e in enumerate(reversed(__version_info__))
 )
+assert __version_as_int__ < 2**31  # fits in int32
 __new_signature_version__ = 360
 
 # Rich console.
@@ -56,6 +59,16 @@ __use_console__ = True
 
 # Remove overdue locals in debug training.
 install(show_locals=False)
+
+
+def __getattr__(name):
+    if name == "version_split":
+        warnings.warn(
+            "version_split is deprecated and will be removed in future versions. Use __version__ instead.",
+            DeprecationWarning,
+        )
+        return _version_split
+    raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
 def turn_console_off():

--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -43,7 +43,7 @@ if (NEST_ASYNCIO_ENV := os.getenv("NEST_ASYNCIO")) in ("1", None):
 __version__ = "7.0.0"
 
 _version_split = __version__.split(".")
-__version_info__ = tuple(map(int, _version_split))
+__version_info__ = tuple(int(part) for part in _version_split)
 _version_int_base = 1000
 assert max(__version_info__) < _version_int_base
 


### PR DESCRIPTION
### Bug

#1982 

### Description of the Change

Uses 1000 base, to fix `6.12.2` `__version_as_int__` being larger than one from release `7.2.1` .

### Alternate Designs

already discussed in #1982 

### Possible Drawbacks

If for some reason int16 was used to store the version number it could be a problem, but glance at subtensor code seems to indicate, int32 was used there.

### Verification Process

Manual + added simple asserts to prevent similar problems from ever occurring in the future (it will basically immediately explode on import)

### Release Notes

- Fix `bittensor.__version_as_int__` from release 6.12.x being higher number than  one from `7.x` line by encoding it using 1000 base instead of 10.
- Deprecated `bittensor.version_split` - use `bittensor.__version__`, `bittensor.__version_info__` or `bittensor.__version_as_int__` instead
