### PR TITLE
Add back BT_SUBTENSOR_CHAIN_ENDPOINT env variable

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -125,7 +125,10 @@ __archive_entrypoint__ = "wss://archive.chain.opentensor.ai:443/"
 # Needs to use wss://
 __bellagene_entrypoint__ = "wss://parachain.opentensor.ai:443"
 
-__local_entrypoint__ = "ws://127.0.0.1:9944"
+if (BT_SUBTENSOR_CHAIN_ENDPOINT := os.getenv("BT_SUBTENSOR_CHAIN_ENDPOINT")) is not None:
+    __local_entrypoint__ = BT_SUBTENSOR_CHAIN_ENDPOINT
+else:
+    __local_entrypoint__ = "ws://127.0.0.1:9944"
 
 __tao_symbol__: str = chr(0x03C4)
 

--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -125,7 +125,9 @@ __archive_entrypoint__ = "wss://archive.chain.opentensor.ai:443/"
 # Needs to use wss://
 __bellagene_entrypoint__ = "wss://parachain.opentensor.ai:443"
 
-if (BT_SUBTENSOR_CHAIN_ENDPOINT := os.getenv("BT_SUBTENSOR_CHAIN_ENDPOINT")) is not None:
+if (
+    BT_SUBTENSOR_CHAIN_ENDPOINT := os.getenv("BT_SUBTENSOR_CHAIN_ENDPOINT")
+) is not None:
     __local_entrypoint__ = BT_SUBTENSOR_CHAIN_ENDPOINT
 else:
     __local_entrypoint__ = "ws://127.0.0.1:9944"


### PR DESCRIPTION
Add back referencing the BT_SUBTENSOR_CHAIN_ENDPOINT environment variable

### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.

### Description of the Change

Add back the BT_SUBTENSOR_CHAIN_ENDPOINT reference, but moved to the `bittensor.__init__`, to align with `os import` location and general direction of variable setting.

This currently is set to if network is local, it will check first for the environment variable being present and using that, then fall back to the standard local network.
Enabling this will simplify using alternate networks that aren't opentensor's instance but don't necessitate local.

i.e. users can export their environment variable and all utilization of the bittensor network will default the alternate network.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Explored adding back to the original subtensor.py, but recent updates seems to prefer the network being defined in the bittensor object itself.

Also explored having an override on the finney network so there's no need to specify the network as local to use defined network.
But future switch to local with this enabled will make it easier for users to still access btcli even if they can't run a local subtensor.

Also considered potentially adding "remote" network type as another option and that leveraging environment variable or being set.

Open to updates and alignment with strategic direction,

### Possible Drawbacks

- Requires `subtensor.local` to be set at launch, could lead to most use still falling back to opentensor instance
- Not super verbose on which network you're using, in case users may not remember having set the variable
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Updated code, and ran standard commands using `btcli` without local flag set, and then again with local flag set.
Imported bittensor into python project and checked object definitions to confirm accurate variable setting.
No impacts to use.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

- Add back BT_SUBTENSOR_CHAIN_ENDPOINT environment variable read when launching local network 
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->