### PR TITLE
Asyc `bittensor/extrinsics` (part 4)

### DIFF
--- a/bittensor/axon.py
+++ b/bittensor/axon.py
@@ -794,7 +794,7 @@ class axon:
         self.started = False
         return self
 
-    def serve(
+    async def serve(
         self, netuid: int, subtensor: Optional[bittensor.subtensor] = None
     ) -> "bittensor.axon":
         """
@@ -821,7 +821,7 @@ class axon:
             to start receiving and processing requests from other neurons.
         """
         if subtensor is not None and hasattr(subtensor, "serve_axon"):
-            subtensor.serve_axon(netuid=netuid, axon=self)
+            await subtensor.serve_axon(netuid=netuid, axon=self)
         return self
 
     async def default_verify(self, synapse: bittensor.Synapse):

--- a/bittensor/extrinsics/root.py
+++ b/bittensor/extrinsics/root.py
@@ -1,31 +1,36 @@
 # The MIT License (MIT)
 # Copyright © 2021 Yuma Rao
 # Copyright © 2023 Opentensor Foundation
-
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 # documentation files (the “Software”), to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
 # and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
+#
 # The above copyright notice and this permission notice shall be included in all copies or substantial portions of
 # the Software.
-
+#
 # THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
 # THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import bittensor
+"""
+This module provides functions for interacting with the Bittensor root network,
+including registration and setting weights on the blockchain.
+"""
 
 import time
+from typing import Union, List
+
 import numpy as np
 from numpy.typing import NDArray
 from rich.prompt import Confirm
-from typing import Union, List
+
+import bittensor
 import bittensor.utils.weight_utils as weight_utils
 from bittensor.utils.registration import torch, legacy_torch_api_compat
-
 
 bittensor.logging.on()
 
@@ -37,20 +42,17 @@ def root_register_extrinsic(
     wait_for_finalization: bool = True,
     prompt: bool = False,
 ) -> bool:
-    r"""Registers the wallet to root network.
+    """Registers the wallet to root network.
 
     Args:
-        wallet (bittensor.wallet):
-            Bittensor wallet object.
-        wait_for_inclusion (bool):
-            If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
-        wait_for_finalization (bool):
-            If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
-        prompt (bool):
-            If ``true``, the call waits for confirmation from the user before proceeding.
+        subtensor (bittensor.subtensor): Bittensor subtensor object.
+        wallet (bittensor.wallet): Bittensor wallet object.
+        wait_for_inclusion (bool): If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
+        wait_for_finalization (bool): If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
+        prompt (bool): If ``true``, the call waits for confirmation from the user before proceeding.
+
     Returns:
-        success (bool):
-            Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
+        success (bool): Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
     """
 
     wallet.coldkey  # unlock coldkey
@@ -58,6 +60,7 @@ def root_register_extrinsic(
     is_registered = subtensor.is_hotkey_registered(
         netuid=0, hotkey_ss58=wallet.hotkey.ss58_address
     )
+
     if is_registered:
         bittensor.__console__.print(
             f":white_heavy_check_mark: [green]Already registered on root network.[/green]"
@@ -70,7 +73,7 @@ def root_register_extrinsic(
             return False
 
     with bittensor.__console__.status(":satellite: Registering to root network..."):
-        success, err_msg = subtensor._do_root_register(
+        success, err_msg = subtensor.do_root_register(
             wallet=wallet,
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,
@@ -78,7 +81,7 @@ def root_register_extrinsic(
 
         if success is not True or success is False:
             bittensor.__console__.print(
-                ":cross_mark: [red]Failed[/red]: error:{}".format(err_msg)
+                f":cross_mark: [red]Failed[/red]: error:{err_msg}"
             )
             time.sleep(0.5)
 
@@ -110,27 +113,22 @@ def set_root_weights_extrinsic(
     wait_for_finalization: bool = False,
     prompt: bool = False,
 ) -> bool:
-    r"""Sets the given weights and values on chain for wallet hotkey account.
+    """Sets the given weights and values on chain for wallet hotkey account.
 
     Args:
-        wallet (bittensor.wallet):
-            Bittensor wallet object.
-        netuids (Union[NDArray[np.int64], torch.LongTensor, List[int]]):
-            The ``netuid`` of the subnet to set weights for.
-        weights (Union[NDArray[np.float32], torch.FloatTensor, list]):
-            Weights to set. These must be ``float`` s and must correspond to the passed ``netuid`` s.
-        version_key (int):
-            The version key of the validator.
-        wait_for_inclusion (bool):
-            If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
-        wait_for_finalization (bool):
-            If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
-        prompt (bool):
-            If ``true``, the call waits for confirmation from the user before proceeding.
+        subtensor (bittensor.subtensor): Bittensor subtensor object.
+        wallet (bittensor.wallet): Bittensor wallet object.
+        netuids (Union[NDArray[np.int64], torch.LongTensor, List[int]]): The ``netuid`` of the subnet to set weights for.
+        weights (Union[NDArray[np.float32], torch.FloatTensor, list]): Weights to set. These must be ``float`` s and must correspond to the passed ``netuid`` s.
+        version_key (int): The version key of the validator.
+        wait_for_inclusion (bool): If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
+        wait_for_finalization (bool): If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
+        prompt (bool): If ``true``, the call waits for confirmation from the user before proceeding.
+
     Returns:
-        success (bool):
-            Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
+        success (bool): Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
     """
+
     # First convert types.
     if isinstance(netuids, list):
         netuids = np.array(netuids, dtype=np.int64)
@@ -146,9 +144,7 @@ def set_root_weights_extrinsic(
     non_zero_weights = weights[non_zero_weight_idx]
     if non_zero_weights.size < min_allowed_weights:
         raise ValueError(
-            "The minimum number of weights required to set weights is {}, got {}".format(
-                min_allowed_weights, non_zero_weights.size
-            )
+            f"The minimum number of weights required to set weights is {min_allowed_weights}, got {non_zero_weights.size}"
         )
 
     # Normalize the weights to max value.
@@ -162,22 +158,18 @@ def set_root_weights_extrinsic(
     # Ask before moving on.
     if prompt:
         if not Confirm.ask(
-            "Do you want to set the following root weights?:\n[bold white]  weights: {}\n  uids: {}[/bold white ]?".format(
-                formatted_weights, netuids
-            )
+            f"Do you want to set the following root weights?:\n[bold white]  weights: {formatted_weights}\n  uids: {netuids}[/bold white ]?"
         ):
             return False
 
     with bittensor.__console__.status(
-        ":satellite: Setting root weights on [white]{}[/white] ...".format(
-            subtensor.network
-        )
+        f":satellite: Setting root weights on [white]{subtensor.network}[/white] ..."
     ):
         try:
             weight_uids, weight_vals = weight_utils.convert_weights_and_uids_for_emit(
                 netuids, weights
             )
-            success, error_message = subtensor._do_set_weights(
+            success, error_message = subtensor.do_set_weights(
                 wallet=wallet,
                 netuid=0,
                 uids=weight_uids,
@@ -203,7 +195,7 @@ def set_root_weights_extrinsic(
                 return True
             else:
                 bittensor.__console__.print(
-                    ":cross_mark: [red]Failed[/red]: error:{}".format(error_message)
+                    f":cross_mark: [red]Failed[/red]: error:{error_message}"
                 )
                 bittensor.logging.warning(
                     prefix="Set weights",
@@ -213,9 +205,7 @@ def set_root_weights_extrinsic(
 
         except Exception as e:
             # TODO( devs ): lets remove all of the bittensor.__console__ calls and replace with the bittensor logger.
-            bittensor.__console__.print(
-                ":cross_mark: [red]Failed[/red]: error:{}".format(e)
-            )
+            bittensor.__console__.print(f":cross_mark: [red]Failed[/red]: error:{e}")
             bittensor.logging.warning(
                 prefix="Set weights", suffix="<red>Failed: </red>" + str(e)
             )

--- a/bittensor/extrinsics/senate.py
+++ b/bittensor/extrinsics/senate.py
@@ -18,13 +18,15 @@
 
 """This module provides functionality for interacting with the senate features of the Bittensor blockchain."""
 
-import bittensor
-
+import asyncio
 import time
+
 from rich.prompt import Confirm
 
+import bittensor
 
-def register_senate_extrinsic(
+
+async def register_senate_extrinsic(
     subtensor: "bittensor.subtensor",
     wallet: "bittensor.wallet",
     wait_for_inclusion: bool = False,
@@ -53,15 +55,15 @@ def register_senate_extrinsic(
 
     with bittensor.__console__.status(":satellite: Registering with senate..."):
         # create extrinsic call
-        call = subtensor.substrate.compose_call(
+        call = await subtensor.substrate.compose_call(
             call_module="SubtensorModule",
             call_function="join_senate",
             call_params={"hotkey": wallet.hotkey.ss58_address},
         )
-        extrinsic = subtensor.substrate.create_signed_extrinsic(
+        extrinsic = await subtensor.substrate.create_signed_extrinsic(
             call=call, keypair=wallet.coldkey
         )
-        response = subtensor.substrate.submit_extrinsic(
+        response = await subtensor.substrate.submit_extrinsic(
             extrinsic,
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,
@@ -77,11 +79,11 @@ def register_senate_extrinsic(
             bittensor.__console__.print(
                 f":cross_mark: [red]Failed[/red]: error:{response.error_message}"
             )
-            time.sleep(0.5)
+            await asyncio.sleep(0.5)
 
         # Successful registration, final check for membership
         else:
-            is_registered = subtensor.is_senate_member(wallet.hotkey.ss58_address)
+            is_registered = await subtensor.is_senate_member(wallet.hotkey.ss58_address)
 
             if is_registered:
                 bittensor.__console__.print(
@@ -95,7 +97,7 @@ def register_senate_extrinsic(
                 )
 
 
-def leave_senate_extrinsic(
+async def leave_senate_extrinsic(
     subtensor: "bittensor.subtensor",
     wallet: "bittensor.wallet",
     wait_for_inclusion: bool = False,
@@ -124,15 +126,15 @@ def leave_senate_extrinsic(
 
     with bittensor.__console__.status(":satellite: Leaving senate..."):
         # create extrinsic call
-        call = subtensor.substrate.compose_call(
+        call = await subtensor.substrate.compose_call(
             call_module="SubtensorModule",
             call_function="leave_senate",
             call_params={"hotkey": wallet.hotkey.ss58_address},
         )
-        extrinsic = subtensor.substrate.create_signed_extrinsic(
+        extrinsic = await subtensor.substrate.create_signed_extrinsic(
             call=call, keypair=wallet.coldkey
         )
-        response = subtensor.substrate.submit_extrinsic(
+        response = await subtensor.substrate.submit_extrinsic(
             extrinsic,
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,
@@ -152,7 +154,7 @@ def leave_senate_extrinsic(
 
         # Successful registration, final check for membership
         else:
-            is_registered = subtensor.is_senate_member(wallet.hotkey.ss58_address)
+            is_registered = await subtensor.is_senate_member(wallet.hotkey.ss58_address)
 
             if not is_registered:
                 bittensor.__console__.print(
@@ -166,7 +168,7 @@ def leave_senate_extrinsic(
                 )
 
 
-def vote_senate_extrinsic(
+async def vote_senate_extrinsic(
     subtensor: "bittensor.subtensor",
     wallet: "bittensor.wallet",
     proposal_hash: str,
@@ -201,7 +203,7 @@ def vote_senate_extrinsic(
 
     with bittensor.__console__.status(":satellite: Casting vote.."):
         # create extrinsic call
-        call = subtensor.substrate.compose_call(
+        call = await subtensor.substrate.compose_call(
             call_module="SubtensorModule",
             call_function="vote",
             call_params={
@@ -211,10 +213,10 @@ def vote_senate_extrinsic(
                 "approve": vote,
             },
         )
-        extrinsic = subtensor.substrate.create_signed_extrinsic(
+        extrinsic = await subtensor.substrate.create_signed_extrinsic(
             call=call, keypair=wallet.coldkey
         )
-        response = subtensor.substrate.submit_extrinsic(
+        response = await subtensor.substrate.submit_extrinsic(
             extrinsic,
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,
@@ -234,7 +236,7 @@ def vote_senate_extrinsic(
 
         # Successful vote, final check for data
         else:
-            vote_data = subtensor.get_vote_data(proposal_hash)
+            vote_data = await subtensor.get_vote_data(proposal_hash)
             has_voted = (
                 vote_data["ayes"].count(wallet.hotkey.ss58_address) > 0
                 or vote_data["nays"].count(wallet.hotkey.ss58_address) > 0

--- a/bittensor/extrinsics/senate.py
+++ b/bittensor/extrinsics/senate.py
@@ -1,22 +1,23 @@
 # The MIT License (MIT)
 # Copyright © 2021 Yuma Rao
 # Copyright © 2023 Opentensor Foundation
-
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 # documentation files (the “Software”), to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
 # and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
+#
 # The above copyright notice and this permission notice shall be included in all copies or substantial portions of
 # the Software.
-
+#
 # THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
 # THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-# Imports
+"""This module provides functionality for interacting with the senate features of the Bittensor blockchain."""
+
 import bittensor
 
 import time
@@ -30,20 +31,17 @@ def register_senate_extrinsic(
     wait_for_finalization: bool = True,
     prompt: bool = False,
 ) -> bool:
-    r"""Registers the wallet to chain for senate voting.
+    """Registers the wallet to chain for senate voting.
 
     Args:
-        wallet (bittensor.wallet):
-            Bittensor wallet object.
-        wait_for_inclusion (bool):
-            If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
-        wait_for_finalization (bool):
-            If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
-        prompt (bool):
-            If ``true``, the call waits for confirmation from the user before proceeding.
+        subtensor (bittensor.subtensor): Bittensor subtensor object.
+        wallet (bittensor.wallet): Bittensor wallet object.
+        wait_for_inclusion (bool): If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
+        wait_for_finalization (bool): If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
+        prompt (bool): If ``true``, the call waits for confirmation from the user before proceeding.
+
     Returns:
-        success (bool):
-            Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
+        success (bool): Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
     """
     wallet.coldkey  # unlock coldkey
     wallet.hotkey  # unlock hotkey
@@ -54,50 +52,47 @@ def register_senate_extrinsic(
             return False
 
     with bittensor.__console__.status(":satellite: Registering with senate..."):
-        with subtensor.substrate as substrate:
-            # create extrinsic call
-            call = substrate.compose_call(
-                call_module="SubtensorModule",
-                call_function="join_senate",
-                call_params={"hotkey": wallet.hotkey.ss58_address},
-            )
-            extrinsic = substrate.create_signed_extrinsic(
-                call=call, keypair=wallet.coldkey
-            )
-            response = substrate.submit_extrinsic(
-                extrinsic,
-                wait_for_inclusion=wait_for_inclusion,
-                wait_for_finalization=wait_for_finalization,
-            )
+        # create extrinsic call
+        call = subtensor.substrate.compose_call(
+            call_module="SubtensorModule",
+            call_function="join_senate",
+            call_params={"hotkey": wallet.hotkey.ss58_address},
+        )
+        extrinsic = subtensor.substrate.create_signed_extrinsic(
+            call=call, keypair=wallet.coldkey
+        )
+        response = subtensor.substrate.submit_extrinsic(
+            extrinsic,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+        )
 
-            # We only wait here if we expect finalization.
-            if not wait_for_finalization and not wait_for_inclusion:
-                return True
+        # We only wait here if we expect finalization.
+        if not wait_for_finalization and not wait_for_inclusion:
+            return True
 
-            # process if registration successful
-            response.process_events()
-            if not response.is_success:
+        # process if registration successful
+        response.process_events()
+        if not response.is_success:
+            bittensor.__console__.print(
+                f":cross_mark: [red]Failed[/red]: error:{response.error_message}"
+            )
+            time.sleep(0.5)
+
+        # Successful registration, final check for membership
+        else:
+            is_registered = subtensor.is_senate_member(wallet.hotkey.ss58_address)
+
+            if is_registered:
                 bittensor.__console__.print(
-                    ":cross_mark: [red]Failed[/red]: error:{}".format(
-                        response.error_message
-                    )
+                    ":white_heavy_check_mark: [green]Registered[/green]"
                 )
-                time.sleep(0.5)
-
-            # Successful registration, final check for membership
+                return True
             else:
-                is_registered = wallet.is_senate_member(subtensor)
-
-                if is_registered:
-                    bittensor.__console__.print(
-                        ":white_heavy_check_mark: [green]Registered[/green]"
-                    )
-                    return True
-                else:
-                    # neuron not found, try again
-                    bittensor.__console__.print(
-                        ":cross_mark: [red]Unknown error. Senate membership not found.[/red]"
-                    )
+                # neuron not found, try again
+                bittensor.__console__.print(
+                    ":cross_mark: [red]Unknown error. Senate membership not found.[/red]"
+                )
 
 
 def leave_senate_extrinsic(
@@ -107,20 +102,17 @@ def leave_senate_extrinsic(
     wait_for_finalization: bool = True,
     prompt: bool = False,
 ) -> bool:
-    r"""Removes the wallet from chain for senate voting.
+    """Removes the wallet from chain for senate voting.
 
     Args:
-        wallet (bittensor.wallet):
-            Bittensor wallet object.
-        wait_for_inclusion (bool):
-            If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
-        wait_for_finalization (bool):
-            If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
-        prompt (bool):
-            If ``true``, the call waits for confirmation from the user before proceeding.
+        subtensor (bittensor.subtensor): Bittensor subtensor object.
+        wallet (bittensor.wallet): Bittensor wallet object.
+        wait_for_inclusion (bool): If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
+        wait_for_finalization (bool): If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
+        prompt (bool): If ``true``, the call waits for confirmation from the user before proceeding.
+
     Returns:
-        success (bool):
-            Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
+        success (bool): Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
     """
     wallet.coldkey  # unlock coldkey
     wallet.hotkey  # unlock hotkey
@@ -131,50 +123,47 @@ def leave_senate_extrinsic(
             return False
 
     with bittensor.__console__.status(":satellite: Leaving senate..."):
-        with subtensor.substrate as substrate:
-            # create extrinsic call
-            call = substrate.compose_call(
-                call_module="SubtensorModule",
-                call_function="leave_senate",
-                call_params={"hotkey": wallet.hotkey.ss58_address},
-            )
-            extrinsic = substrate.create_signed_extrinsic(
-                call=call, keypair=wallet.coldkey
-            )
-            response = substrate.submit_extrinsic(
-                extrinsic,
-                wait_for_inclusion=wait_for_inclusion,
-                wait_for_finalization=wait_for_finalization,
-            )
+        # create extrinsic call
+        call = subtensor.substrate.compose_call(
+            call_module="SubtensorModule",
+            call_function="leave_senate",
+            call_params={"hotkey": wallet.hotkey.ss58_address},
+        )
+        extrinsic = subtensor.substrate.create_signed_extrinsic(
+            call=call, keypair=wallet.coldkey
+        )
+        response = subtensor.substrate.submit_extrinsic(
+            extrinsic,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+        )
 
-            # We only wait here if we expect finalization.
-            if not wait_for_finalization and not wait_for_inclusion:
-                return True
+        # We only wait here if we expect finalization.
+        if not wait_for_finalization and not wait_for_inclusion:
+            return True
 
-            # process if registration successful
-            response.process_events()
-            if not response.is_success:
+        # process if registration successful
+        response.process_events()
+        if not response.is_success:
+            bittensor.__console__.print(
+                f":cross_mark: [red]Failed[/red]: error:{response.error_message}"
+            )
+            time.sleep(0.5)
+
+        # Successful registration, final check for membership
+        else:
+            is_registered = subtensor.is_senate_member(wallet.hotkey.ss58_address)
+
+            if not is_registered:
                 bittensor.__console__.print(
-                    ":cross_mark: [red]Failed[/red]: error:{}".format(
-                        response.error_message
-                    )
+                    ":white_heavy_check_mark: [green]Left senate[/green]"
                 )
-                time.sleep(0.5)
-
-            # Successful registration, final check for membership
+                return True
             else:
-                is_registered = wallet.is_senate_member(subtensor)
-
-                if not is_registered:
-                    bittensor.__console__.print(
-                        ":white_heavy_check_mark: [green]Left senate[/green]"
-                    )
-                    return True
-                else:
-                    # neuron not found, try again
-                    bittensor.__console__.print(
-                        ":cross_mark: [red]Unknown error. Senate membership still found.[/red]"
-                    )
+                # neuron not found, try again
+                bittensor.__console__.print(
+                    ":cross_mark: [red]Unknown error. Senate membership still found.[/red]"
+                )
 
 
 def vote_senate_extrinsic(
@@ -190,17 +179,17 @@ def vote_senate_extrinsic(
     r"""Votes ayes or nays on proposals.
 
     Args:
-        wallet (bittensor.wallet):
-            Bittensor wallet object.
-        wait_for_inclusion (bool):
-            If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
-        wait_for_finalization (bool):
-            If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
-        prompt (bool):
-            If ``true``, the call waits for confirmation from the user before proceeding.
+        subtensor (bittensor.subtensor): Bittensor subtensor object.
+        wallet (bittensor.wallet): Bittensor wallet object.
+        proposal_hash (str): The hash of the proposal being voted on.
+        proposal_idx (int): The index of the proposal being voted on.
+        vote (bool): The vote to be cast (True for yes, False for no).
+        wait_for_inclusion (bool): If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
+        wait_for_finalization (bool): If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
+        prompt (bool): If ``true``, the call waits for confirmation from the user before proceeding.
+
     Returns:
-        success (bool):
-            Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
+        success (bool): Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
     """
     wallet.coldkey  # unlock coldkey
     wallet.hotkey  # unlock hotkey
@@ -211,56 +200,53 @@ def vote_senate_extrinsic(
             return False
 
     with bittensor.__console__.status(":satellite: Casting vote.."):
-        with subtensor.substrate as substrate:
-            # create extrinsic call
-            call = substrate.compose_call(
-                call_module="SubtensorModule",
-                call_function="vote",
-                call_params={
-                    "hotkey": wallet.hotkey.ss58_address,
-                    "proposal": proposal_hash,
-                    "index": proposal_idx,
-                    "approve": vote,
-                },
+        # create extrinsic call
+        call = subtensor.substrate.compose_call(
+            call_module="SubtensorModule",
+            call_function="vote",
+            call_params={
+                "hotkey": wallet.hotkey.ss58_address,
+                "proposal": proposal_hash,
+                "index": proposal_idx,
+                "approve": vote,
+            },
+        )
+        extrinsic = subtensor.substrate.create_signed_extrinsic(
+            call=call, keypair=wallet.coldkey
+        )
+        response = subtensor.substrate.submit_extrinsic(
+            extrinsic,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+        )
+
+        # We only wait here if we expect finalization.
+        if not wait_for_finalization and not wait_for_inclusion:
+            return True
+
+        # process if vote successful
+        response.process_events()
+        if not response.is_success:
+            bittensor.__console__.print(
+                f":cross_mark: [red]Failed[/red]: error:{response.error_message}"
             )
-            extrinsic = substrate.create_signed_extrinsic(
-                call=call, keypair=wallet.coldkey
-            )
-            response = substrate.submit_extrinsic(
-                extrinsic,
-                wait_for_inclusion=wait_for_inclusion,
-                wait_for_finalization=wait_for_finalization,
+            time.sleep(0.5)
+
+        # Successful vote, final check for data
+        else:
+            vote_data = subtensor.get_vote_data(proposal_hash)
+            has_voted = (
+                vote_data["ayes"].count(wallet.hotkey.ss58_address) > 0
+                or vote_data["nays"].count(wallet.hotkey.ss58_address) > 0
             )
 
-            # We only wait here if we expect finalization.
-            if not wait_for_finalization and not wait_for_inclusion:
-                return True
-
-            # process if vote successful
-            response.process_events()
-            if not response.is_success:
+            if has_voted:
                 bittensor.__console__.print(
-                    ":cross_mark: [red]Failed[/red]: error:{}".format(
-                        response.error_message
-                    )
+                    ":white_heavy_check_mark: [green]Vote cast.[/green]"
                 )
-                time.sleep(0.5)
-
-            # Successful vote, final check for data
+                return True
             else:
-                vote_data = subtensor.get_vote_data(proposal_hash)
-                has_voted = (
-                    vote_data["ayes"].count(wallet.hotkey.ss58_address) > 0
-                    or vote_data["nays"].count(wallet.hotkey.ss58_address) > 0
+                # hotkey not found in ayes/nays
+                bittensor.__console__.print(
+                    ":cross_mark: [red]Unknown error. Couldn't find vote.[/red]"
                 )
-
-                if has_voted:
-                    bittensor.__console__.print(
-                        ":white_heavy_check_mark: [green]Vote cast.[/green]"
-                    )
-                    return True
-                else:
-                    # hotkey not found in ayes/nays
-                    bittensor.__console__.print(
-                        ":cross_mark: [red]Unknown error. Couldn't find vote.[/red]"
-                    )

--- a/bittensor/extrinsics/serving.py
+++ b/bittensor/extrinsics/serving.py
@@ -22,7 +22,7 @@ publishing metadata, and performing extrinsics related to network services.
 """
 
 import json
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from retry import retry
 from rich.prompt import Confirm
@@ -32,7 +32,7 @@ import bittensor.utils.networking as net
 from ..errors import MetadataError
 
 
-def serve_extrinsic(
+async def serve_extrinsic(
     subtensor: "bittensor.subtensor",
     wallet: "bittensor.wallet",
     ip: str,
@@ -65,7 +65,8 @@ def serve_extrinsic(
     """
     # Decrypt hotkey
     wallet.hotkey
-    params: "subtensor.AxonServeCallParams" = {
+
+    params: Dict[str, Any] = {
         "version": bittensor.__version_as_int__,
         "ip": net.ip_to_int(ip),
         "port": port,
@@ -78,7 +79,8 @@ def serve_extrinsic(
         "placeholder2": placeholder2,
     }
     bittensor.logging.debug("Checking axon ...")
-    neuron = subtensor.get_neuron_for_pubkey_and_subnet(
+
+    neuron = await subtensor.get_neuron_for_pubkey_and_subnet(
         wallet.hotkey.ss58_address, netuid=netuid
     )
     neuron_up_to_date = not neuron.is_null and params == {
@@ -96,6 +98,7 @@ def serve_extrinsic(
     output = params.copy()
     output["coldkey"] = wallet.coldkeypub.ss58_address
     output["hotkey"] = wallet.hotkey.ss58_address
+
     if neuron_up_to_date:
         bittensor.logging.debug(
             f"Axon already served on: AxonInfo({wallet.hotkey.ss58_address},{ip}:{port}) "
@@ -116,7 +119,7 @@ def serve_extrinsic(
     bittensor.logging.debug(
         f"Serving axon with: AxonInfo({wallet.hotkey.ss58_address},{ip}:{port}) -> {subtensor.network}:{netuid}"
     )
-    success, error_message = subtensor.do_serve_axon(
+    success, error_message = await subtensor.do_serve_axon(
         wallet=wallet,
         call_params=params,
         wait_for_finalization=wait_for_finalization,
@@ -138,10 +141,10 @@ def serve_extrinsic(
         return True
 
 
-def serve_axon_extrinsic(
+async def serve_axon_extrinsic(
     subtensor: "bittensor.subtensor",
     netuid: int,
-    axon: "bittensor.Axon",
+    axon: "bittensor.axon",
     wait_for_inclusion: bool = False,
     wait_for_finalization: bool = True,
     prompt: bool = False,
@@ -167,15 +170,21 @@ def serve_axon_extrinsic(
     if axon.external_ip is None:
         try:
             external_ip = net.get_external_ip()
-            bittensor.__console__.print(f":white_heavy_check_mark: [green]Found external ip: {external_ip}[/green]")
-            bittensor.logging.success(prefix="External IP", suffix=f"<blue>{external_ip}</blue>")
+            bittensor.__console__.print(
+                f":white_heavy_check_mark: [green]Found external ip: {external_ip}[/green]"
+            )
+            bittensor.logging.success(
+                prefix="External IP", suffix=f"<blue>{external_ip}</blue>"
+            )
         except Exception as e:
-            raise RuntimeError(f"Unable to attain your external ip. Check your internet connection. error: {e}") from e
+            raise RuntimeError(
+                f"Unable to attain your external ip. Check your internet connection. error: {e}"
+            ) from e
     else:
         external_ip = axon.external_ip
 
     # ---- Subscribe to chain ----
-    serve_success = subtensor.serve(
+    serve_success = await subtensor.serve(
         wallet=axon.wallet,
         ip=external_ip,
         port=external_port,
@@ -187,7 +196,7 @@ def serve_axon_extrinsic(
     return serve_success
 
 
-def publish_metadata(
+async def publish_metadata(
     subtensor: "bittensor.subtensor",
     wallet: "bittensor.wallet",
     netuid: int,
@@ -217,14 +226,16 @@ def publish_metadata(
 
     wallet.hotkey
 
-    call = subtensor.substrate.compose_call(
+    call = await subtensor.substrate.compose_call(
         call_module="Commitments",
         call_function="set_commitment",
         call_params={"netuid": netuid, "info": {"fields": [[{f"{type_}": data}]]}},
     )
 
-    extrinsic = subtensor.substrate.create_signed_extrinsic(call=call, keypair=wallet.hotkey)
-    response = subtensor.substrate.submit_extrinsic(
+    extrinsic = await subtensor.substrate.create_signed_extrinsic(
+        call=call, keypair=wallet.hotkey
+    )
+    response = await subtensor.substrate.submit_extrinsic(
         extrinsic,
         wait_for_inclusion=wait_for_inclusion,
         wait_for_finalization=wait_for_finalization,
@@ -240,15 +251,22 @@ def publish_metadata(
         raise MetadataError(response.error_message)
 
 
-def get_metadata(self, netuid: int, hotkey: str, block: Optional[int] = None) -> str:
+async def get_metadata(
+    subtensor: "bittensor.Subtensor",
+    netuid: int,
+    hotkey: str,
+    block: Optional[int] = None,
+) -> str:
     @retry(delay=2, tries=3, backoff=2, max_delay=4)
-    def make_substrate_call_with_retry():
-        return self.substrate.query(
+    async def make_substrate_call_with_retry():
+        return await subtensor.substrate.query(
             module="Commitments",
             storage_function="CommitmentOf",
             params=[netuid, hotkey],
-            block_hash=None if block is None else self.substrate.get_block_hash(block),
+            block_hash=None
+            if block is None
+            else await subtensor.substrate.get_block_hash(block),
         )
 
-    commit_data = make_substrate_call_with_retry()
+    commit_data = await make_substrate_call_with_retry()
     return commit_data.value

--- a/bittensor/extrinsics/serving.py
+++ b/bittensor/extrinsics/serving.py
@@ -1,24 +1,34 @@
 # The MIT License (MIT)
 # Copyright © 2021 Yuma Rao
 # Copyright © 2023 Opentensor Foundation
-
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 # documentation files (the “Software”), to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
 # and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
+#
 # The above copyright notice and this permission notice shall be included in all copies or substantial portions of
 # the Software.
-
+#
 # THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
 # THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+
+"""
+This module provides functions for interacting with the Bittensor network, including serving axon endpoints,
+publishing metadata, and performing extrinsics related to network services.
+"""
+
 import json
+from typing import Optional
+
+from retry import retry
+from rich.prompt import Confirm
+
 import bittensor
 import bittensor.utils.networking as net
-from rich.prompt import Confirm
 from ..errors import MetadataError
 
 
@@ -35,36 +45,27 @@ def serve_extrinsic(
     wait_for_finalization=True,
     prompt: bool = False,
 ) -> bool:
-    r"""Subscribes a Bittensor endpoint to the subtensor chain.
+    """Subscribes a Bittensor endpoint to the subtensor chain.
 
     Args:
-        wallet (bittensor.wallet):
-            Bittensor wallet object.
-        ip (str):
-            Endpoint host port i.e., ``192.122.31.4``.
-        port (int):
-            Endpoint port number i.e., ``9221``.
-        protocol (int):
-            An ``int`` representation of the protocol.
-        netuid (int):
-            The network uid to serve on.
-        placeholder1 (int):
-            A placeholder for future use.
-        placeholder2 (int):
-            A placeholder for future use.
-        wait_for_inclusion (bool):
-            If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
-        wait_for_finalization (bool):
-            If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
-        prompt (bool):
-            If ``true``, the call waits for confirmation from the user before proceeding.
+        subtensor (bittensor.subtensor): Bittensor subtensor object.
+        wallet (bittensor.wallet): Bittensor wallet object.
+        ip (str): Endpoint host port i.e., ``192.122.31.4``.
+        port (int): Endpoint port number i.e., ``9221``.
+        protocol (int): An ``int`` representation of the protocol.
+        netuid (int): The network uid to serve on.
+        placeholder1 (int): A placeholder for future use.
+        placeholder2 (int): A placeholder for future use.
+        wait_for_inclusion (bool): If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
+        wait_for_finalization (bool): If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
+        prompt (bool): If ``true``, the call waits for confirmation from the user before proceeding.
+
     Returns:
-        success (bool):
-            Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
+        success (bool): Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
     """
     # Decrypt hotkey
     wallet.hotkey
-    params: "bittensor.AxonServeCallParams" = {
+    params: "subtensor.AxonServeCallParams" = {
         "version": bittensor.__version_as_int__,
         "ip": net.ip_to_int(ip),
         "port": port,
@@ -115,7 +116,7 @@ def serve_extrinsic(
     bittensor.logging.debug(
         f"Serving axon with: AxonInfo({wallet.hotkey.ss58_address},{ip}:{port}) -> {subtensor.network}:{netuid}"
     )
-    success, error_message = subtensor._do_serve_axon(
+    success, error_message = subtensor.do_serve_axon(
         wallet=wallet,
         call_params=params,
         wait_for_finalization=wait_for_finalization,
@@ -123,7 +124,7 @@ def serve_extrinsic(
     )
 
     if wait_for_inclusion or wait_for_finalization:
-        if success == True:
+        if success is True:
             bittensor.logging.debug(
                 f"Axon served with: AxonInfo({wallet.hotkey.ss58_address},{ip}:{port}) on {subtensor.network}:{netuid} "
             )
@@ -145,45 +146,31 @@ def serve_axon_extrinsic(
     wait_for_finalization: bool = True,
     prompt: bool = False,
 ) -> bool:
-    r"""Serves the axon to the network.
+    """Serves the axon to the network.
 
     Args:
-        netuid ( int ):
-            The ``netuid`` being served on.
-        axon (bittensor.Axon):
-            Axon to serve.
-        wait_for_inclusion (bool):
-            If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
-        wait_for_finalization (bool):
-            If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
-        prompt (bool):
-            If ``true``, the call waits for confirmation from the user before proceeding.
+        subtensor (bittensor.subtensor): Bittensor subtensor object.
+        netuid ( int ): The ``netuid`` being served on.
+        axon (bittensor.Axon): Axon to serve.
+        wait_for_inclusion (bool): If set, waits for the extrinsic to enter a block before returning ``true``, or returns ``false`` if the extrinsic fails to enter the block within the timeout.
+        wait_for_finalization (bool): If set, waits for the extrinsic to be finalized on the chain before returning ``true``, or returns ``false`` if the extrinsic fails to be finalized within the timeout.
+        prompt (bool): If ``true``, the call waits for confirmation from the user before proceeding.
+
     Returns:
-        success (bool):
-            Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
+        success (bool): Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
     """
     axon.wallet.hotkey
     axon.wallet.coldkeypub
     external_port = axon.external_port
 
     # ---- Get external ip ----
-    if axon.external_ip == None:
+    if axon.external_ip is None:
         try:
             external_ip = net.get_external_ip()
-            bittensor.__console__.print(
-                ":white_heavy_check_mark: [green]Found external ip: {}[/green]".format(
-                    external_ip
-                )
-            )
-            bittensor.logging.success(
-                prefix="External IP", suffix="<blue>{}</blue>".format(external_ip)
-            )
-        except Exception as E:
-            raise RuntimeError(
-                "Unable to attain your external ip. Check your internet connection. error: {}".format(
-                    E
-                )
-            ) from E
+            bittensor.__console__.print(f":white_heavy_check_mark: [green]Found external ip: {external_ip}[/green]")
+            bittensor.logging.success(prefix="External IP", suffix=f"<blue>{external_ip}</blue>")
+        except Exception as e:
+            raise RuntimeError(f"Unable to attain your external ip. Check your internet connection. error: {e}") from e
     else:
         external_ip = axon.external_ip
 
@@ -204,7 +191,7 @@ def publish_metadata(
     subtensor: "bittensor.subtensor",
     wallet: "bittensor.wallet",
     netuid: int,
-    type: str,
+    type_: str,
     data: bytes,
     wait_for_inclusion: bool = False,
     wait_for_finalization: bool = True,
@@ -213,69 +200,55 @@ def publish_metadata(
     Publishes metadata on the Bittensor network using the specified wallet and network identifier.
 
     Args:
-        subtensor (bittensor.subtensor):
-            The subtensor instance representing the Bittensor blockchain connection.
-        wallet (bittensor.wallet):
-            The wallet object used for authentication in the transaction.
-        netuid (int):
-            Network UID on which the metadata is to be published.
-        type (str):
-            The data type of the information being submitted. It should be one of the following: ``'Sha256'``, ``'Blake256'``, ``'Keccak256'``, or ``'Raw0-128'``. This specifies the format or hashing algorithm used for the data.
-        data (str):
-            The actual metadata content to be published. This should be formatted or hashed according to the ``type`` specified. (Note: max ``str`` length is 128 bytes)
-        wait_for_inclusion (bool, optional):
-            If ``True``, the function will wait for the extrinsic to be included in a block before returning. Defaults to ``False``.
-        wait_for_finalization (bool, optional):
-            If ``True``, the function will wait for the extrinsic to be finalized on the chain before returning. Defaults to ``True``.
+        subtensor (bittensor.subtensor): The subtensor instance representing the Bittensor blockchain connection.
+        wallet (bittensor.wallet): The wallet object used for authentication in the transaction.
+        netuid (int): Network UID on which the metadata is to be published.
+        type_ (str): The data type of the information being submitted. It should be one of the following: ``'Sha256'``, ``'Blake256'``, ``'Keccak256'``, or ``'Raw0-128'``. This specifies the format or hashing algorithm used for the data.
+        data (str): The actual metadata content to be published. This should be formatted or hashed according to the ``type`` specified. (Note: max ``str`` length is 128 bytes)
+        wait_for_inclusion (bool, optional): If ``True``, the function will wait for the extrinsic to be included in a block before returning. Defaults to ``False``.
+        wait_for_finalization (bool, optional): If ``True``, the function will wait for the extrinsic to be finalized on the chain before returning. Defaults to ``True``.
 
     Returns:
-        bool:
-            ``True`` if the metadata was successfully published (and finalized if specified). ``False`` otherwise.
+        bool: ``True`` if the metadata was successfully published (and finalized if specified). ``False`` otherwise.
 
     Raises:
-        MetadataError:
-            If there is an error in submitting the extrinsic or if the response from the blockchain indicates failure.
+        MetadataError: If there is an error in submitting the extrinsic or if the response from the blockchain indicates failure.
     """
 
     wallet.hotkey
 
-    with subtensor.substrate as substrate:
-        call = substrate.compose_call(
-            call_module="Commitments",
-            call_function="set_commitment",
-            call_params={"netuid": netuid, "info": {"fields": [[{f"{type}": data}]]}},
-        )
+    call = subtensor.substrate.compose_call(
+        call_module="Commitments",
+        call_function="set_commitment",
+        call_params={"netuid": netuid, "info": {"fields": [[{f"{type_}": data}]]}},
+    )
 
-        extrinsic = substrate.create_signed_extrinsic(call=call, keypair=wallet.hotkey)
-        response = substrate.submit_extrinsic(
-            extrinsic,
-            wait_for_inclusion=wait_for_inclusion,
-            wait_for_finalization=wait_for_finalization,
-        )
-        # We only wait here if we expect finalization.
-        if not wait_for_finalization and not wait_for_inclusion:
-            return True
-        response.process_events()
-        if response.is_success:
-            return True
-        else:
-            raise MetadataError(response.error_message)
+    extrinsic = subtensor.substrate.create_signed_extrinsic(call=call, keypair=wallet.hotkey)
+    response = subtensor.substrate.submit_extrinsic(
+        extrinsic,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+    )
+    # We only wait here if we expect finalization.
+    if not wait_for_finalization and not wait_for_inclusion:
+        return True
 
-
-from retry import retry
-from typing import Optional
+    response.process_events()
+    if response.is_success:
+        return True
+    else:
+        raise MetadataError(response.error_message)
 
 
 def get_metadata(self, netuid: int, hotkey: str, block: Optional[int] = None) -> str:
     @retry(delay=2, tries=3, backoff=2, max_delay=4)
     def make_substrate_call_with_retry():
-        with self.substrate as substrate:
-            return substrate.query(
-                module="Commitments",
-                storage_function="CommitmentOf",
-                params=[netuid, hotkey],
-                block_hash=None if block == None else substrate.get_block_hash(block),
-            )
+        return self.substrate.query(
+            module="Commitments",
+            storage_function="CommitmentOf",
+            params=[netuid, hotkey],
+            block_hash=None if block is None else self.substrate.get_block_hash(block),
+        )
 
     commit_data = make_substrate_call_with_retry()
     return commit_data.value

--- a/bittensor/extrinsics/set_weights.py
+++ b/bittensor/extrinsics/set_weights.py
@@ -96,7 +96,7 @@ def set_weights_extrinsic(
         ":satellite: Setting weights on [white]{}[/white] ...".format(subtensor.network)
     ):
         try:
-            success, error_message = subtensor._do_set_weights(
+            success, error_message = subtensor.do_set_weights(
                 wallet=wallet,
                 netuid=netuid,
                 uids=weight_uids,

--- a/bittensor/mock/subtensor_mock.py
+++ b/bittensor/mock/subtensor_mock.py
@@ -1459,7 +1459,7 @@ class MockSubtensor(Subtensor):
     ) -> Tuple[bool, Optional[str]]:
         return True, None
 
-    def _do_serve_axon(
+    def do_serve_axon(
         self,
         wallet: "wallet",
         call_params: "AxonServeCallParams",

--- a/bittensor/mock/subtensor_mock.py
+++ b/bittensor/mock/subtensor_mock.py
@@ -1447,7 +1447,7 @@ class MockSubtensor(Subtensor):
     ) -> Tuple[bool, Optional[str]]:
         return True, None
 
-    def _do_set_weights(
+    def do_set_weights(
         self,
         wallet: "wallet",
         netuid: int,

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -2294,7 +2294,7 @@ class Subtensor:
     # Senate #
     ##########
 
-    def register_senate(
+    async def register_senate(
         self,
         wallet: "bittensor.wallet",
         wait_for_inclusion: bool = True,
@@ -2317,11 +2317,11 @@ class Subtensor:
         This function supports flexible stake management, allowing neurons to adjust their network participation
         and potential reward accruals.
         """
-        return register_senate_extrinsic(
+        return await register_senate_extrinsic(
             self, wallet, wait_for_inclusion, wait_for_finalization, prompt
         )
 
-    def leave_senate(
+    async def leave_senate(
         self,
         wallet: "bittensor.wallet",
         wait_for_inclusion: bool = True,
@@ -2344,11 +2344,11 @@ class Subtensor:
         This function supports flexible stake management, allowing neurons to adjust their network participation
         and potential reward accruals.
         """
-        return leave_senate_extrinsic(
+        return await leave_senate_extrinsic(
             self, wallet, wait_for_inclusion, wait_for_finalization, prompt
         )
 
-    def vote_senate(
+    async def vote_senate(
         self,
         wallet: "bittensor.wallet",
         proposal_hash: str,
@@ -2377,7 +2377,7 @@ class Subtensor:
         This function supports flexible stake management, allowing neurons to adjust their network participation
         and potential reward accruals.
         """
-        return vote_senate_extrinsic(
+        return await vote_senate_extrinsic(
             self,
             wallet,
             proposal_hash,

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -1794,7 +1794,7 @@ class Subtensor:
     ###########
     # Serving #
     ###########
-    def serve(
+    async def serve(
         self,
         wallet: "bittensor.wallet",
         ip: str,
@@ -1830,7 +1830,7 @@ class Subtensor:
         This function is essential for establishing the neuron's presence in the network, enabling
         it to participate in the decentralized machine learning processes of Bittensor.
         """
-        return serve_extrinsic(
+        return await serve_extrinsic(
             self,
             wallet,
             ip,
@@ -1843,7 +1843,7 @@ class Subtensor:
             wait_for_finalization,
         )
 
-    def serve_axon(
+    async def serve_axon(
         self,
         netuid: int,
         axon: "bittensor.axon",
@@ -1867,7 +1867,7 @@ class Subtensor:
         By registering an Axon, the neuron becomes an active part of the network's distributed
         computing infrastructure, contributing to the collective intelligence of Bittensor.
         """
-        return serve_axon_extrinsic(
+        return await serve_axon_extrinsic(
             self, netuid, axon, wait_for_inclusion, wait_for_finalization
         )
 
@@ -2776,7 +2776,8 @@ class Subtensor:
         return await make_substrate_call_with_retry()
 
     # Make some commitment on-chain about arbitrary data.
-    def commit(self, wallet, netuid: int, data: str):
+    # TODO: Determine if this is used somewhere?
+    async def commit(self, wallet, netuid: int, data: str):
         """
         Commits arbitrary data to the Bittensor network by publishing metadata.
 
@@ -2785,9 +2786,11 @@ class Subtensor:
             netuid (int): The unique identifier of the subnetwork.
             data (str): The data to be committed to the network.
         """
-        publish_metadata(self, wallet, netuid, f"Raw{len(data)}", data.encode())
+        await publish_metadata(self, wallet, netuid, f"Raw{len(data)}", data.encode())
 
-    def get_commitment(self, netuid: int, uid: int, block: Optional[int] = None) -> str:
+    async def get_commitment(
+        self, netuid: int, uid: int, block: Optional[int] = None
+    ) -> str:
         """
         Retrieves the on-chain commitment for a specific neuron in the Bittensor network.
 
@@ -2800,10 +2803,10 @@ class Subtensor:
         Returns:
             str: The commitment data as a string.
         """
-        metagraph = self.metagraph(netuid)
+        metagraph = await self.metagraph(netuid)
         hotkey = metagraph.hotkeys[uid]  # type: ignore
 
-        metadata = get_metadata(self, netuid, hotkey, block)
+        metadata = await get_metadata(self, netuid, hotkey, block)
         commitment = metadata["info"]["fields"][0]  # type: ignore
         hex_data = commitment[list(commitment.keys())[0]][2:]  # type: ignore
 

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -831,7 +831,7 @@ class Subtensor:
 
         return success, message
 
-    async def _do_set_weights(
+    async def do_set_weights(
         self,
         wallet: "bittensor.wallet",
         uids: List[int],
@@ -2582,7 +2582,7 @@ class Subtensor:
             prompt=prompt,
         )
 
-    async def _do_root_register(
+    async def do_root_register(
         self,
         wallet: "bittensor.wallet",
         wait_for_inclusion: bool = False,

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -2551,7 +2551,7 @@ class Subtensor:
     # Root #
     ########
 
-    def root_register(
+    async def root_register(
         self,
         wallet: "bittensor.wallet",
         wait_for_inclusion: bool = False,
@@ -2574,7 +2574,7 @@ class Subtensor:
         This function enables neurons to engage in the most critical and influential aspects of the network's
         governance, signifying a high level of commitment and responsibility in the Bittensor ecosystem.
         """
-        return root_register_extrinsic(
+        return await root_register_extrinsic(
             subtensor=self,
             wallet=wallet,
             wait_for_inclusion=wait_for_inclusion,
@@ -2620,7 +2620,7 @@ class Subtensor:
         return await make_substrate_call_with_retry()
 
     @legacy_torch_api_compat
-    def root_set_weights(
+    async def root_set_weights(
         self,
         wallet: "bittensor.wallet",
         netuids: Union[NDArray[np.int64], "torch.LongTensor", list],
@@ -2651,7 +2651,7 @@ class Subtensor:
         This function plays a pivotal role in shaping the root network's collective intelligence and decision-making
         processes, reflecting the principles of decentralized governance and collaborative learning in Bittensor.
         """
-        return set_root_weights_extrinsic(
+        return await set_root_weights_extrinsic(
             subtensor=self,
             wallet=wallet,
             netuids=netuids,

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -1871,7 +1871,7 @@ class Subtensor:
             self, netuid, axon, wait_for_inclusion, wait_for_finalization
         )
 
-    async def _do_serve_axon(
+    async def do_serve_axon(
         self,
         wallet: "bittensor.wallet",
         call_params: AxonServeCallParams,

--- a/tests/integration_tests/test_subtensor_integration.py
+++ b/tests/integration_tests/test_subtensor_integration.py
@@ -321,7 +321,7 @@ class TestSubtensor(unittest.TestCase):
                 return True
 
         self.subtensor.set_weights = MagicMock(return_value=True)
-        self.subtensor._do_set_weights = MagicMock(return_value=(True, None))
+        self.subtensor.do_set_weights = MagicMock(return_value=(True, None))
 
         success = self.subtensor.set_weights(
             wallet=self.wallet,
@@ -333,7 +333,7 @@ class TestSubtensor(unittest.TestCase):
 
     def test_set_weights_inclusion(self):
         chain_weights = [0]
-        self.subtensor._do_set_weights = MagicMock(return_value=(True, None))
+        self.subtensor.do_set_weights = MagicMock(return_value=(True, None))
         self.subtensor.set_weights = MagicMock(return_value=True)
 
         success = self.subtensor.set_weights(
@@ -347,7 +347,7 @@ class TestSubtensor(unittest.TestCase):
 
     def test_set_weights_failed(self):
         chain_weights = [0]
-        self.subtensor._do_set_weights = MagicMock(
+        self.subtensor.do_set_weights = MagicMock(
             return_value=(False, "Mock failure message")
         )
         self.subtensor.set_weights = MagicMock(return_value=False)

--- a/tests/unit_tests/extrinsics/test_root.py
+++ b/tests/unit_tests/extrinsics/test_root.py
@@ -86,7 +86,7 @@ def test_root_register_extrinsic(
 
     with patch.object(
         mock_subtensor,
-        "_do_root_register",
+        "do_root_register",
         return_value=(registration_success, "Error registering"),
     ) as mock_register, patch("rich.prompt.Confirm.ask", return_value=user_response):
         # Act
@@ -186,7 +186,7 @@ def test_set_root_weights_extrinsic(
 ):
     # Arrange
     with patch.object(
-        mock_subtensor, "_do_set_weights", return_value=(expected_success, "Mock error")
+        mock_subtensor, "do_set_weights", return_value=(expected_success, "Mock error")
     ), patch.object(
         mock_subtensor, "min_allowed_weights", return_value=0
     ), patch.object(mock_subtensor, "max_weight_limit", return_value=1), patch(

--- a/tests/unit_tests/extrinsics/test_set_weights.py
+++ b/tests/unit_tests/extrinsics/test_set_weights.py
@@ -73,7 +73,7 @@ def test_set_weights_extrinsic(
         return_value=(uids_tensor, weights_tensor),
     ), patch("rich.prompt.Confirm.ask", return_value=user_accepts), patch.object(
         mock_subtensor,
-        "_do_set_weights",
+        "do_set_weights",
         return_value=(expected_success, "Mock error message"),
     ) as mock_do_set_weights:
         result, message = set_weights_extrinsic(


### PR DESCRIPTION
Inclused async migration for:
- `bittensor/extrinsics/root.py`
- `bittensor/extrinsics/senate.py`.
- `bittensor/extrinsics/serving.py`
All of them refactored, has some small bug fixes, and async migrated.

For easy review you can do this via commits.