### PR TITLE
Fix for `circular import` related with `btlogging` in use `bittensor.btlogging.on()`

### DIFF
--- a/bin/btcli
+++ b/bin/btcli
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
+import sys
+
+import shtab
 import websocket
 
-import sys
-import shtab
+import bittensor
 from bittensor import cli as btcli
-from bittensor import logging as bt_logging
 
 
 def main():
@@ -23,9 +24,9 @@ def main():
     except KeyboardInterrupt:
         print('KeyboardInterrupt')
     except RuntimeError as e:
-        bt_logging.error(f'RuntimeError: {e}')
+        bittensor.logging.error(f'RuntimeError: {e}')
     except websocket.WebSocketConnectionClosedException as e:
-        bt_logging.error(f'Subtensor related error. WebSocketConnectionClosedException: {e}')
+        bittensor.logging.error(f'Subtensor related error. WebSocketConnectionClosedException: {e}')
 
 
 if __name__ == '__main__':

--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -282,6 +282,9 @@ from .chain_data import (
     ProposalVoteData,
 )
 
+# should be imported before `subtensor_module`
+from .btlogging import logging
+
 # Allows avoiding name spacing conflicts and continue access to the `subtensor` module with `subtensor_module` name
 from . import subtensor as subtensor_module
 
@@ -291,7 +294,6 @@ from .subtensor import Subtensor
 from .subtensor import Subtensor as subtensor
 
 from .cli import cli as cli, COMMANDS as ALL_COMMANDS
-from .btlogging import logging
 from .metagraph import metagraph as metagraph
 from .threadpool import PriorityThreadPoolExecutor as PriorityThreadPoolExecutor
 

--- a/bittensor/extrinsics/root.py
+++ b/bittensor/extrinsics/root.py
@@ -19,16 +19,15 @@
 import bittensor
 
 import time
-import logging
 import numpy as np
 from numpy.typing import NDArray
 from rich.prompt import Confirm
 from typing import Union, List
 import bittensor.utils.weight_utils as weight_utils
-from bittensor.btlogging.defines import BITTENSOR_LOGGER_NAME
 from bittensor.utils.registration import torch, legacy_torch_api_compat
 
