### PR TITLE
[Fix] Allow unstake below network min

### DIFF
--- a/bittensor/extrinsics/registration.py
+++ b/bittensor/extrinsics/registration.py
@@ -461,6 +461,8 @@ def run_faucet_extrinsic(
                 if attempts == max_allowed_attempts:
                     raise MaxAttemptsException
                 attempts += 1
+                # Wait a bit before trying again
+                time.sleep(1)
 
             # Successful registration
             else:

--- a/bittensor/extrinsics/registration.py
+++ b/bittensor/extrinsics/registration.py
@@ -473,7 +473,7 @@ def run_faucet_extrinsic(
                 if successes == 3:
                     raise MaxSuccessException
 
-                attempts = 1 # Reset attempts on success
+                attempts = 1  # Reset attempts on success
                 successes += 1
 
         except KeyboardInterrupt:

--- a/bittensor/extrinsics/registration.py
+++ b/bittensor/extrinsics/registration.py
@@ -472,6 +472,8 @@ def run_faucet_extrinsic(
 
                 if successes == 3:
                     raise MaxSuccessException
+
+                attempts = 1 # Reset attempts on success
                 successes += 1
 
         except KeyboardInterrupt:

--- a/bittensor/extrinsics/staking.py
+++ b/bittensor/extrinsics/staking.py
@@ -207,7 +207,7 @@ def add_stake_extrinsic(
                 block = subtensor.get_current_block()
                 new_stake = subtensor.get_stake_for_coldkey_and_hotkey(
                     coldkey_ss58=wallet.coldkeypub.ss58_address,
-                    hotkey_ss58=wallet.hotkey.ss58_address,
+                    hotkey_ss58=hotkey_ss58,
                     block=block,
                 )  # Get current stake
 

--- a/bittensor/extrinsics/staking.py
+++ b/bittensor/extrinsics/staking.py
@@ -115,6 +115,9 @@ def add_stake_extrinsic(
             coldkey_ss58=wallet.coldkeypub.ss58_address, hotkey_ss58=hotkey_ss58
         )
 
+        # Grab the existential deposit.
+        existential_deposit = subtensor.get_existential_deposit()
+
     # Convert to bittensor.Balance
     if amount is None:
         # Stake it all.
@@ -124,9 +127,10 @@ def add_stake_extrinsic(
     else:
         staking_balance = amount
 
-    # Remove existential balance to keep key alive.
-    if staking_balance > bittensor.Balance.from_rao(1000):
-        staking_balance = staking_balance - bittensor.Balance.from_rao(1000)
+    # Leave existential balance to keep key alive.
+    if staking_balance > old_balance - existential_deposit:
+        # If we are staking all, we need to leave at least the existential deposit.
+        staking_balance = old_balance - existential_deposit
     else:
         staking_balance = staking_balance
 

--- a/bittensor/extrinsics/staking.py
+++ b/bittensor/extrinsics/staking.py
@@ -19,8 +19,32 @@
 import bittensor
 from rich.prompt import Confirm
 from time import sleep
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Tuple
 from bittensor.utils.balance import Balance
+
+
+def _check_threshold_amount(
+    subtensor: "bittensor.subtensor", stake_balance: Balance
+) -> Tuple[bool, Balance]:
+    """
+    Checks if the new stake balance will be above the minimum required stake threshold.
+
+    Args:
+        stake_balance (Balance):
+            the balance to check for threshold limits.
+
+    Returns:
+        success, threshold (bool, Balance):
+            ``true`` if the staking balance is above the threshold, or ``false`` if the
+                staking balance is below the threshold.
+            The threshold balance required to stake.
+    """
+    min_req_stake: Balance = subtensor.get_minimum_required_stake()
+
+    if min_req_stake > stake_balance:
+        return False, min_req_stake
+    else:
+        return True, min_req_stake
 
 
 def add_stake_extrinsic(
@@ -114,6 +138,18 @@ def add_stake_extrinsic(
             )
         )
         return False
+
+    # If nominating, we need to check if the new stake balance will be above the minimum required stake threshold.
+    if not own_hotkey:
+        new_stake_balance = old_stake + staking_balance
+        is_above_threshold, threshold = _check_threshold_amount(
+            subtensor, new_stake_balance
+        )
+        if not is_above_threshold:
+            bittensor.__console__.print(
+                f":cross_mark: [red]New stake balance of {new_stake_balance} is below the minimum required nomination stake threshold {threshold}.[/red]"
+            )
+            return False
 
     # Ask before moving on.
     if prompt:

--- a/bittensor/extrinsics/unstaking.py
+++ b/bittensor/extrinsics/unstaking.py
@@ -163,7 +163,10 @@ def unstake_extrinsic(
     if not check_threshold_amount(
         subtensor=subtensor, stake_balance=(stake_on_uid - unstaking_balance)
     ):
-        return False
+        bittensor.__console__.print(
+            f":warning: [yellow]This action will unstake the entire staked balance![/yellow]"
+        )
+        unstaking_balance = stake_on_uid
 
     # Ask before moving on.
     if prompt:
@@ -339,7 +342,10 @@ def unstake_multiple_extrinsic(
         if not check_threshold_amount(
             subtensor=subtensor, stake_balance=(stake_on_uid - unstaking_balance)
         ):
-            return False
+            bittensor.__console__.print(
+                f":warning: [yellow]This action will unstake the entire staked balance![/yellow]"
+            )
+            unstaking_balance = stake_on_uid
 
         # Ask before moving on.
         if prompt:

--- a/bittensor/extrinsics/unstaking.py
+++ b/bittensor/extrinsics/unstaking.py
@@ -72,13 +72,13 @@ def __do_remove_stake_single(
 
 
 def check_threshold_amount(
-    subtensor: "bittensor.subtensor", unstaking_balance: Balance
+    subtensor: "bittensor.subtensor", stake_balance: Balance
 ) -> bool:
     """
-    Checks if the unstaking amount is above the threshold or 0
+    Checks if the remaining stake balance is above the minimum required stake threshold.
 
     Args:
-        unstaking_balance (Balance):
+        stake_balance (Balance):
             the balance to check for threshold limits.
 
     Returns:
@@ -88,9 +88,9 @@ def check_threshold_amount(
     """
     min_req_stake: Balance = subtensor.get_minimum_required_stake()
 
-    if min_req_stake > unstaking_balance > 0:
+    if min_req_stake > stake_balance > 0:
         bittensor.__console__.print(
-            f":cross_mark: [red]Unstaking balance of {unstaking_balance} less than minimum of {min_req_stake} TAO[/red]"
+            f":cross_mark: [yellow]Remaining stake balance of {stake_balance} less than minimum of {min_req_stake} TAO[/yellow]"
         )
         return False
     else:
@@ -161,7 +161,7 @@ def unstake_extrinsic(
         return False
 
     if not check_threshold_amount(
-        subtensor=subtensor, unstaking_balance=unstaking_balance
+        subtensor=subtensor, stake_balance=(stake_on_uid - unstaking_balance)
     ):
         return False
 
@@ -337,7 +337,7 @@ def unstake_multiple_extrinsic(
             continue
 
         if not check_threshold_amount(
-            subtensor=subtensor, unstaking_balance=unstaking_balance
+            subtensor=subtensor, stake_balance=(stake_on_uid - unstaking_balance)
         ):
             return False
 

--- a/tests/e2e_tests/multistep/test_dendrite.py
+++ b/tests/e2e_tests/multistep/test_dendrite.py
@@ -90,7 +90,7 @@ async def test_dendrite(local_chain):
     metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945")
     neuron = metagraph.neurons[0]
     # assert stake is 10000
-    assert neuron.stake.tao == 9999.999999
+    assert neuron.stake.tao == 10_000.0
 
     # assert neuron is not validator
     assert neuron.active is True

--- a/tests/e2e_tests/multistep/test_incentive.py
+++ b/tests/e2e_tests/multistep/test_incentive.py
@@ -287,7 +287,7 @@ async def test_incentive(local_chain):
     alice_neuron = metagraph.neurons[0]
     assert alice_neuron.validator_permit is True
     assert alice_neuron.dividends == 1
-    assert alice_neuron.stake.tao == 9999.999999
+    assert alice_neuron.stake.tao == 10_000.0
     assert alice_neuron.validator_trust == 1
 
 

--- a/tests/e2e_tests/multistep/test_incentive.py
+++ b/tests/e2e_tests/multistep/test_incentive.py
@@ -252,7 +252,7 @@ async def test_incentive(local_chain):
     alice_neuron = metagraph.neurons[0]
     assert alice_neuron.validator_permit is False
     assert alice_neuron.dividends == 0
-    assert alice_neuron.stake.tao == 9999.999999
+    assert alice_neuron.stake.tao == 10_000.0
     assert alice_neuron.validator_trust == 0
 
     # wait until 360 blocks pass (subnet tempo)

--- a/tests/e2e_tests/subcommands/weights/test_commit_weights.py
+++ b/tests/e2e_tests/subcommands/weights/test_commit_weights.py
@@ -61,7 +61,7 @@ def test_commit_and_reveal_weights(local_chain):
             "--wallet.path",
             "/tmp/btcli-wallet2",
             "--amount",
-            "999998998",
+            "100000",
         ],
     )
 

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -2693,9 +2693,7 @@ def test_set_identity_command(
         "bittensor.wallet", return_value=mock_wallet
     ), patch("bittensor.__console__", MagicMock()), patch(
         "rich.prompt.Prompt.ask", side_effect=["y", "y"]
-    ), patch(
-        "sys.exit"
-    ) as mock_exit:
+    ), patch("sys.exit") as mock_exit:
         # Act
         if expected_exception:
             with pytest.raises(expected_exception) as exc_info:

--- a/tests/unit_tests/extrinsics/test_staking.py
+++ b/tests/unit_tests/extrinsics/test_staking.py
@@ -114,9 +114,6 @@ def test_add_stake_extrinsic(
             else amount
         )
 
-    if staking_balance > bittensor.Balance.from_rao(1000):
-        staking_balance = staking_balance - bittensor.Balance.from_rao(1000)
-
     with patch.object(
         mock_subtensor, "_do_stake", return_value=expected_success
     ) as mock_add_stake, patch.object(
@@ -135,7 +132,20 @@ def test_add_stake_extrinsic(
         mock_subtensor, "is_hotkey_delegate", return_value=hotkey_delegate
     ), patch.object(mock_subtensor, "get_delegate_take", return_value=0.01), patch(
         "rich.prompt.Confirm.ask", return_value=user_accepts
-    ) as mock_confirm:
+    ) as mock_confirm, patch.object(
+        mock_subtensor,
+        "get_minimum_required_stake",
+        return_value=bittensor.Balance.from_tao(0.01),
+    ), patch.object(
+        mock_subtensor,
+        "get_existential_deposit",
+        return_value=bittensor.Balance.from_rao(100_000),
+    ):
+        mock_balance = mock_subtensor.get_balance()
+        existential_deposit = mock_subtensor.get_existential_deposit()
+        if staking_balance > mock_balance - existential_deposit:
+            staking_balance = mock_balance - existential_deposit
+
         # Act
         if not hotkey_owner and not hotkey_delegate:
             with pytest.raises(exception):

--- a/tests/unit_tests/extrinsics/test_unstaking.py
+++ b/tests/unit_tests/extrinsics/test_unstaking.py
@@ -39,8 +39,8 @@ def mock_get_minimum_required_stake():
         ("5FHneW46...", 10.0, True, True, True, False, False, False),
         # Not enough stake to unstake
         ("5FHneW46...", 1000.0, True, True, False, None, False, False),
-        # Unsuccessful - unstake threshold not reached
-        (None, 0.01, True, True, False, None, False, False),
+        # Successful - unstake threshold not reached
+        (None, 0.01, True, True, False, None, True, True),
         # Successful unstaking all
         (None, None, False, False, False, None, True, True),
         # Failure - unstaking failed
@@ -51,7 +51,7 @@ def mock_get_minimum_required_stake():
         "successful-with-prompt",
         "failure-prompt-declined",
         "failure-not-enough-stake",
-        "failure-threshold-not-reached",
+        "success-threshold-not-reached",
         "success-unstake-all",
         "failure-unstake-failed",
     ],
@@ -166,18 +166,20 @@ def test_unstake_extrinsic(
             None,
             None,
         ),
-        # Unsuccessful unstake - threshold not reached
+        # Successful unstake - new stake below threshold
         (
             ["5FHneW46..."],
-            [0.01],
+            [
+                100 - mock_get_minimum_required_stake() + 0.01
+            ],  # New stake just below threshold
             100,
             True,
             True,
             False,
             True,
-            [None],
-            False,
-            0,
+            [True],
+            True,  # Sucessful unstake
+            1,
             None,
             None,
         ),
@@ -247,7 +249,7 @@ def test_unstake_extrinsic(
         "partial-success-one-fail",
         "success-no-hotkey",
         "failure-not-enough-stake",
-        "failure-threshold-not-reached",
+        "success-threshold-not-reached",
         "failure-prompt-declined",
         "failure-type-error-hotkeys",
         "failure-value-error-amounts",


### PR DESCRIPTION
<!--

### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.

-->

### Bug

<!-- Link to the issue describing the bug that you're fixing. -->
This fixes an errant exit when trying to unstake an amount that is below the minimum required stake on-chain.

### Description of the Change

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

- The code will now check if the *remaining balance* is below the aforementioned minimum (rather than the amount to unstake), and only for nominated stakes.
- The code will now only emit a warning message, instead unstaking all staked balance, as expected since opentensor/subtensor/pull/462
- The code will now check the threshold when attempting to stake, to reduce failed extrinsics

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions?
Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->
- Wrote some CLI tests
- Tested with btcli on testnet

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
Allow unstake below network minimum