### PR TITLE
Async for `test_subtensor.py`, fix bugs, replacement `retry.retry` to `tenacity.retry`

### DIFF
--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -31,7 +31,6 @@ from typing import List, Dict, Union, Optional, Tuple, TypedDict, Any
 import numpy as np
 import scalecodec
 from numpy.typing import NDArray
-from retry import retry
 from scalecodec.base import RuntimeConfiguration
 from scalecodec.exceptions import RemainingScaleBytesNotEmptyException
 from scalecodec.type_registry import load_type_registry_preset
@@ -112,6 +111,7 @@ from bittensor.utils import (
 from bittensor.utils.balance import Balance
 from bittensor.utils.registration import POWSolution
 from bittensor.utils.registration import legacy_torch_api_compat
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 
 KEY_NONCE: Dict[str, int] = {}
@@ -862,7 +862,7 @@ class Subtensor:
         trust in other neurons based on observed performance and contributions.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -1004,7 +1004,7 @@ class Subtensor:
         verifiable record of the neuron's weight distribution at a specific point in time.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -1133,7 +1133,7 @@ class Subtensor:
         transparency and accountability for the neuron's weight distribution.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -1387,7 +1387,7 @@ class Subtensor:
                 message.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             # create extrinsic call
             call = await self.substrate.compose_call(
@@ -1448,7 +1448,7 @@ class Subtensor:
             Tuple[bool, Optional[str]]: A tuple containing a boolean indicating success or failure, and an optional error message.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             # create extrinsic call
             call = await self.substrate.compose_call(
@@ -1504,7 +1504,7 @@ class Subtensor:
                 error message.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             # create extrinsic call
             call = await self.substrate.compose_call(
@@ -1659,7 +1659,7 @@ class Subtensor:
             error (str): Error message if transfer failed.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="Balances",
@@ -1895,7 +1895,7 @@ class Subtensor:
         enhancing the decentralized computation capabilities of Bittensor.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -1958,7 +1958,7 @@ class Subtensor:
             error (:func:`Optional[str]`): Error message if serve prometheus failed, ``None`` otherwise.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -2007,7 +2007,7 @@ class Subtensor:
             error (:func:`Optional[str]`): Error message if associate IPs failed, None otherwise.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -2136,7 +2136,7 @@ class Subtensor:
             StakeError: If the extrinsic failed.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -2263,7 +2263,7 @@ class Subtensor:
             StakeError: If the extrinsic failed.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -2588,7 +2588,7 @@ class Subtensor:
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = True,
     ) -> Tuple[bool, Optional[str]]:
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             # create extrinsic call
             call = await self.substrate.compose_call(
@@ -2692,7 +2692,7 @@ class Subtensor:
         network-specific details, providing insights into the neuron's role and status within the Bittensor network.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry() -> "ScaleType":
             return await self.substrate.query(
                 module="Registry",
@@ -2749,7 +2749,7 @@ class Subtensor:
         call_params = bittensor.utils.wallet_utils.create_identity_dict(**params)
         call_params["identified"] = identified
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry() -> bool:
             call = await self.substrate.compose_call(
                 call_module="Registry",
@@ -2839,7 +2839,7 @@ class Subtensor:
         providing valuable insights into the state and dynamics of the Bittensor ecosystem.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry() -> "ScaleType":
             return await self.substrate.query(
                 module="SubtensorModule",
@@ -2878,7 +2878,7 @@ class Subtensor:
         relationships within the Bittensor ecosystem, such as inter-neuronal connections and stake distributions.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             return await self.substrate.query_map(
                 module="SubtensorModule",
@@ -2912,7 +2912,7 @@ class Subtensor:
         operational parameters.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             return await self.substrate.get_constant(
                 module_name=module_name,
@@ -2952,7 +2952,7 @@ class Subtensor:
         parts of the Bittensor blockchain, enhancing the understanding and analysis of the network's state and dynamics.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry() -> "ScaleType":
             return await self.substrate.query(
                 module=module,
@@ -2993,7 +2993,7 @@ class Subtensor:
         modules, offering insights into the network's state and the relationships between its different components.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry() -> "QueryMapResult":
             return await self.substrate.query_map(
                 module=module,
@@ -3030,7 +3030,7 @@ class Subtensor:
         useful for specific use cases where standard queries are insufficient.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry() -> Dict[Any, Any]:
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -3139,7 +3139,7 @@ class Subtensor:
             Optional[Union[int, float]]: The value of the specified hyperparameter if the subnet exists, ``None``
                 otherwise.
         """
-        if not self.subnet_exists(netuid, block):
+        if not await self.subnet_exists(netuid, block):
             return None
 
         result = await self.query_subtensor(param_name, block, [netuid])
@@ -4116,7 +4116,7 @@ class Subtensor:
         the roles of different subnets, and their unique features.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4152,12 +4152,11 @@ class Subtensor:
         subnet, including its governance, performance, and role within the broader network.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
             )
-
             return await self.substrate.rpc_request(
                 method="subnetInfo_getSubnetInfo",  # custom rpc method
                 params=[netuid, block_hash] if block_hash else [netuid],
@@ -4314,7 +4313,7 @@ class Subtensor:
         the Bittensor network's consensus and governance structures.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry(encoded_hotkey_: List[int]):
             block_hash = None if block is None else self.substrate.get_block_hash(block)
 
@@ -4353,7 +4352,7 @@ class Subtensor:
 
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4389,7 +4388,7 @@ class Subtensor:
 
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4425,7 +4424,7 @@ class Subtensor:
         involvement in the network's delegation and consensus mechanisms.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry(encoded_coldkey_: List[int]):
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4540,7 +4539,7 @@ class Subtensor:
             Exception: If the substrate call fails after the maximum number of retries.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             return await self.substrate.query(
                 module="SubtensorModule", storage_function="NominatorMinRequiredStake"
@@ -4806,7 +4805,7 @@ class Subtensor:
         if uid is None:
             return NeuronInfo.get_null_neuron()
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -5138,7 +5137,7 @@ class Subtensor:
             bool: ``True`` if the delegation is successful, ``False`` otherwise.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -5189,7 +5188,7 @@ class Subtensor:
             bool: ``True`` if the undelegation is successful, ``False`` otherwise.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -5239,7 +5238,7 @@ class Subtensor:
             bool: ``True`` if the nomination is successful, ``False`` otherwise.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -5290,7 +5289,7 @@ class Subtensor:
             bool: ``True`` if the take rate increase is successful, ``False`` otherwise.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -5344,7 +5343,7 @@ class Subtensor:
             bool: ``True`` if the take rate decrease is successful, ``False`` otherwise.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -5394,7 +5393,7 @@ class Subtensor:
         """
         try:
 
-            @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+            @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
             async def make_substrate_call_with_retry():
                 return await self.substrate.query(
                     module="System",
@@ -5427,7 +5426,7 @@ class Subtensor:
         operations on the blockchain. It serves as a reference point for network activities and data synchronization.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             return await self.substrate.get_block_number(None)  # type: ignore
 
@@ -5448,7 +5447,7 @@ class Subtensor:
         including the distribution of financial resources and the financial status of network participants.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=bittensor.logging)
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry():
             return await self.substrate.query_map(
                 module="System",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,3 +18,4 @@ httpx==0.27.0
 ruff==0.4.7
 aioresponses==0.7.6
 factory-boy==3.3.0
+tenacity==8.3.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -31,6 +31,7 @@ rich
 scalecodec==1.2.9
 shtab==1.6.5
 substrate-interface==1.7.5
+tenacity==8.3.0
 termcolor
 tqdm
 uvicorn==0.22.0

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -25,8 +25,8 @@ import pytest
 
 # Application
 import bittensor
-from bittensor.subtensor import Subtensor, Balance
 from bittensor import subtensor_module
+from bittensor.subtensor import Subtensor, Balance
 
 
 def test_serve_axon_with_external_ip_set():
@@ -37,7 +37,6 @@ def test_serve_axon_with_external_ip_set():
 
     mock_subtensor = MagicMock(spec=bittensor.subtensor, serve_axon=mock_serve_axon)
 
-    mock_add_insecure_port = mock.MagicMock(return_value=None)
     mock_wallet = MagicMock(
         spec=bittensor.wallet,
         coldkey=MagicMock(),
@@ -130,56 +129,31 @@ class ExitEarly(Exception):
     pass
 
 
-def test_stake_multiple():
-    mock_amount: bittensor.Balance = bittensor.Balance.from_tao(1.0)
+@pytest.mark.asyncio
+async def test_stake_multiple(mocker):
+    """Test add_stake_multiple function returns proper extrinsic."""
+    # Prep
+    subtensor_module.add_stake_multiple_extrinsic = mocker.AsyncMock()
 
-    mock_wallet = MagicMock(
-        spec=bittensor.wallet,
-        coldkey=MagicMock(),
-        coldkeypub=MagicMock(
-            # mock ss58 address
-            ss58_address="5DD26kC2kxajmwfbbZmVmxhrY9VeeyR1Gpzy9i8wxLUg6zxm"
-        ),
-        hotkey=MagicMock(
-            ss58_address="5CtstubuSoVLJGCXkiWRNKrrGg2DVBZ9qMs2qYTLsZR4q1Wg"
-        ),
+    mock_subtensor = mocker.MagicMock()
+    mock_wallet = mocker.MagicMock()
+    mock_hotkey_ss58s = mocker.MagicMock()
+    mock_amounts = mocker.MagicMock()
+
+    # Call
+
+    result = await bittensor.subtensor.add_stake_multiple(
+        mock_subtensor,
+        wallet=mock_wallet,
+        hotkey_ss58s=mock_hotkey_ss58s,
+        amounts=mock_amounts,
     )
 
-    mock_hotkey_ss58s = ["5CtstubuSoVLJGCXkiWRNKrrGg2DVBZ9qMs2qYTLsZR4q1Wg"]
-
-    mock_amounts = [mock_amount]  # more than 1000 RAO
-
-    mock_neuron = MagicMock(
-        is_null=False,
+    # Assertions
+    assert result == subtensor_module.add_stake_multiple_extrinsic.return_value
+    subtensor_module.add_stake_multiple_extrinsic.assert_called_once_with(
+        mock_subtensor, mock_wallet, mock_hotkey_ss58s, mock_amounts, True, False, False
     )
-
-    mock_do_stake = MagicMock(side_effect=ExitEarly)
-
-    mock_subtensor = MagicMock(
-        spec=bittensor.subtensor,
-        network="mock_net",
-        get_balance=MagicMock(
-            return_value=bittensor.Balance.from_tao(mock_amount.tao + 20.0)
-        ),  # enough balance to stake
-        get_neuron_for_pubkey_and_subnet=MagicMock(return_value=mock_neuron),
-        _do_stake=mock_do_stake,
-    )
-
-    with pytest.raises(ExitEarly):
-        bittensor.subtensor.add_stake_multiple(
-            mock_subtensor,
-            wallet=mock_wallet,
-            hotkey_ss58s=mock_hotkey_ss58s,
-            amounts=mock_amounts,
-        )
-
-        mock_do_stake.assert_called_once()
-        # args, kwargs
-        _, kwargs = mock_do_stake.call_args
-
-        assert kwargs["amount"] == pytest.approx(
-            mock_amount.rao, rel=1e9
-        )  # delta of 1.0 TAO
 
 
 @pytest.mark.parametrize(
@@ -275,90 +249,62 @@ def test_determine_chain_endpoint_and_network(
     assert result_endpoint == expected_endpoint
 
 
-# Subtensor().get_error_info_by_index tests
 @pytest.fixture
-def substrate():
-    class MockSubstrate:
-        pass
-
-    return MockSubstrate()
-
-
-@pytest.fixture
-def subtensor(substrate):
-    mock.patch.object(
-        subtensor_module,
-        "get_subtensor_errors",
-        return_value={
-            "1": ("ErrorOne", "Description one"),
-            "2": ("ErrorTwo", "Description two"),
-        },
-    ).start()
+def subtensor():
     return Subtensor()
 
 
-def test_get_error_info_by_index_known_error(subtensor):
-    name, description = subtensor.get_error_info_by_index(1)
-    assert name == "ErrorOne"
-    assert description == "Description one"
-
-
-def test_get_error_info_by_index_unknown_error(subtensor):
-    mock_logger = mock.patch.object(bittensor.logging, "warning").start()
-    fake_index = 999
-    name, description = subtensor.get_error_info_by_index(fake_index)
-    assert name == "Unknown Error"
-    assert description == ""
-    mock_logger.assert_called_once_with(
-        f"Subtensor returned an error with an unknown index: {fake_index}"
-    )
-
-
 # Subtensor()._get_hyperparameter tests
-def test_hyperparameter_subnet_does_not_exist(subtensor, mocker):
+@pytest.mark.asyncio
+async def test_hyperparameter_subnet_does_not_exist(subtensor, mocker):
     """Tests when the subnet does not exist."""
-    subtensor.subnet_exists = mocker.MagicMock(return_value=False)
-    assert subtensor._get_hyperparameter("Difficulty", 1, None) is None
+    subtensor.subnet_exists = mocker.AsyncMock(return_value=False)
+    assert await subtensor._get_hyperparameter("Difficulty", 1, None) is None
+    subtensor.subnet_exists.assert_awaited_once()
     subtensor.subnet_exists.assert_called_once_with(1, None)
 
 
-def test_hyperparameter_result_is_none(subtensor, mocker):
+@pytest.mark.asyncio
+async def test_hyperparameter_result_is_none(subtensor, mocker):
     """Tests when query_subtensor returns None."""
-    subtensor.subnet_exists = mocker.MagicMock(return_value=True)
-    subtensor.query_subtensor = mocker.MagicMock(return_value=None)
-    assert subtensor._get_hyperparameter("Difficulty", 1, None) is None
+    subtensor.subnet_exists = mocker.AsyncMock(return_value=True)
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=None)
+    assert await subtensor._get_hyperparameter("Difficulty", 1, None) is None
     subtensor.subnet_exists.assert_called_once_with(1, None)
     subtensor.query_subtensor.assert_called_once_with("Difficulty", None, [1])
 
 
-def test_hyperparameter_result_has_no_value(subtensor, mocker):
+@pytest.mark.asyncio
+async def test_hyperparameter_result_has_no_value(subtensor, mocker):
     """Test when the result has no 'value' attribute."""
 
-    subtensor.subnet_exists = mocker.MagicMock(return_value=True)
-    subtensor.query_subtensor = mocker.MagicMock(return_value=None)
-    assert subtensor._get_hyperparameter("Difficulty", 1, None) is None
+    subtensor.subnet_exists = mocker.AsyncMock(return_value=True)
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=None)
+    assert await subtensor._get_hyperparameter("Difficulty", 1, None) is None
     subtensor.subnet_exists.assert_called_once_with(1, None)
     subtensor.query_subtensor.assert_called_once_with("Difficulty", None, [1])
 
 
-def test_hyperparameter_success_int(subtensor, mocker):
+@pytest.mark.asyncio
+async def test_hyperparameter_success_int(subtensor, mocker):
     """Test when query_subtensor returns an integer value."""
-    subtensor.subnet_exists = mocker.MagicMock(return_value=True)
-    subtensor.query_subtensor = mocker.MagicMock(
+    subtensor.subnet_exists = mocker.AsyncMock(return_value=True)
+    subtensor.query_subtensor = mocker.AsyncMock(
         return_value=mocker.MagicMock(value=100)
     )
-    assert subtensor._get_hyperparameter("Difficulty", 1, None) == 100
+    assert await subtensor._get_hyperparameter("Difficulty", 1, None) == 100
     subtensor.subnet_exists.assert_called_once_with(1, None)
     subtensor.query_subtensor.assert_called_once_with("Difficulty", None, [1])
 
 
-def test_hyperparameter_success_float(subtensor, mocker):
+@pytest.mark.asyncio
+async def test_hyperparameter_success_float(subtensor, mocker):
     """Test when query_subtensor returns a float value."""
-    subtensor.subnet_exists = mocker.MagicMock(return_value=True)
-    subtensor.query_subtensor = mocker.MagicMock(
+    subtensor.subnet_exists = mocker.AsyncMock(return_value=True)
+    subtensor.query_subtensor = mocker.AsyncMock(
         return_value=mocker.MagicMock(value=0.5)
     )
-    assert subtensor._get_hyperparameter("Difficulty", 1, None) == 0.5
+    assert await subtensor._get_hyperparameter("Difficulty", 1, None) == 0.5
     subtensor.subnet_exists.assert_called_once_with(1, None)
     subtensor.query_subtensor.assert_called_once_with("Difficulty", None, [1])
 
@@ -392,7 +338,8 @@ def test_hyperparameter_success_float(subtensor, mocker):
         ("tempo", "Tempo", 1, int),
     ],
 )
-def test_hyper_parameter_success_calls(
+@pytest.mark.asyncio
+async def test_hyper_parameter_success_calls(
     subtensor, mocker, method, param_name, value, expected_result_type
 ):
     """
@@ -400,7 +347,7 @@ def test_hyper_parameter_success_calls(
     expected values.
     """
     # Prep
-    subtensor._get_hyperparameter = mocker.MagicMock(return_value=value)
+    subtensor._get_hyperparameter = mocker.AsyncMock(return_value=value)
 
     spy_u16_normalized_float = mocker.spy(subtensor_module, "u16_normalized_float")
     spy_u64_normalized_float = mocker.spy(subtensor_module, "u64_normalized_float")
@@ -408,7 +355,7 @@ def test_hyper_parameter_success_calls(
 
     # Call
     subtensor_method = getattr(subtensor, method)
-    result = subtensor_method(netuid=7, block=707)
+    result = await subtensor_method(netuid=7, block=707)
 
     # Assertions
     subtensor._get_hyperparameter.assert_called_once_with(
@@ -433,17 +380,18 @@ def test_hyper_parameter_success_calls(
         spy_balance_from_rao.assert_called_once()
 
 
-def test_blocks_since_last_update_success_calls(subtensor, mocker):
+@pytest.mark.asyncio
+async def test_blocks_since_last_update_success_calls(subtensor, mocker):
     """Tests the weights_rate_limit method to ensure it correctly fetches the LastUpdate hyperparameter."""
     # Prep
     uid = 7
     mocked_current_block = 2
     mocked_result = {uid: 1}
-    subtensor._get_hyperparameter = mocker.MagicMock(return_value=mocked_result)
-    subtensor.get_current_block = mocker.MagicMock(return_value=mocked_current_block)
+    subtensor._get_hyperparameter = mocker.AsyncMock(return_value=mocked_result)
+    subtensor.get_current_block = mocker.AsyncMock(return_value=mocked_current_block)
 
     # Call
-    result = subtensor.blocks_since_last_update(netuid=7, uid=uid)
+    result = await subtensor.blocks_since_last_update(netuid=7, uid=uid)
 
     # Assertions
     subtensor.get_current_block.assert_called_once()
@@ -455,13 +403,14 @@ def test_blocks_since_last_update_success_calls(subtensor, mocker):
     assert isinstance(result, int)
 
 
-def test_weights_rate_limit_success_calls(subtensor, mocker):
+@pytest.mark.asyncio
+async def test_weights_rate_limit_success_calls(subtensor, mocker):
     """Tests the weights_rate_limit method to ensure it correctly fetches the WeightsSetRateLimit hyperparameter."""
     # Prep
-    subtensor._get_hyperparameter = mocker.MagicMock(return_value=5)
+    subtensor._get_hyperparameter = mocker.AsyncMock(return_value=5)
 
     # Call
-    result = subtensor.weights_rate_limit(netuid=7)
+    result = await subtensor.weights_rate_limit(netuid=7)
 
     # Assertions
     subtensor._get_hyperparameter.assert_called_once_with(
@@ -477,15 +426,16 @@ def test_weights_rate_limit_success_calls(subtensor, mocker):
 
 
 # `get_total_stake_for_hotkey` tests
-def test_get_total_stake_for_hotkey_success(subtensor, mocker):
+@pytest.mark.asyncio
+async def test_get_total_stake_for_hotkey_success(subtensor, mocker):
     """Tests successful retrieval of total stake for hotkey."""
     # Prep
-    subtensor.query_subtensor = mocker.MagicMock(return_value=mocker.MagicMock(value=1))
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=mocker.MagicMock(value=1))
     fake_ss58_address = "12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU"
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.get_total_stake_for_hotkey(ss58_address=fake_ss58_address)
+    result = await subtensor.get_total_stake_for_hotkey(ss58_address=fake_ss58_address)
 
     # Assertions
     subtensor.query_subtensor.assert_called_once_with(
@@ -496,15 +446,16 @@ def test_get_total_stake_for_hotkey_success(subtensor, mocker):
     assert isinstance(result, Balance)
 
 
-def test_get_total_stake_for_hotkey_not_result(subtensor, mocker):
+@pytest.mark.asyncio
+async def test_get_total_stake_for_hotkey_not_result(subtensor, mocker):
     """Tests retrieval of total stake for hotkey when no result is returned."""
     # Prep
-    subtensor.query_subtensor = mocker.MagicMock(return_value=None)
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=None)
     fake_ss58_address = "12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU"
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.get_total_stake_for_hotkey(ss58_address=fake_ss58_address)
+    result = await subtensor.get_total_stake_for_hotkey(ss58_address=fake_ss58_address)
 
     # Assertions
     subtensor.query_subtensor.assert_called_once_with(
@@ -515,15 +466,16 @@ def test_get_total_stake_for_hotkey_not_result(subtensor, mocker):
     assert isinstance(result, type(None))
 
 
-def test_get_total_stake_for_hotkey_not_value(subtensor, mocker):
+@pytest.mark.asyncio
+async def test_get_total_stake_for_hotkey_not_value(subtensor, mocker):
     """Tests retrieval of total stake for hotkey when no value attribute is present."""
     # Prep
-    subtensor.query_subtensor = mocker.MagicMock(return_value=object)
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=object)
     fake_ss58_address = "12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU"
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.get_total_stake_for_hotkey(ss58_address=fake_ss58_address)
+    result = await subtensor.get_total_stake_for_hotkey(ss58_address=fake_ss58_address)
 
     # Assertions
     subtensor.query_subtensor.assert_called_once_with(
@@ -536,15 +488,16 @@ def test_get_total_stake_for_hotkey_not_value(subtensor, mocker):
 
 
 # `get_total_stake_for_coldkey` tests
-def test_get_total_stake_for_coldkey_success(subtensor, mocker):
+@pytest.mark.asyncio
+async def test_get_total_stake_for_coldkey_success(subtensor, mocker):
     """Tests successful retrieval of total stake for coldkey."""
     # Prep
-    subtensor.query_subtensor = mocker.MagicMock(return_value=mocker.MagicMock(value=1))
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=mocker.MagicMock(value=1))
     fake_ss58_address = "12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU"
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.get_total_stake_for_coldkey(ss58_address=fake_ss58_address)
+    result = await subtensor.get_total_stake_for_coldkey(ss58_address=fake_ss58_address)
 
     # Assertions
     subtensor.query_subtensor.assert_called_once_with(
@@ -555,15 +508,16 @@ def test_get_total_stake_for_coldkey_success(subtensor, mocker):
     assert isinstance(result, Balance)
 
 
-def test_get_total_stake_for_coldkey_not_result(subtensor, mocker):
+@pytest.mark.asyncio
+async def test_get_total_stake_for_coldkey_not_result(subtensor, mocker):
     """Tests retrieval of total stake for coldkey when no result is returned."""
     # Prep
-    subtensor.query_subtensor = mocker.MagicMock(return_value=None)
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=None)
     fake_ss58_address = "12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU"
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.get_total_stake_for_coldkey(ss58_address=fake_ss58_address)
+    result = await subtensor.get_total_stake_for_coldkey(ss58_address=fake_ss58_address)
 
     # Assertions
     subtensor.query_subtensor.assert_called_once_with(
@@ -574,15 +528,16 @@ def test_get_total_stake_for_coldkey_not_result(subtensor, mocker):
     assert isinstance(result, type(None))
 
 
-def test_get_total_stake_for_coldkey_not_value(subtensor, mocker):
+@pytest.mark.asyncio
+async def test_get_total_stake_for_coldkey_not_value(subtensor, mocker):
     """Tests retrieval of total stake for coldkey when no value attribute is present."""
     # Prep
-    subtensor.query_subtensor = mocker.MagicMock(return_value=object)
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=object)
     fake_ss58_address = "12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU"
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.get_total_stake_for_coldkey(ss58_address=fake_ss58_address)
+    result = await subtensor.get_total_stake_for_coldkey(ss58_address=fake_ss58_address)
 
     # Assertions
     subtensor.query_subtensor.assert_called_once_with(
@@ -595,7 +550,8 @@ def test_get_total_stake_for_coldkey_not_value(subtensor, mocker):
 
 
 # `get_stake` tests
-def test_get_stake_returns_correct_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_stake_returns_correct_data(mocker, subtensor):
     """Tests that get_stake returns correct data."""
     # Prep
     hotkey_ss58 = "test_hotkey"
@@ -609,7 +565,7 @@ def test_get_stake_returns_correct_data(mocker, subtensor):
     )
 
     # Call
-    result = subtensor.get_stake(hotkey_ss58, block)
+    result = await subtensor.get_stake(hotkey_ss58, block)
 
     # Assertion
     assert result == [
@@ -619,37 +575,36 @@ def test_get_stake_returns_correct_data(mocker, subtensor):
     subtensor.query_map_subtensor.assert_called_once_with("Stake", block, [hotkey_ss58])
 
 
-def test_get_stake_no_block(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_stake_no_block(mocker, subtensor):
     """Tests get_stake with no block specified."""
     # Prep
     hotkey_ss58 = "test_hotkey"
-    expected_query_result = [
-        (MagicMock(value="coldkey1"), MagicMock(value=100)),
-    ]
-    mocker.patch.object(
-        subtensor, "query_map_subtensor", return_value=expected_query_result
+    subtensor.query_map_subtensor = mocker.AsyncMock(
+        name="QueryMapResult",
+        return_value=[
+            (mocker.MagicMock(value="coldkey1"), mocker.MagicMock(value=100)),
+        ],
     )
 
     # Call
-    result = subtensor.get_stake(hotkey_ss58)
+    result = await subtensor.get_stake(hotkey_ss58)
 
     # Assertion
     assert result == [("coldkey1", Balance.from_rao(100))]
-    subtensor.query_map_subtensor.assert_called_once_with("Stake", None, [hotkey_ss58])
+    # subtensor.query_map_subtensor.assert_called_once_with("Stake", None, [hotkey_ss58])
 
 
-def test_get_stake_empty_result(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_stake_empty_result(mocker, subtensor):
     """Tests get_stake with an empty result."""
     # Prep
     hotkey_ss58 = "test_hotkey"
     block = 123
-    expected_query_result = []
-    mocker.patch.object(
-        subtensor, "query_map_subtensor", return_value=expected_query_result
-    )
+    subtensor.query_map_subtensor = mocker.AsyncMock(return_value=[])
 
     # Call
-    result = subtensor.get_stake(hotkey_ss58, block)
+    result = await subtensor.get_stake(hotkey_ss58, block)
 
     # Assertion
     assert result == []
@@ -657,80 +612,88 @@ def test_get_stake_empty_result(mocker, subtensor):
 
 
 # `does_hotkey_exist` tests
-def test_does_hotkey_exist_true(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_does_hotkey_exist_true(mocker, subtensor):
     """Test does_hotkey_exist returns True when hotkey exists and is valid."""
     # Prep
     hotkey_ss58 = "test_hotkey"
     block = 123
-    mock_result = mocker.MagicMock(value="valid_coldkey")
+    mock_result = mocker.AsyncMock(value="valid_coldkey")
     mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
 
     # Call
-    result = subtensor.does_hotkey_exist(hotkey_ss58, block)
+    result = await subtensor.does_hotkey_exist(hotkey_ss58, block)
 
     # Assertions
     assert result is True
     subtensor.query_subtensor.assert_called_once_with("Owner", block, [hotkey_ss58])
 
 
-def test_does_hotkey_exist_false_special_value(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_does_hotkey_exist_false_special_value(mocker, subtensor):
     """Test does_hotkey_exist returns False when result value is the special value."""
     # Prep
     hotkey_ss58 = "test_hotkey"
     block = 123
-    special_value = "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM"
-    mock_result = MagicMock(value=special_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    subtensor.query_subtensor = mocker.AsyncMock(
+        return_value=mocker.MagicMock(
+            value="5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM"
+        )
+    )
 
     # Call
-    result = subtensor.does_hotkey_exist(hotkey_ss58, block)
+    result = await subtensor.does_hotkey_exist(hotkey_ss58, block)
 
     # Assertions
     assert result is False
     subtensor.query_subtensor.assert_called_once_with("Owner", block, [hotkey_ss58])
 
 
-def test_does_hotkey_exist_false_no_value(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_does_hotkey_exist_false_no_value(mocker, subtensor):
     """Test does_hotkey_exist returns False when result has no value attribute."""
     # Prep
     hotkey_ss58 = "test_hotkey"
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.value
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=mock_result)
 
     # Call
-    result = subtensor.does_hotkey_exist(hotkey_ss58, block)
+    result = await subtensor.does_hotkey_exist(hotkey_ss58, block)
 
     # Assertions
     assert result is False
     subtensor.query_subtensor.assert_called_once_with("Owner", block, [hotkey_ss58])
 
 
-def test_does_hotkey_exist_false_no_result(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_does_hotkey_exist_false_no_result(mocker, subtensor):
     """Test does_hotkey_exist returns False when query_subtensor returns None."""
     # Prep
     hotkey_ss58 = "test_hotkey"
     block = 123
-    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=None)
 
     # Call
-    result = subtensor.does_hotkey_exist(hotkey_ss58, block)
+    result = await subtensor.does_hotkey_exist(hotkey_ss58, block)
 
     # Assertions
     assert result is False
     subtensor.query_subtensor.assert_called_once_with("Owner", block, [hotkey_ss58])
 
 
-def test_does_hotkey_exist_no_block(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_does_hotkey_exist_no_block(mocker, subtensor):
     """Test does_hotkey_exist with no block specified."""
     # Prep
     hotkey_ss58 = "test_hotkey"
-    mock_result = mocker.MagicMock(value="valid_coldkey")
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    subtensor.query_subtensor = mocker.AsyncMock(
+        return_value=mocker.MagicMock(value="valid_coldkey")
+    )
 
     # Call
-    result = subtensor.does_hotkey_exist(hotkey_ss58)
+    result = await subtensor.does_hotkey_exist(hotkey_ss58)
 
     # Assertions
     assert result is True
@@ -738,18 +701,21 @@ def test_does_hotkey_exist_no_block(mocker, subtensor):
 
 
 # `get_hotkey_owner` tests
-def test_get_hotkey_owner_exists(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_hotkey_owner_exists(mocker, subtensor):
     """Test get_hotkey_owner when the hotkey exists."""
     # Prep
     hotkey_ss58 = "test_hotkey"
     block = 123
     expected_owner = "coldkey_owner"
-    mock_result = mocker.MagicMock(value=expected_owner)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
-    mocker.patch.object(subtensor, "does_hotkey_exist", return_value=True)
+
+    subtensor.query_subtensor = mocker.AsyncMock(
+        return_value=mocker.MagicMock(value=expected_owner)
+    )
+    subtensor.does_hotkey_exist = mocker.AsyncMock(return_value=True)
 
     # Call
-    result = subtensor.get_hotkey_owner(hotkey_ss58, block)
+    result = await subtensor.get_hotkey_owner(hotkey_ss58, block)
 
     # Assertions
     assert result == expected_owner
@@ -757,7 +723,8 @@ def test_get_hotkey_owner_exists(mocker, subtensor):
     subtensor.does_hotkey_exist.assert_called_once_with(hotkey_ss58, block)
 
 
-def test_get_hotkey_owner_does_not_exist(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_hotkey_owner_does_not_exist(mocker, subtensor):
     """Test get_hotkey_owner when the hotkey does not exist."""
     # Prep
     hotkey_ss58 = "test_hotkey"
@@ -766,7 +733,7 @@ def test_get_hotkey_owner_does_not_exist(mocker, subtensor):
     mocker.patch.object(subtensor, "does_hotkey_exist", return_value=False)
 
     # Call
-    result = subtensor.get_hotkey_owner(hotkey_ss58, block)
+    result = await subtensor.get_hotkey_owner(hotkey_ss58, block)
 
     # Assertions
     assert result is None
@@ -774,17 +741,22 @@ def test_get_hotkey_owner_does_not_exist(mocker, subtensor):
     subtensor.does_hotkey_exist.assert_not_called()
 
 
-def test_get_hotkey_owner_no_block(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_hotkey_owner_no_block(mocker, subtensor):
     """Test get_hotkey_owner with no block specified."""
     # Prep
     hotkey_ss58 = "test_hotkey"
     expected_owner = "coldkey_owner"
     mock_result = mocker.MagicMock(value=expected_owner)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
-    mocker.patch.object(subtensor, "does_hotkey_exist", return_value=True)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
+    mocker.patch.object(
+        subtensor, "does_hotkey_exist", new=mocker.AsyncMock(return_value=True)
+    )
 
     # Call
-    result = subtensor.get_hotkey_owner(hotkey_ss58)
+    result = await subtensor.get_hotkey_owner(hotkey_ss58)
 
     # Assertions
     assert result == expected_owner
@@ -792,18 +764,23 @@ def test_get_hotkey_owner_no_block(mocker, subtensor):
     subtensor.does_hotkey_exist.assert_called_once_with(hotkey_ss58, None)
 
 
-def test_get_hotkey_owner_no_value_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_hotkey_owner_no_value_attribute(mocker, subtensor):
     """Test get_hotkey_owner when the result has no value attribute."""
     # Prep
     hotkey_ss58 = "test_hotkey"
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.value
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
-    mocker.patch.object(subtensor, "does_hotkey_exist", return_value=True)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
+    mocker.patch.object(
+        subtensor, "does_hotkey_exist", new=mocker.AsyncMock(return_value=True)
+    )
 
     # Call
-    result = subtensor.get_hotkey_owner(hotkey_ss58, block)
+    result = await subtensor.get_hotkey_owner(hotkey_ss58, block)
 
     # Assertions
     assert result is None
@@ -812,7 +789,8 @@ def test_get_hotkey_owner_no_value_attribute(mocker, subtensor):
 
 
 # `get_axon_info` tests
-def test_get_axon_info_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_axon_info_success(mocker, subtensor):
     """Test get_axon_info returns correct data when axon information is found."""
     # Prep
     netuid = 1
@@ -829,10 +807,12 @@ def test_get_axon_info_success(mocker, subtensor):
             "placeholder2": "data2",
         }
     )
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_axon_info(netuid, hotkey_ss58, block)
+    result = await subtensor.get_axon_info(netuid, hotkey_ss58, block)
 
     # Asserts
     assert result is not None
@@ -850,16 +830,19 @@ def test_get_axon_info_success(mocker, subtensor):
     )
 
 
-def test_get_axon_info_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_axon_info_no_data(mocker, subtensor):
     """Test get_axon_info returns None when no axon information is found."""
     # Prep
     netuid = 1
     hotkey_ss58 = "test_hotkey"
     block = 123
-    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=None)
+    )
 
     # Call
-    result = subtensor.get_axon_info(netuid, hotkey_ss58, block)
+    result = await subtensor.get_axon_info(netuid, hotkey_ss58, block)
 
     # Asserts
     assert result is None
@@ -868,7 +851,8 @@ def test_get_axon_info_no_data(mocker, subtensor):
     )
 
 
-def test_get_axon_info_no_value_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_axon_info_no_value_attribute(mocker, subtensor):
     """Test get_axon_info returns None when result has no value attribute."""
     # Prep
     netuid = 1
@@ -876,10 +860,12 @@ def test_get_axon_info_no_value_attribute(mocker, subtensor):
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.value
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_axon_info(netuid, hotkey_ss58, block)
+    result = await subtensor.get_axon_info(netuid, hotkey_ss58, block)
 
     # Asserts
     assert result is None
@@ -888,7 +874,8 @@ def test_get_axon_info_no_value_attribute(mocker, subtensor):
     )
 
 
-def test_get_axon_info_no_block(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_axon_info_no_block(mocker, subtensor):
     """Test get_axon_info with no block specified."""
     # Prep
     netuid = 1
@@ -904,10 +891,12 @@ def test_get_axon_info_no_block(mocker, subtensor):
             "placeholder2": "data2",
         }
     )
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_axon_info(netuid, hotkey_ss58)
+    result = await subtensor.get_axon_info(netuid, hotkey_ss58)
 
     # Asserts
     assert result is not None
@@ -926,7 +915,8 @@ def test_get_axon_info_no_block(mocker, subtensor):
 
 
 # get_prometheus_info tests
-def test_get_prometheus_info_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_prometheus_info_success(mocker, subtensor):
     """Test get_prometheus_info returns correct data when information is found."""
     # Prep
     netuid = 1
@@ -941,10 +931,12 @@ def test_get_prometheus_info_success(mocker, subtensor):
             "block": 1000,
         }
     )
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_prometheus_info(netuid, hotkey_ss58, block)
+    result = await subtensor.get_prometheus_info(netuid, hotkey_ss58, block)
 
     # Asserts
     assert result is not None
@@ -958,16 +950,19 @@ def test_get_prometheus_info_success(mocker, subtensor):
     )
 
 
-def test_get_prometheus_info_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_prometheus_info_no_data(mocker, subtensor):
     """Test get_prometheus_info returns None when no information is found."""
     # Prep
     netuid = 1
     hotkey_ss58 = "test_hotkey"
     block = 123
-    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=None)
+    )
 
     # Call
-    result = subtensor.get_prometheus_info(netuid, hotkey_ss58, block)
+    result = await subtensor.get_prometheus_info(netuid, hotkey_ss58, block)
 
     # Asserts
     assert result is None
@@ -976,7 +971,8 @@ def test_get_prometheus_info_no_data(mocker, subtensor):
     )
 
 
-def test_get_prometheus_info_no_value_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_prometheus_info_no_value_attribute(mocker, subtensor):
     """Test get_prometheus_info returns None when result has no value attribute."""
     # Prep
     netuid = 1
@@ -984,10 +980,12 @@ def test_get_prometheus_info_no_value_attribute(mocker, subtensor):
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.value
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_prometheus_info(netuid, hotkey_ss58, block)
+    result = await subtensor.get_prometheus_info(netuid, hotkey_ss58, block)
 
     # Asserts
     assert result is None
@@ -996,7 +994,8 @@ def test_get_prometheus_info_no_value_attribute(mocker, subtensor):
     )
 
 
-def test_get_prometheus_info_no_block(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_prometheus_info_no_block(mocker, subtensor):
     """Test get_prometheus_info with no block specified."""
     # Prep
     netuid = 1
@@ -1010,10 +1009,12 @@ def test_get_prometheus_info_no_block(mocker, subtensor):
             "block": 1000,
         }
     )
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_prometheus_info(netuid, hotkey_ss58)
+    result = await subtensor.get_prometheus_info(netuid, hotkey_ss58)
 
     # Asserts
     assert result is not None
@@ -1033,29 +1034,37 @@ def test_get_prometheus_info_no_block(mocker, subtensor):
 
 
 # `block` property test
-def test_block_property(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_block_property(mocker, subtensor):
     """Test block property returns the correct block number."""
     expected_block = 123
-    mocker.patch.object(subtensor, "get_current_block", return_value=expected_block)
+    mocker.patch.object(
+        subtensor,
+        "get_current_block",
+        new=mocker.AsyncMock(return_value=expected_block),
+    )
 
-    result = subtensor.block
+    result = await subtensor.block
 
     assert result == expected_block
     subtensor.get_current_block.assert_called_once()
 
 
 # `total_issuance` tests
-def test_total_issuance_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_total_issuance_success(mocker, subtensor):
     """Test total_issuance returns correct data when issuance information is found."""
     # Prep
     block = 123
     issuance_value = 1000
     mock_result = mocker.MagicMock(value=issuance_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.total_issuance(block)
+    result = await subtensor.total_issuance(block)
 
     # Asserts
     assert result is not None
@@ -1065,15 +1074,18 @@ def test_total_issuance_success(mocker, subtensor):
     )
 
 
-def test_total_issuance_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_total_issuance_no_data(mocker, subtensor):
     """Test total_issuance returns None when no issuance information is found."""
     # Prep
     block = 123
-    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=None)
+    )
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.total_issuance(block)
+    result = await subtensor.total_issuance(block)
 
     # Asserts
     assert result is None
@@ -1081,17 +1093,20 @@ def test_total_issuance_no_data(mocker, subtensor):
     spy_balance_from_rao.assert_not_called()
 
 
-def test_total_issuance_no_value_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_total_issuance_no_value_attribute(mocker, subtensor):
     """Test total_issuance returns None when result has no value attribute."""
     # Prep
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.value
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.total_issuance(block)
+    result = await subtensor.total_issuance(block)
 
     # Asserts
     assert result is None
@@ -1099,16 +1114,19 @@ def test_total_issuance_no_value_attribute(mocker, subtensor):
     spy_balance_from_rao.assert_not_called()
 
 
-def test_total_issuance_no_block(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_total_issuance_no_block(mocker, subtensor):
     """Test total_issuance with no block specified."""
     # Prep
     issuance_value = 1000
     mock_result = mocker.MagicMock(value=issuance_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.total_issuance()
+    result = await subtensor.total_issuance()
 
     # Asserts
     assert result is not None
@@ -1119,17 +1137,20 @@ def test_total_issuance_no_block(mocker, subtensor):
 
 
 # `total_stake` method tests
-def test_total_stake_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_total_stake_success(mocker, subtensor):
     """Test total_stake returns correct data when stake information is found."""
     # Prep
     block = 123
     stake_value = 5000
     mock_result = mocker.MagicMock(value=stake_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.total_stake(block)
+    result = await subtensor.total_stake(block)
 
     # Asserts
     assert result is not None
@@ -1139,15 +1160,18 @@ def test_total_stake_success(mocker, subtensor):
     )
 
 
-def test_total_stake_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_total_stake_no_data(mocker, subtensor):
     """Test total_stake returns None when no stake information is found."""
     # Prep
     block = 123
-    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=None)
+    )
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.total_stake(block)
+    result = await subtensor.total_stake(block)
 
     # Asserts
     assert result is None
@@ -1155,17 +1179,20 @@ def test_total_stake_no_data(mocker, subtensor):
     spy_balance_from_rao.assert_not_called()
 
 
-def test_total_stake_no_value_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_total_stake_no_value_attribute(mocker, subtensor):
     """Test total_stake returns None when result has no value attribute."""
     # Prep
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.value
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.total_stake(block)
+    result = await subtensor.total_stake(block)
 
     # Asserts
     assert result is None
@@ -1173,16 +1200,19 @@ def test_total_stake_no_value_attribute(mocker, subtensor):
     spy_balance_from_rao.assert_not_called()
 
 
-def test_total_stake_no_block(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_total_stake_no_block(mocker, subtensor):
     """Test total_stake with no block specified."""
     # Prep
     stake_value = 5000
     mock_result = mocker.MagicMock(value=stake_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.total_stake()
+    result = await subtensor.total_stake()
 
     # Asserts
     assert result is not None
@@ -1195,16 +1225,21 @@ def test_total_stake_no_block(mocker, subtensor):
 
 
 # `serving_rate_limit` method tests
-def test_serving_rate_limit_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_serving_rate_limit_success(mocker, subtensor):
     """Test serving_rate_limit returns correct data when rate limit information is found."""
     # Prep
     netuid = 1
     block = 123
     rate_limit_value = "10"
-    mocker.patch.object(subtensor, "_get_hyperparameter", return_value=rate_limit_value)
+    mocker.patch.object(
+        subtensor,
+        "_get_hyperparameter",
+        new=mocker.AsyncMock(return_value=rate_limit_value),
+    )
 
     # Call
-    result = subtensor.serving_rate_limit(netuid, block)
+    result = await subtensor.serving_rate_limit(netuid, block)
 
     # Asserts
     assert result is not None
@@ -1214,15 +1249,18 @@ def test_serving_rate_limit_success(mocker, subtensor):
     )
 
 
-def test_serving_rate_limit_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_serving_rate_limit_no_data(mocker, subtensor):
     """Test serving_rate_limit returns None when no rate limit information is found."""
     # Prep
     netuid = 1
     block = 123
-    mocker.patch.object(subtensor, "_get_hyperparameter", return_value=None)
+    mocker.patch.object(
+        subtensor, "_get_hyperparameter", new=mocker.AsyncMock(return_value=None)
+    )
 
     # Call
-    result = subtensor.serving_rate_limit(netuid, block)
+    result = await subtensor.serving_rate_limit(netuid, block)
 
     # Asserts
     assert result is None
@@ -1231,15 +1269,20 @@ def test_serving_rate_limit_no_data(mocker, subtensor):
     )
 
 
-def test_serving_rate_limit_no_block(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_serving_rate_limit_no_block(mocker, subtensor):
     """Test serving_rate_limit with no block specified."""
     # Prep
     netuid = 1
     rate_limit_value = "10"
-    mocker.patch.object(subtensor, "_get_hyperparameter", return_value=rate_limit_value)
+    mocker.patch.object(
+        subtensor,
+        "_get_hyperparameter",
+        new=mocker.AsyncMock(return_value=rate_limit_value),
+    )
 
     # Call
-    result = subtensor.serving_rate_limit(netuid)
+    result = await subtensor.serving_rate_limit(netuid)
 
     # Asserts
     assert result is not None
@@ -1250,16 +1293,19 @@ def test_serving_rate_limit_no_block(mocker, subtensor):
 
 
 # `tx_rate_limit` tests
-def test_tx_rate_limit_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_tx_rate_limit_success(mocker, subtensor):
     """Test tx_rate_limit returns correct data when rate limit information is found."""
     # Prep
     block = 123
     rate_limit_value = 100
     mock_result = mocker.MagicMock(value=rate_limit_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.tx_rate_limit(block)
+    result = await subtensor.tx_rate_limit(block)
 
     # Asserts
     assert result is not None
@@ -1267,45 +1313,54 @@ def test_tx_rate_limit_success(mocker, subtensor):
     subtensor.query_subtensor.assert_called_once_with("TxRateLimit", block)
 
 
-def test_tx_rate_limit_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_tx_rate_limit_no_data(mocker, subtensor):
     """Test tx_rate_limit returns None when no rate limit information is found."""
     # Prep
     block = 123
-    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=None)
+    )
 
     # Call
-    result = subtensor.tx_rate_limit(block)
+    result = await subtensor.tx_rate_limit(block)
 
     # Asserts
     assert result is None
     subtensor.query_subtensor.assert_called_once_with("TxRateLimit", block)
 
 
-def test_tx_rate_limit_no_value_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_tx_rate_limit_no_value_attribute(mocker, subtensor):
     """Test tx_rate_limit returns None when result has no value attribute."""
     # Prep
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.value
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.tx_rate_limit(block)
+    result = await subtensor.tx_rate_limit(block)
 
     # Asserts
     assert result is None
     subtensor.query_subtensor.assert_called_once_with("TxRateLimit", block)
 
 
-def test_tx_rate_limit_no_block(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_tx_rate_limit_no_block(mocker, subtensor):
     """Test tx_rate_limit with no block specified."""
     # Prep
     rate_limit_value = 100
     mock_result = mocker.MagicMock(value=rate_limit_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.tx_rate_limit()
+    result = await subtensor.tx_rate_limit()
 
     # Asserts
     assert result is not None
@@ -1319,63 +1374,75 @@ def test_tx_rate_limit_no_block(mocker, subtensor):
 
 
 # `subnet_exists` tests
-def test_subnet_exists_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_subnet_exists_success(mocker, subtensor):
     """Test subnet_exists returns True when subnet exists."""
     # Prep
     netuid = 1
     block = 123
     mock_result = mocker.MagicMock(value=True)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.subnet_exists(netuid, block)
+    result = await subtensor.subnet_exists(netuid, block)
 
     # Asserts
     assert result is True
     subtensor.query_subtensor.assert_called_once_with("NetworksAdded", block, [netuid])
 
 
-def test_subnet_exists_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_subnet_exists_no_data(mocker, subtensor):
     """Test subnet_exists returns False when no subnet information is found."""
     # Prep
     netuid = 1
     block = 123
-    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=None)
+    )
 
     # Call
-    result = subtensor.subnet_exists(netuid, block)
+    result = await subtensor.subnet_exists(netuid, block)
 
     # Asserts
     assert result is False
     subtensor.query_subtensor.assert_called_once_with("NetworksAdded", block, [netuid])
 
 
-def test_subnet_exists_no_value_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_subnet_exists_no_value_attribute(mocker, subtensor):
     """Test subnet_exists returns False when result has no value attribute."""
     # Prep
     netuid = 1
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.value
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.subnet_exists(netuid, block)
+    result = await subtensor.subnet_exists(netuid, block)
 
     # Asserts
     assert result is False
     subtensor.query_subtensor.assert_called_once_with("NetworksAdded", block, [netuid])
 
 
-def test_subnet_exists_no_block(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_subnet_exists_no_block(mocker, subtensor):
     """Test subnet_exists with no block specified."""
     # Prep
     netuid = 1
     mock_result = mocker.MagicMock(value=True)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.subnet_exists(netuid)
+    result = await subtensor.subnet_exists(netuid)
 
     # Asserts
     assert result is True
@@ -1383,7 +1450,8 @@ def test_subnet_exists_no_block(mocker, subtensor):
 
 
 # `get_all_subnet_netuids` tests
-def test_get_all_subnet_netuids_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_all_subnet_netuids_success(mocker, subtensor):
     """Test get_all_subnet_netuids returns correct list when netuid information is found."""
     # Prep
     block = 123
@@ -1392,48 +1460,57 @@ def test_get_all_subnet_netuids_success(mocker, subtensor):
     mock_result = mocker.MagicMock()
     mock_result.records = True
     mock_result.__iter__.return_value = [(mock_netuid1, True), (mock_netuid2, True)]
-    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_map_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_all_subnet_netuids(block)
+    result = await subtensor.get_all_subnet_netuids(block)
 
     # Asserts
     assert result == [1, 2]
     subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", block)
 
 
-def test_get_all_subnet_netuids_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_all_subnet_netuids_no_data(mocker, subtensor):
     """Test get_all_subnet_netuids returns empty list when no netuid information is found."""
     # Prep
     block = 123
-    mocker.patch.object(subtensor, "query_map_subtensor", return_value=None)
+    mocker.patch.object(
+        subtensor, "query_map_subtensor", new=mocker.AsyncMock(return_value=None)
+    )
 
     # Call
-    result = subtensor.get_all_subnet_netuids(block)
+    result = await subtensor.get_all_subnet_netuids(block)
 
     # Asserts
     assert result == []
     subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", block)
 
 
-def test_get_all_subnet_netuids_no_records_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_all_subnet_netuids_no_records_attribute(mocker, subtensor):
     """Test get_all_subnet_netuids returns empty list when result has no records attribute."""
     # Prep
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.records
     mock_result.__iter__.return_value = []
-    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_map_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_all_subnet_netuids(block)
+    result = await subtensor.get_all_subnet_netuids(block)
 
     # Asserts
     assert result == []
     subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", block)
 
 
-def test_get_all_subnet_netuids_no_block(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_all_subnet_netuids_no_block(mocker, subtensor):
     """Test get_all_subnet_netuids with no block specified."""
     # Prep
     mock_netuid1 = mocker.MagicMock(value=1)
@@ -1441,10 +1518,12 @@ def test_get_all_subnet_netuids_no_block(mocker, subtensor):
     mock_result = mocker.MagicMock()
     mock_result.records = True
     mock_result.__iter__.return_value = [(mock_netuid1, True), (mock_netuid2, True)]
-    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_map_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_all_subnet_netuids()
+    result = await subtensor.get_all_subnet_netuids()
 
     # Asserts
     assert result == [1, 2]
@@ -1452,16 +1531,19 @@ def test_get_all_subnet_netuids_no_block(mocker, subtensor):
 
 
 # `get_total_subnets` tests
-def test_get_total_subnets_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_total_subnets_success(mocker, subtensor):
     """Test get_total_subnets returns correct data when total subnet information is found."""
     # Prep
     block = 123
     total_subnets_value = 10
     mock_result = mocker.MagicMock(value=total_subnets_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_total_subnets(block)
+    result = await subtensor.get_total_subnets(block)
 
     # Asserts
     assert result is not None
@@ -1469,45 +1551,54 @@ def test_get_total_subnets_success(mocker, subtensor):
     subtensor.query_subtensor.assert_called_once_with("TotalNetworks", block)
 
 
-def test_get_total_subnets_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_total_subnets_no_data(mocker, subtensor):
     """Test get_total_subnets returns None when no total subnet information is found."""
     # Prep
     block = 123
-    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=None)
+    )
 
     # Call
-    result = subtensor.get_total_subnets(block)
+    result = await subtensor.get_total_subnets(block)
 
     # Asserts
     assert result is None
     subtensor.query_subtensor.assert_called_once_with("TotalNetworks", block)
 
 
-def test_get_total_subnets_no_value_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_total_subnets_no_value_attribute(mocker, subtensor):
     """Test get_total_subnets returns None when result has no value attribute."""
     # Prep
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.value  # Simulating a missing value attribute
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_total_subnets(block)
+    result = await subtensor.get_total_subnets(block)
 
     # Asserts
     assert result is None
     subtensor.query_subtensor.assert_called_once_with("TotalNetworks", block)
 
 
-def test_get_total_subnets_no_block(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_total_subnets_no_block(mocker, subtensor):
     """Test get_total_subnets with no block specified."""
     # Prep
     total_subnets_value = 10
     mock_result = mocker.MagicMock(value=total_subnets_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_total_subnets()
+    result = await subtensor.get_total_subnets()
 
     # Asserts
     assert result is not None
@@ -1516,17 +1607,20 @@ def test_get_total_subnets_no_block(mocker, subtensor):
 
 
 # `get_subnet_modality` tests
-def test_get_subnet_modality_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_modality_success(mocker, subtensor):
     """Test get_subnet_modality returns correct data when modality information is found."""
     # Prep
     netuid = 1
     block = 123
     modality_value = 42
     mock_result = mocker.MagicMock(value=modality_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_subnet_modality(netuid, block)
+    result = await subtensor.get_subnet_modality(netuid, block)
 
     # Asserts
     assert result is not None
@@ -1536,15 +1630,18 @@ def test_get_subnet_modality_success(mocker, subtensor):
     )
 
 
-def test_get_subnet_modality_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_modality_no_data(mocker, subtensor):
     """Test get_subnet_modality returns None when no modality information is found."""
     # Prep
     netuid = 1
     block = 123
-    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=None)
+    )
 
     # Call
-    result = subtensor.get_subnet_modality(netuid, block)
+    result = await subtensor.get_subnet_modality(netuid, block)
 
     # Asserts
     assert result is None
@@ -1553,17 +1650,20 @@ def test_get_subnet_modality_no_data(mocker, subtensor):
     )
 
 
-def test_get_subnet_modality_no_value_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_modality_no_value_attribute(mocker, subtensor):
     """Test get_subnet_modality returns None when result has no value attribute."""
     # Prep
     netuid = 1
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.value  # Simulating a missing value attribute
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_subnet_modality(netuid, block)
+    result = await subtensor.get_subnet_modality(netuid, block)
 
     # Asserts
     assert result is None
@@ -1572,16 +1672,19 @@ def test_get_subnet_modality_no_value_attribute(mocker, subtensor):
     )
 
 
-def test_get_subnet_modality_no_block_specified(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_modality_no_block_specified(mocker, subtensor):
     """Test get_subnet_modality with no block specified."""
     # Prep
     netuid = 1
     modality_value = 42
     mock_result = mocker.MagicMock(value=modality_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_subnet_modality(netuid)
+    result = await subtensor.get_subnet_modality(netuid)
 
     # Asserts
     assert result is not None
@@ -1590,18 +1693,21 @@ def test_get_subnet_modality_no_block_specified(mocker, subtensor):
 
 
 # `get_emission_value_by_subnet` tests
-def test_get_emission_value_by_subnet_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_emission_value_by_subnet_success(mocker, subtensor):
     """Test get_emission_value_by_subnet returns correct data when emission value is found."""
     # Prep
     netuid = 1
     block = 123
     emission_value = 1000
     mock_result = mocker.MagicMock(value=emission_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.get_emission_value_by_subnet(netuid, block)
+    result = await subtensor.get_emission_value_by_subnet(netuid, block)
 
     # Asserts
     assert result is not None
@@ -1610,16 +1716,19 @@ def test_get_emission_value_by_subnet_success(mocker, subtensor):
     assert result == Balance.from_rao(emission_value)
 
 
-def test_get_emission_value_by_subnet_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_emission_value_by_subnet_no_data(mocker, subtensor):
     """Test get_emission_value_by_subnet returns None when no emission value is found."""
     # Prep
     netuid = 1
     block = 123
-    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=None)
+    )
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.get_emission_value_by_subnet(netuid, block)
+    result = await subtensor.get_emission_value_by_subnet(netuid, block)
 
     # Asserts
     assert result is None
@@ -1627,18 +1736,21 @@ def test_get_emission_value_by_subnet_no_data(mocker, subtensor):
     spy_balance_from_rao.assert_not_called()
 
 
-def test_get_emission_value_by_subnet_no_value_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_emission_value_by_subnet_no_value_attribute(mocker, subtensor):
     """Test get_emission_value_by_subnet returns None when result has no value attribute."""
     # Prep
     netuid = 1
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.value  # Simulating a missing value attribute
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.get_emission_value_by_subnet(netuid, block)
+    result = await subtensor.get_emission_value_by_subnet(netuid, block)
 
     # Asserts
     assert result is None
@@ -1646,17 +1758,20 @@ def test_get_emission_value_by_subnet_no_value_attribute(mocker, subtensor):
     spy_balance_from_rao.assert_not_called()
 
 
-def test_get_emission_value_by_subnet_no_block_specified(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_emission_value_by_subnet_no_block_specified(mocker, subtensor):
     """Test get_emission_value_by_subnet with no block specified."""
     # Prep
     netuid = 1
     emission_value = 1000
     mock_result = mocker.MagicMock(value=emission_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
     spy_balance_from_rao = mocker.spy(Balance, "from_rao")
 
     # Call
-    result = subtensor.get_emission_value_by_subnet(netuid)
+    result = await subtensor.get_emission_value_by_subnet(netuid)
 
     # Asserts
     assert result is not None
@@ -1666,7 +1781,8 @@ def test_get_emission_value_by_subnet_no_block_specified(mocker, subtensor):
 
 
 # `get_subnet_connection_requirements` tests
-def test_get_subnet_connection_requirements_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_connection_requirements_success(mocker, subtensor):
     """Test get_subnet_connection_requirements returns correct data when requirements are found."""
     # Prep
     netuid = 1
@@ -1675,10 +1791,12 @@ def test_get_subnet_connection_requirements_success(mocker, subtensor):
     mock_tuple2 = (mocker.MagicMock(value="requirement2"), mocker.MagicMock(value=20))
     mock_result = mocker.MagicMock()
     mock_result.records = [mock_tuple1, mock_tuple2]
-    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_map_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_subnet_connection_requirements(netuid, block)
+    result = await subtensor.get_subnet_connection_requirements(netuid, block)
 
     # Asserts
     assert result == {"requirement1": 10, "requirement2": 20}
@@ -1687,17 +1805,20 @@ def test_get_subnet_connection_requirements_success(mocker, subtensor):
     )
 
 
-def test_get_subnet_connection_requirements_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_connection_requirements_no_data(mocker, subtensor):
     """Test get_subnet_connection_requirements returns empty dict when no data is found."""
     # Prep
     netuid = 1
     block = 123
     mock_result = mocker.MagicMock()
     mock_result.records = []
-    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_map_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_subnet_connection_requirements(netuid, block)
+    result = await subtensor.get_subnet_connection_requirements(netuid, block)
 
     # Asserts
     assert result == {}
@@ -1706,7 +1827,10 @@ def test_get_subnet_connection_requirements_no_data(mocker, subtensor):
     )
 
 
-def test_get_subnet_connection_requirements_no_records_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_connection_requirements_no_records_attribute(
+    mocker, subtensor
+):
     """Test get_subnet_connection_requirements returns empty dict when result has no records attribute."""
     # Prep
     netuid = 1
@@ -1714,10 +1838,12 @@ def test_get_subnet_connection_requirements_no_records_attribute(mocker, subtens
     mock_result = mocker.MagicMock()
     del mock_result.records  # Simulating a missing records attribute
 
-    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_map_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_subnet_connection_requirements(netuid, block)
+    result = await subtensor.get_subnet_connection_requirements(netuid, block)
 
     # Asserts
     assert result == {}
@@ -1726,7 +1852,8 @@ def test_get_subnet_connection_requirements_no_records_attribute(mocker, subtens
     )
 
 
-def test_get_subnet_connection_requirements_no_block_specified(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_connection_requirements_no_block_specified(mocker, subtensor):
     """Test get_subnet_connection_requirements with no block specified."""
     # Prep
     netuid = 1
@@ -1734,10 +1861,12 @@ def test_get_subnet_connection_requirements_no_block_specified(mocker, subtensor
     mock_tuple2 = (mocker.MagicMock(value="requirement2"), mocker.MagicMock(value=20))
     mock_result = mocker.MagicMock()
     mock_result.records = [mock_tuple1, mock_tuple2]
-    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_map_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_subnet_connection_requirements(netuid)
+    result = await subtensor.get_subnet_connection_requirements(netuid)
 
     # Asserts
     assert result == {"requirement1": 10, "requirement2": 20}
@@ -1747,7 +1876,8 @@ def test_get_subnet_connection_requirements_no_block_specified(mocker, subtensor
 
 
 # `get_subnets` tests
-def test_get_subnets_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnets_success(mocker, subtensor):
     """Test get_subnets returns correct list when subnet information is found."""
     # Prep
     block = 123
@@ -1755,59 +1885,70 @@ def test_get_subnets_success(mocker, subtensor):
     mock_netuid2 = mocker.MagicMock(value=2)
     mock_result = mocker.MagicMock()
     mock_result.records = [(mock_netuid1, True), (mock_netuid2, True)]
-    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_map_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_subnets(block)
+    result = await subtensor.get_subnets(block)
 
     # Asserts
     assert result == [1, 2]
     subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", block)
 
 
-def test_get_subnets_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnets_no_data(mocker, subtensor):
     """Test get_subnets returns empty list when no subnet information is found."""
     # Prep
     block = 123
     mock_result = mocker.MagicMock()
     mock_result.records = []
-    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_map_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_subnets(block)
+    result = await subtensor.get_subnets(block)
 
     # Asserts
     assert result == []
     subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", block)
 
 
-def test_get_subnets_no_records_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnets_no_records_attribute(mocker, subtensor):
     """Test get_subnets returns empty list when result has no records attribute."""
     # Prep
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.records  # Simulating a missing records attribute
-    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_map_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_subnets(block)
+    result = await subtensor.get_subnets(block)
 
     # Asserts
     assert result == []
     subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", block)
 
 
-def test_get_subnets_no_block_specified(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnets_no_block_specified(mocker, subtensor):
     """Test get_subnets with no block specified."""
     # Prep
     mock_netuid1 = mocker.MagicMock(value=1)
     mock_netuid2 = mocker.MagicMock(value=2)
     mock_result = mocker.MagicMock()
     mock_result.records = [(mock_netuid1, True), (mock_netuid2, True)]
-    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+    mocker.patch.object(
+        subtensor, "query_map_subtensor", new=mocker.AsyncMock(return_value=mock_result)
+    )
 
     # Call
-    result = subtensor.get_subnets()
+    result = await subtensor.get_subnets()
 
     # Asserts
     assert result == [1, 2]
@@ -1815,16 +1956,23 @@ def test_get_subnets_no_block_specified(mocker, subtensor):
 
 
 # `get_all_subnets_info` tests
-def test_get_all_subnets_info_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_all_subnets_info_success(mocker, subtensor):
     """Test get_all_subnets_info returns correct data when subnet information is found."""
     # Prep
     block = 123
     subnet_data = [1, 2, 3]  # Mocked response data
     mocker.patch.object(
-        subtensor.substrate, "get_block_hash", return_value="mock_block_hash"
+        subtensor.substrate,
+        "get_block_hash",
+        new=mocker.AsyncMock(return_value="mock_block_hash"),
     )
     mock_response = {"result": subnet_data}
-    mocker.patch.object(subtensor.substrate, "rpc_request", return_value=mock_response)
+    mocker.patch.object(
+        subtensor.substrate,
+        "rpc_request",
+        new=mocker.AsyncMock(return_value=mock_response),
+    )
     mocker.patch.object(
         subtensor_module.SubnetInfo,
         "list_from_vec_u8",
@@ -1832,9 +1980,10 @@ def test_get_all_subnets_info_success(mocker, subtensor):
     )
 
     # Call
-    result = subtensor.get_all_subnets_info(block)
+    result = await subtensor.get_all_subnets_info(block)
 
     # Asserts
+    assert result == subtensor_module.SubnetInfo.list_from_vec_u8.return_value
     subtensor.substrate.get_block_hash.assert_called_once_with(block)
     subtensor.substrate.rpc_request.assert_called_once_with(
         method="subnetInfo_getSubnetsInfo", params=["mock_block_hash"]
@@ -1842,8 +1991,9 @@ def test_get_all_subnets_info_success(mocker, subtensor):
     subtensor_module.SubnetInfo.list_from_vec_u8.assert_called_once_with(subnet_data)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("result_", [[], None])
-def test_get_all_subnets_info_no_data(mocker, subtensor, result_):
+async def test_get_all_subnets_info_no_data(mocker, subtensor, result_):
     """Test get_all_subnets_info returns empty list when no subnet information is found."""
     # Prep
     block = 123
@@ -1851,11 +2001,15 @@ def test_get_all_subnets_info_no_data(mocker, subtensor, result_):
         subtensor.substrate, "get_block_hash", return_value="mock_block_hash"
     )
     mock_response = {"result": result_}
-    mocker.patch.object(subtensor.substrate, "rpc_request", return_value=mock_response)
+    mocker.patch.object(
+        subtensor.substrate,
+        "rpc_request",
+        new=mocker.AsyncMock(return_value=mock_response),
+    )
     mocker.patch.object(subtensor_module.SubnetInfo, "list_from_vec_u8")
 
     # Call
-    result = subtensor.get_all_subnets_info(block)
+    result = await subtensor.get_all_subnets_info(block)
 
     # Asserts
     assert result == []
@@ -1866,54 +2020,65 @@ def test_get_all_subnets_info_no_data(mocker, subtensor, result_):
     subtensor_module.SubnetInfo.list_from_vec_u8.assert_not_called()
 
 
-def test_get_all_subnets_info_retry(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_all_subnets_info_retry(mocker, subtensor):
     """Test get_all_subnets_info retries on failure."""
     # Prep
     block = 123
     subnet_data = [1, 2, 3]
     mocker.patch.object(
-        subtensor.substrate, "get_block_hash", return_value="mock_block_hash"
+        subtensor.substrate,
+        "get_block_hash",
+        new=mocker.AsyncMock(return_value="mock_block_hash"),
     )
     mock_response = {"result": subnet_data}
     mock_rpc_request = mocker.patch.object(
         subtensor.substrate,
         "rpc_request",
-        side_effect=[Exception, Exception, mock_response],
+        new=mocker.AsyncMock(side_effect=[Exception, Exception, mock_response]),
     )
     mocker.patch.object(
-        subtensor_module.SubnetInfo, "list_from_vec_u8", return_value=["some_data"]
+        subtensor_module.SubnetInfo, "list_from_vec_u8", new=mocker.MagicMock()
     )
 
     # Call
-    result = subtensor.get_all_subnets_info(block)
+    result = await subtensor.get_all_subnets_info(block)
 
     # Asserts
+    assert result == subtensor_module.SubnetInfo.list_from_vec_u8.return_value
     subtensor.substrate.get_block_hash.assert_called_with(block)
     assert mock_rpc_request.call_count == 3
     subtensor_module.SubnetInfo.list_from_vec_u8.assert_called_once_with(subnet_data)
-    assert result == ["some_data"]
 
 
 # `get_subnet_info` tests
-def test_get_subnet_info_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_info_success(mocker, subtensor):
     """Test get_subnet_info returns correct data when subnet information is found."""
     # Prep
     netuid = 1
     block = 123
     subnet_data = [1, 2, 3]
     mocker.patch.object(
-        subtensor.substrate, "get_block_hash", return_value="mock_block_hash"
+        subtensor.substrate,
+        "get_block_hash",
+        new=mocker.AsyncMock(return_value="mock_block_hash"),
     )
     mock_response = {"result": subnet_data}
-    mocker.patch.object(subtensor.substrate, "rpc_request", return_value=mock_response)
+    mocker.patch.object(
+        subtensor.substrate,
+        "rpc_request",
+        new=mocker.AsyncMock(return_value=mock_response),
+    )
     mocker.patch.object(
         subtensor_module.SubnetInfo, "from_vec_u8", return_value=["from_vec_u8"]
     )
 
     # Call
-    result = subtensor.get_subnet_info(netuid, block)
+    result = await subtensor.get_subnet_info(netuid, block)
 
     # Asserts
+    assert result == subtensor_module.SubnetInfo.from_vec_u8.return_value
     subtensor.substrate.get_block_hash.assert_called_once_with(block)
     subtensor.substrate.rpc_request.assert_called_once_with(
         method="subnetInfo_getSubnetInfo", params=[netuid, "mock_block_hash"]
@@ -1922,20 +2087,27 @@ def test_get_subnet_info_success(mocker, subtensor):
 
 
 @pytest.mark.parametrize("result_", [None, {}])
-def test_get_subnet_info_no_data(mocker, subtensor, result_):
+@pytest.mark.asyncio
+async def test_get_subnet_info_no_data(mocker, subtensor, result_):
     """Test get_subnet_info returns None when no subnet information is found."""
     # Prep
     netuid = 1
     block = 123
     mocker.patch.object(
-        subtensor.substrate, "get_block_hash", return_value="mock_block_hash"
+        subtensor.substrate,
+        "get_block_hash",
+        new=mocker.AsyncMock(return_value="mock_block_hash"),
     )
     mock_response = {"result": result_}
-    mocker.patch.object(subtensor.substrate, "rpc_request", return_value=mock_response)
+    mocker.patch.object(
+        subtensor.substrate,
+        "rpc_request",
+        new=mocker.AsyncMock(return_value=mock_response),
+    )
     mocker.patch.object(subtensor_module.SubnetInfo, "from_vec_u8")
 
     # Call
-    result = subtensor.get_subnet_info(netuid, block)
+    result = await subtensor.get_subnet_info(netuid, block)
 
     # Asserts
     assert result is None
@@ -1946,53 +2118,62 @@ def test_get_subnet_info_no_data(mocker, subtensor, result_):
     subtensor_module.SubnetInfo.from_vec_u8.assert_not_called()
 
 
-def test_get_subnet_info_retry(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_info_retry(mocker, subtensor):
     """Test get_subnet_info retries on failure."""
     # Prep
     netuid = 1
     block = 123
-    subnet_data = [1, 2, 3]
-    mocker.patch.object(
-        subtensor.substrate, "get_block_hash", return_value="mock_block_hash"
-    )
-    mock_response = {"result": subnet_data}
-    mock_rpc_request = mocker.patch.object(
-        subtensor.substrate,
-        "rpc_request",
-        side_effect=[Exception, Exception, mock_response],
-    )
+    expected_block_hash = "block_hash"
+    expected_rpc_result = {"result": [1, 2, 3]}
+
+    subtensor.substrate = mocker.MagicMock()
+    subtensor.substrate.get_block_hash = mocker.AsyncMock()
+    subtensor.substrate.get_block_hash.side_effect = [
+        Exception("First error"),
+        Exception("Second error"),
+        expected_block_hash,
+    ]
+
+    subtensor.substrate.rpc_request = mocker.AsyncMock(return_value=expected_rpc_result)
+
     mocker.patch.object(
         subtensor_module.SubnetInfo, "from_vec_u8", return_value=["from_vec_u8"]
     )
 
     # Call
-    result = subtensor.get_subnet_info(netuid, block)
+    result = await subtensor.get_subnet_info(netuid, block)
 
     # Asserts
     subtensor.substrate.get_block_hash.assert_called_with(block)
-    assert mock_rpc_request.call_count == 3
-    subtensor_module.SubnetInfo.from_vec_u8.assert_called_once_with(subnet_data)
+    assert subtensor.substrate.get_block_hash.call_count == 3
+    assert subtensor.substrate.rpc_request.call_count == 1
+    subtensor_module.SubnetInfo.from_vec_u8.assert_called_once_with([1, 2, 3])
 
 
 # `get_subnet_hyperparameters` tests
-def test_get_subnet_hyperparameters_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_hyperparameters_success(mocker, subtensor):
     """Test get_subnet_hyperparameters returns correct data when hyperparameters are found."""
     # Prep
     netuid = 1
     block = 123
     hex_bytes_result = "0x010203"
+    from_vec_u8_result = "from_vec_u8_result"
     bytes_result = bytes.fromhex(hex_bytes_result[2:])
-    mocker.patch.object(subtensor, "query_runtime_api", return_value=hex_bytes_result)
+
+    subtensor.query_runtime_api = mocker.AsyncMock(return_value=hex_bytes_result)
     mocker.patch.object(
         subtensor_module.SubnetHyperparameters,
         "from_vec_u8",
-        return_value=["from_vec_u8"],
+        return_value=[from_vec_u8_result],
     )
 
     # Call
-    result = subtensor.get_subnet_hyperparameters(netuid, block)
+    result = await subtensor.get_subnet_hyperparameters(netuid, block)
 
     # Asserts
+    assert result == [from_vec_u8_result]
     subtensor.query_runtime_api.assert_called_once_with(
         runtime_api="SubnetInfoRuntimeApi",
         method="get_subnet_hyperparams",
@@ -2004,16 +2185,18 @@ def test_get_subnet_hyperparameters_success(mocker, subtensor):
     )
 
 
-def test_get_subnet_hyperparameters_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_hyperparameters_no_data(mocker, subtensor):
     """Test get_subnet_hyperparameters returns empty list when no data is found."""
     # Prep
     netuid = 1
     block = 123
-    mocker.patch.object(subtensor, "query_runtime_api", return_value=None)
+
+    subtensor.query_runtime_api = mocker.AsyncMock(return_value=None)
     mocker.patch.object(subtensor_module.SubnetHyperparameters, "from_vec_u8")
 
     # Call
-    result = subtensor.get_subnet_hyperparameters(netuid, block)
+    result = await subtensor.get_subnet_hyperparameters(netuid, block)
 
     # Asserts
     assert result == []
@@ -2026,20 +2209,23 @@ def test_get_subnet_hyperparameters_no_data(mocker, subtensor):
     subtensor_module.SubnetHyperparameters.from_vec_u8.assert_not_called()
 
 
-def test_get_subnet_hyperparameters_hex_without_prefix(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_hyperparameters_hex_without_prefix(mocker, subtensor):
     """Test get_subnet_hyperparameters correctly processes hex string without '0x' prefix."""
     # Prep
     netuid = 1
     block = 123
     hex_bytes_result = "010203"
     bytes_result = bytes.fromhex(hex_bytes_result)
-    mocker.patch.object(subtensor, "query_runtime_api", return_value=hex_bytes_result)
+    subtensor.query_runtime_api = mocker.AsyncMock(return_value=hex_bytes_result)
+
     mocker.patch.object(subtensor_module.SubnetHyperparameters, "from_vec_u8")
 
     # Call
-    result = subtensor.get_subnet_hyperparameters(netuid, block)
+    result = await subtensor.get_subnet_hyperparameters(netuid, block)
 
     # Asserts
+    assert result == subtensor_module.SubnetHyperparameters.from_vec_u8.return_value
     subtensor.query_runtime_api.assert_called_once_with(
         runtime_api="SubnetInfoRuntimeApi",
         method="get_subnet_hyperparams",
@@ -2052,49 +2238,54 @@ def test_get_subnet_hyperparameters_hex_without_prefix(mocker, subtensor):
 
 
 # `get_subnet_owner` tests
-def test_get_subnet_owner_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_owner_success(mocker, subtensor):
     """Test get_subnet_owner returns correct data when owner information is found."""
     # Prep
     netuid = 1
     block = 123
     owner_address = "5F3sa2TJAWMqDhXG6jhV4N8ko9rXPM6twz9mG9m3rrgq3xiJ"
-    mock_result = mocker.MagicMock(value=owner_address)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
-
+    subtensor.query_subtensor = mocker.AsyncMock(
+        return_value=mocker.MagicMock(value=owner_address)
+    )
     # Call
-    result = subtensor.get_subnet_owner(netuid, block)
+    result = await subtensor.get_subnet_owner(netuid, block)
 
     # Asserts
     subtensor.query_subtensor.assert_called_once_with("SubnetOwner", block, [netuid])
     assert result == owner_address
 
 
-def test_get_subnet_owner_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_owner_no_data(mocker, subtensor):
     """Test get_subnet_owner returns None when no owner information is found."""
     # Prep
     netuid = 1
     block = 123
-    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=None)
 
     # Call
-    result = subtensor.get_subnet_owner(netuid, block)
+    result = await subtensor.get_subnet_owner(netuid, block)
 
     # Asserts
     subtensor.query_subtensor.assert_called_once_with("SubnetOwner", block, [netuid])
     assert result is None
 
 
-def test_get_subnet_owner_no_value_attribute(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_subnet_owner_no_value_attribute(mocker, subtensor):
     """Test get_subnet_owner returns None when result has no value attribute."""
     # Prep
     netuid = 1
     block = 123
     mock_result = mocker.MagicMock()
     del mock_result.value  # Simulating a missing value attribute
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=mock_result)
 
     # Call
-    result = subtensor.get_subnet_owner(netuid, block)
+    result = await subtensor.get_subnet_owner(netuid, block)
 
     # Asserts
     subtensor.query_subtensor.assert_called_once_with("SubnetOwner", block, [netuid])
@@ -2107,35 +2298,39 @@ def test_get_subnet_owner_no_value_attribute(mocker, subtensor):
 
 
 # `is_hotkey_delegate` tests
-def test_is_hotkey_delegate_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_is_hotkey_delegate_success(mocker, subtensor):
     """Test is_hotkey_delegate returns True when hotkey is a delegate."""
     # Prep
     hotkey_ss58 = "hotkey_ss58"
     block = 123
-    mock_delegates = [
-        mocker.MagicMock(hotkey_ss58=hotkey_ss58),
-        mocker.MagicMock(hotkey_ss58="hotkey_ss583"),
-    ]
-    mocker.patch.object(subtensor, "get_delegates", return_value=mock_delegates)
+    subtensor.get_delegates = mocker.AsyncMock(
+        return_value=[
+            mocker.MagicMock(hotkey_ss58=hotkey_ss58),
+            mocker.MagicMock(hotkey_ss58="hotkey_ss583"),
+        ]
+    )
 
     # Call
-    result = subtensor.is_hotkey_delegate(hotkey_ss58, block)
+    result = await subtensor.is_hotkey_delegate(hotkey_ss58, block)
 
     # Asserts
     subtensor.get_delegates.assert_called_once_with(block=block)
     assert result is True
 
 
-def test_is_hotkey_delegate_not_found(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_is_hotkey_delegate_not_found(mocker, subtensor):
     """Test is_hotkey_delegate returns False when hotkey is not a delegate."""
     # Prep
     hotkey_ss58 = "hotkey_ss58"
     block = 123
-    mock_delegates = [mocker.MagicMock(hotkey_ss58="hotkey_ss583")]
-    mocker.patch.object(subtensor, "get_delegates", return_value=mock_delegates)
+    subtensor.get_delegates = mocker.AsyncMock(
+        return_value=[mocker.MagicMock(hotkey_ss58="hotkey_ss583")]
+    )
 
     # Call
-    result = subtensor.is_hotkey_delegate(hotkey_ss58, block)
+    result = await subtensor.is_hotkey_delegate(hotkey_ss58, block)
 
     # Asserts
     subtensor.get_delegates.assert_called_once_with(block=block)
@@ -2143,35 +2338,37 @@ def test_is_hotkey_delegate_not_found(mocker, subtensor):
 
 
 # `get_delegate_take` tests
-def test_get_delegate_take_success(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_delegate_take_success(mocker, subtensor):
     """Test get_delegate_take returns correct data when delegate take is found."""
     # Prep
     hotkey_ss58 = "hotkey_ss58"
     block = 123
     delegate_take_value = 32768
-    mock_result = mocker.MagicMock(value=delegate_take_value)
-    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_result)
+    subtensor.query_subtensor = mocker.AsyncMock(
+        return_value=mocker.MagicMock(value=delegate_take_value)
+    )
     spy_u16_normalized_float = mocker.spy(subtensor_module, "u16_normalized_float")
 
     # Call
-    subtensor.get_delegate_take(hotkey_ss58, block)
+    await subtensor.get_delegate_take(hotkey_ss58, block)
 
     # Asserts
     subtensor.query_subtensor.assert_called_once_with("Delegates", block, [hotkey_ss58])
     spy_u16_normalized_float.assert_called_once_with(delegate_take_value)
 
 
-def test_get_delegate_take_no_data(mocker, subtensor):
+@pytest.mark.asyncio
+async def test_get_delegate_take_no_data(mocker, subtensor):
     """Test get_delegate_take returns None when no delegate take is found."""
     # Prep
     hotkey_ss58 = "hotkey_ss58"
     block = 123
-    delegate_take_value = 32768
-    mocker.patch.object(subtensor, "query_subtensor", return_value=None)
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=None)
     spy_u16_normalized_float = mocker.spy(subtensor_module, "u16_normalized_float")
 
     # Call
-    result = subtensor.get_delegate_take(hotkey_ss58, block)
+    result = await subtensor.get_delegate_take(hotkey_ss58, block)
 
     # Asserts
     subtensor.query_subtensor.assert_called_once_with("Delegates", block, [hotkey_ss58])


### PR DESCRIPTION
Through this PR, I have already discovered several bugs, including the fact that the `retray.retry` we used earlier does not support asynchronous functions (it literally doesn't wait for the result). I replaced this with `tenacity.retry` which does the job mentioned perfectly.
All tests in `tests/unit_tests/test_subtensor.py` passed well.