-logger = logging.getLogger(BITTENSOR_LOGGER_NAME)
+
+bittensor.logging.on()
 
 
 def root_register_extrinsic(
@@ -77,7 +76,7 @@ def root_register_extrinsic(
             wait_for_finalization=wait_for_finalization,
         )
 
-        if success != True or success == False:
+        if success is not True or success is False:
             bittensor.__console__.print(
                 ":cross_mark: [red]Failed[/red]: error:{}".format(err_msg)
             )
@@ -144,7 +143,6 @@ def set_root_weights_extrinsic(
 
     # Get non zero values.
     non_zero_weight_idx = np.argwhere(weights > 0).squeeze(axis=1)
-    non_zero_weight_uids = netuids[non_zero_weight_idx]
     non_zero_weights = weights[non_zero_weight_idx]
     if non_zero_weights.size < min_allowed_weights:
         raise ValueError(

--- a/bittensor/extrinsics/set_weights.py
+++ b/bittensor/extrinsics/set_weights.py
@@ -16,18 +16,18 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import bittensor
+from typing import Union, Tuple
 
-import logging
 import numpy as np
 from numpy.typing import NDArray
 from rich.prompt import Confirm
-from typing import Union, Tuple
+
+import bittensor
 import bittensor.utils.weight_utils as weight_utils
-from bittensor.btlogging.defines import BITTENSOR_LOGGER_NAME
 from bittensor.utils.registration import torch, use_torch
 
-logger = logging.getLogger(BITTENSOR_LOGGER_NAME)
+
+bittensor.logging.on()
 
 
 def set_weights_extrinsic(
@@ -109,7 +109,7 @@ def set_weights_extrinsic(
             if not wait_for_finalization and not wait_for_inclusion:
                 return True, "Not waiting for finalization or inclusion."
 
-            if success == True:
+            if success is True:
                 bittensor.__console__.print(
                     ":white_heavy_check_mark: [green]Finalized[/green]"
                 )

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -41,7 +41,6 @@ from substrateinterface.exceptions import SubstrateRequestException
 from bittensor.utils.async_substrate import AsyncSubstrateInterface
 
 import bittensor
-from bittensor.btlogging import logging as _logger
 from bittensor.utils import torch, weight_utils
 from bittensor.chain_data import (
     NeuronInfo,
@@ -213,7 +212,7 @@ class Subtensor:
         # Check if network is a config object. (Single argument passed as first positional)
         if isinstance(network, bittensor.config):
             if network.subtensor is None:
-                _logger.warning(
+                bittensor.logging.warning(
                     "If passing a bittensor config object, it must not be empty. Using default subtensor config."
                 )
                 config = None
@@ -232,14 +231,14 @@ class Subtensor:
             self.network == "finney"
             or self.chain_endpoint == bittensor.__finney_entrypoint__
         ) and log_verbose:
-            _logger.info(
+            bittensor.logging.info(
                 f"You are connecting to {self.network} network with endpoint {self.chain_endpoint}."
             )
-            _logger.warning(
+            bittensor.logging.warning(
                 "We strongly encourage running a local subtensor node whenever possible. "
                 "This increases decentralization and resilience of the network."
             )
-            _logger.warning(
+            bittensor.logging.warning(
                 "In a future release, local subtensor will become the default endpoint. "
                 "To get ahead of this change, please run a local subtensor node and point to it."
             )
@@ -252,10 +251,10 @@ class Subtensor:
                 bittensor.__finney_entrypoint__, ws_options=ws_options
             )
         except ConnectionRefusedError:
-            _logger.error(
+            bittensor.logging.error(
                 f"Could not connect to {self.network} network with {self.chain_endpoint} chain endpoint. Exiting...",
             )
-            _logger.info(
+            bittensor.logging.info(
                 "You can check if you have connectivity by running this command: nc -vz localhost "
                 f"{self.chain_endpoint.split(':')[2]}"
             )
@@ -268,14 +267,14 @@ class Subtensor:
         # except:
         #     bittensor.logging.warning("Could not set websocket timeout.")
         except AttributeError as e:
-            _logger.warning(f"AttributeError: {e}")
+            bittensor.logging.warning(f"AttributeError: {e}")
         except TypeError as e:
-            _logger.warning(f"TypeError: {e}")
+            bittensor.logging.warning(f"TypeError: {e}")
         except (socket.error, OSError) as e:
-            _logger.warning(f"Socket error: {e}")
+            bittensor.logging.warning(f"Socket error: {e}")
 
         if log_verbose:
-            _logger.info(
+            bittensor.logging.info(
                 f"Connected to {self.network} network and {self.chain_endpoint}."
             )
 
@@ -753,14 +752,14 @@ class Subtensor:
             except SubstrateRequestException as e:
                 if "Priority is too low" in e.args[0]["message"]:
                     wait = min(wait_time * attempt, max_wait)
-                    _logger.warning(
+                    bittensor.logging.warning(
                         f"Priority is too low, retrying with new nonce: {nonce} in {wait} seconds."
                     )
                     nonce = nonce + 1
                     time.sleep(wait)
                     continue
                 else:
-                    _logger.error(f"Error sending extrinsic: {e}")
+                    bittensor.logging.error(f"Error sending extrinsic: {e}")
                     response = None
 
         return response
@@ -826,7 +825,7 @@ class Subtensor:
                     prompt=prompt,
                 )
             except Exception as e:
-                _logger.error(f"Error setting weights: {e}")
+                bittensor.logging.error(f"Error setting weights: {e}")
             finally:
                 retries += 1
 
@@ -863,7 +862,7 @@ class Subtensor:
         trust in other neurons based on observed performance and contributions.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -941,7 +940,7 @@ class Subtensor:
         success = False
         message = "No attempt made. Perhaps it is too soon to commit weights!"
 
-        _logger.info(
+        bittensor.logging.info(
             "Committing weights with params: netuid={}, uids={}, weights={}, version_key={}".format(
                 netuid, uids, weights, version_key
             )
@@ -957,7 +956,7 @@ class Subtensor:
             version_key=version_key,
         )
 
-        _logger.info("Commit Hash: {}".format(commit_hash))
+        bittensor.logging.info("Commit Hash: {}".format(commit_hash))
 
         while retries < max_retries:
             try:
@@ -1005,7 +1004,7 @@ class Subtensor:
         verifiable record of the neuron's weight distribution at a specific point in time.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -1134,7 +1133,7 @@ class Subtensor:
         transparency and accountability for the neuron's weight distribution.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -1388,7 +1387,7 @@ class Subtensor:
                 message.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             # create extrinsic call
             call = await self.substrate.compose_call(
@@ -1449,7 +1448,7 @@ class Subtensor:
             Tuple[bool, Optional[str]]: A tuple containing a boolean indicating success or failure, and an optional error message.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             # create extrinsic call
             call = await self.substrate.compose_call(
@@ -1505,7 +1504,7 @@ class Subtensor:
                 error message.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             # create extrinsic call
             call = await self.substrate.compose_call(
@@ -1629,7 +1628,7 @@ class Subtensor:
             return fee
         else:
             fee = Balance.from_rao(int(2e7))
-            _logger.error(
+            bittensor.logging.error(
                 "To calculate the transaction fee, the value must be Balance, float, or int. Received type: %s. Fee "
                 "is %s",
                 type(value),
@@ -1660,7 +1659,7 @@ class Subtensor:
             error (str): Error message if transfer failed.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="Balances",
@@ -1896,7 +1895,7 @@ class Subtensor:
         enhancing the decentralized computation capabilities of Bittensor.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -1959,7 +1958,7 @@ class Subtensor:
             error (:func:`Optional[str]`): Error message if serve prometheus failed, ``None`` otherwise.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -2008,7 +2007,7 @@ class Subtensor:
             error (:func:`Optional[str]`): Error message if associate IPs failed, None otherwise.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -2137,7 +2136,7 @@ class Subtensor:
             StakeError: If the extrinsic failed.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -2264,7 +2263,7 @@ class Subtensor:
             StakeError: If the extrinsic failed.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -2589,7 +2588,7 @@ class Subtensor:
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = True,
     ) -> Tuple[bool, Optional[str]]:
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             # create extrinsic call
             call = await self.substrate.compose_call(
@@ -2693,7 +2692,7 @@ class Subtensor:
         network-specific details, providing insights into the neuron's role and status within the Bittensor network.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry() -> "ScaleType":
             return await self.substrate.query(
                 module="Registry",
@@ -2750,7 +2749,7 @@ class Subtensor:
         call_params = bittensor.utils.wallet_utils.create_identity_dict(**params)
         call_params["identified"] = identified
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry() -> bool:
             call = await self.substrate.compose_call(
                 call_module="Registry",
@@ -2837,7 +2836,7 @@ class Subtensor:
         providing valuable insights into the state and dynamics of the Bittensor ecosystem.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry() -> "ScaleType":
             return await self.substrate.query(
                 module="SubtensorModule",
@@ -2876,7 +2875,7 @@ class Subtensor:
         relationships within the Bittensor ecosystem, such as inter-neuronal connections and stake distributions.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             return await self.substrate.query_map(
                 module="SubtensorModule",
@@ -2910,7 +2909,7 @@ class Subtensor:
         operational parameters.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             return await self.substrate.get_constant(
                 module_name=module_name,
@@ -2950,7 +2949,7 @@ class Subtensor:
         parts of the Bittensor blockchain, enhancing the understanding and analysis of the network's state and dynamics.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry() -> "ScaleType":
             return await self.substrate.query(
                 module=module,
@@ -2991,7 +2990,7 @@ class Subtensor:
         modules, offering insights into the network's state and the relationships between its different components.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry() -> "QueryMapResult":
             return await self.substrate.query_map(
                 module=module,
@@ -3028,7 +3027,7 @@ class Subtensor:
         useful for specific use cases where standard queries are insufficient.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry() -> Dict[Any, Any]:
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4114,7 +4113,7 @@ class Subtensor:
         the roles of different subnets, and their unique features.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4150,7 +4149,7 @@ class Subtensor:
         subnet, including its governance, performance, and role within the broader network.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4312,7 +4311,7 @@ class Subtensor:
         the Bittensor network's consensus and governance structures.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry(encoded_hotkey_: List[int]):
             block_hash = None if block is None else self.substrate.get_block_hash(block)
 
@@ -4351,7 +4350,7 @@ class Subtensor:
 
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4387,7 +4386,7 @@ class Subtensor:
 
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4423,7 +4422,7 @@ class Subtensor:
         involvement in the network's delegation and consensus mechanisms.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry(encoded_coldkey_: List[int]):
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4538,7 +4537,7 @@ class Subtensor:
             Exception: If the substrate call fails after the maximum number of retries.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             return await self.substrate.query(
                 module="SubtensorModule", storage_function="NominatorMinRequiredStake"
@@ -4804,7 +4803,7 @@ class Subtensor:
         if uid is None:
             return NeuronInfo.get_null_neuron()
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -5138,7 +5137,7 @@ class Subtensor:
             bool: ``True`` if the delegation is successful, ``False`` otherwise.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -5189,7 +5188,7 @@ class Subtensor:
             bool: ``True`` if the undelegation is successful, ``False`` otherwise.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -5239,7 +5238,7 @@ class Subtensor:
             bool: ``True`` if the nomination is successful, ``False`` otherwise.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -5394,7 +5393,7 @@ class Subtensor:
         """
         try:
 
-            @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+            @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
             async def make_substrate_call_with_retry():
                 return await self.substrate.query(
                     module="System",
@@ -5409,7 +5408,7 @@ class Subtensor:
 
             result = await make_substrate_call_with_retry()
         except RemainingScaleBytesNotEmptyException:
-            _logger.error(
+            bittensor.logging.error(
                 "Received a corrupted message. This likely points to an error with the network or subnet."
             )
             return Balance(1000)
@@ -5427,7 +5426,7 @@ class Subtensor:
         operations on the blockchain. It serves as a reference point for network activities and data synchronization.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             return await self.substrate.get_block_number(None)  # type: ignore
 
@@ -5448,7 +5447,7 @@ class Subtensor:
         including the distribution of financial resources and the financial status of network participants.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=_logger)
+        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
         async def make_substrate_call_with_retry():
             return await self.substrate.query_map(
                 module="System",

--- a/bittensor/utils/async_substrate.py
+++ b/bittensor/utils/async_substrate.py
@@ -445,7 +445,7 @@ class Websocket:
                 websockets.connect(self.ws_url, **self._options), timeout=None
             )
             self._receiving_task = asyncio.create_task(self._start_receiving())
-        except Exception as e:
+        except Exception:
             await self._reconnect()
 
     async def _reconnect(self):
@@ -459,10 +459,10 @@ class Websocket:
                 self._receiving_task = asyncio.create_task(self._start_receiving())
                 self._initialized = True
                 return
-            except Exception as e:
+            except Exception:
                 self._attempts += 1
         raise ConnectionError(
-            f"Failed to reconnect after {self._max_reconnect_attempts} attempts. {e}"
+            f"Failed to reconnect after {self._max_reconnect_attempts} attempts"
         )
 
     async def _exit_with_timer(self):

--- a/bittensor/utils/subtensor.py
+++ b/bittensor/utils/subtensor.py
@@ -20,13 +20,12 @@
 """Module providing common helper functions for working with Subtensor."""
 
 import json
-import logging
 import os
 from typing import Dict, Optional, Union, Any
 
 from substrateinterface.base import SubstrateInterface
 
-_logger = logging.getLogger("subtensor.errors_handler")
+import bittensor
 
 _USER_HOME_DIR = os.path.expanduser("~")
 _BT_DIR = os.path.join(_USER_HOME_DIR, ".bittensor")
@@ -35,6 +34,7 @@ _ST_BUILD_ID = "subtensor_build_id"
 
 # Create directory if it doesn't exist
 os.makedirs(_BT_DIR, exist_ok=True)
+bittensor.logging.on()
 
 
 # Pallet's typing class `PalletMetadataV14` is defined only at
@@ -54,7 +54,7 @@ def _get_errors_from_pallet(pallet) -> Optional[Dict[str, Dict[str, str]]]:
         ValueError: If the pallet does not contain error definitions or the list is empty.
     """
     if not hasattr(pallet, "errors") or not pallet.errors:
-        _logger.warning(
+        bittensor.logging.warning(
             "The pallet does not contain any error definitions or the list is empty."
         )
         return None
@@ -80,7 +80,7 @@ def _save_errors_to_cache(uniq_version: str, errors: Dict[str, Dict[str, str]]):
         with open(_ERRORS_FILE_PATH, "w") as json_file:
             json.dump(data, json_file, indent=4)
     except IOError as e:
-        _logger.warning(f"Error saving to file: {e}")
+        bittensor.logging.warning(f"Error saving to file: {e}")
 
 
 def _get_errors_from_cache() -> Optional[Dict[str, Dict[str, Dict[str, str]]]]:
@@ -96,7 +96,7 @@ def _get_errors_from_cache() -> Optional[Dict[str, Dict[str, Dict[str, str]]]]:
         with open(_ERRORS_FILE_PATH, "r") as json_file:
             data = json.load(json_file)
     except IOError as e:
-        _logger.warning(f"Error reading from file: {e}")
+        bittensor.logging.warning(f"Error reading from file: {e}")
         return None
 
     return data
@@ -133,7 +133,7 @@ def get_subtensor_errors(
         _save_errors_to_cache(
             uniq_version=substrate.metadata[0].value, errors=subtensor_errors_map
         )
-        _logger.info(f"File {_ERRORS_FILE_PATH} has been updated.")
+        bittensor.logging.info(f"File {_ERRORS_FILE_PATH} has been updated.")
         return subtensor_errors_map
     else:
         return cached_errors_map.get("errors", {})

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -25,11 +25,7 @@ import pytest
 
 # Application
 import bittensor
-from bittensor.subtensor import (
-    Subtensor,
-    _logger,
-    Balance,
-)
+from bittensor.subtensor import Subtensor, Balance
 from bittensor import subtensor_module
 
 
@@ -308,7 +304,7 @@ def test_get_error_info_by_index_known_error(subtensor):
 
 
 def test_get_error_info_by_index_unknown_error(subtensor):
-    mock_logger = mock.patch.object(_logger, "warning").start()
+    mock_logger = mock.patch.object(bittensor.logging, "warning").start()
     fake_index = 999
     name, description = subtensor.get_error_info_by_index(fake_index)
     assert name == "Unknown Error"


### PR DESCRIPTION
These changes fix the `circular import` bug associated with the use of `bittensor.btlogging.on()`.

But the issue is different.

bittensor.btlogging is a independent sub-package and must be imported not centrally, but in each used place (module) separately. Its use should be used with `from bittensor.btlogging import logging`. 
Then we will not depend on the order of imported modules and sub-packages in `bittensor/__init__.py`.

It may be worth making an announcement that `bittensor.logging` will not be available soon and it is worth using the full import path in places where it is required as `from bittensor.btlogging import logging` insted of `bittensor.logging` or `import logging`.

Also, this PR includes the replacement all `import logging` to using `bittensor.logging` across the entire `bittensor` package, except the tests configuration and e2e tests.