### PR TITLE
Async substrate: working extrinsics, adds tests

### DIFF
--- a/bittensor/utils/async_substrate.py
+++ b/bittensor/utils/async_substrate.py
@@ -1231,6 +1231,7 @@ class AsyncSubstrateInterface:
 
         :return: QueryMapResult object
         """
+        params = params or []
         block_hash = (
             block_hash
             if block_hash
@@ -1261,7 +1262,6 @@ class AsyncSubstrateInterface:
         # Check MapType conditions
         if len(param_types) == 0:
             raise ValueError("Given storage function is not a map")
-
         if len(params) > len(param_types) - 1:
             raise ValueError(
                 f"Storage function map can accept max {len(param_types) - 1} parameters, {len(params)} given"

--- a/bittensor/utils/async_substrate.py
+++ b/bittensor/utils/async_substrate.py
@@ -716,7 +716,7 @@ class AsyncSubstrateInterface:
             else "state_getStorage"
         )
         return Preprocessed(
-            query_for[0] if query_for else None,
+            str(query_for),
             method,
             [storage_key.to_hex(), block_hash],
             value_scale_type,

--- a/bittensor/utils/async_substrate.py
+++ b/bittensor/utils/async_substrate.py
@@ -726,11 +726,14 @@ class AsyncSubstrateInterface:
     async def _process_response(
         self,
         response: dict,
+        subscription_id: Union[int, str],
         value_scale_type: str,
         storage_item: Optional[ScaleType] = None,
         runtime: Optional[Runtime] = None,
         result_handler: Optional[ResultHandler] = None,
     ) -> tuple[Union[ScaleType, dict], bool]:
+        obj = response
+
         if value_scale_type:
             if not runtime:
                 async with self._lock:
@@ -756,11 +759,12 @@ class AsyncSubstrateInterface:
             )
             obj.decode(check_remaining=True)
             obj.meta_info = {"result_found": response.get("result") is not None}
-            return obj, True
-        elif asyncio.iscoroutinefunction(result_handler):
+        if asyncio.iscoroutinefunction(result_handler):
             # For multipart responses as a result of subscriptions.
-            return await result_handler(response)
-        return response, True
+            message, bool_result = await result_handler(obj, subscription_id)
+            if bool_result:
+                return message, bool_result
+        return obj, True
 
     async def _make_rpc_request(
         self,
@@ -771,6 +775,8 @@ class AsyncSubstrateInterface:
         result_handler: Optional[ResultHandler] = None,
     ) -> RequestManager.RequestResults:
         request_manager = RequestManager(payloads)
+
+        subscription_added = False
 
         async with self.ws as ws:
             for item in payloads:
@@ -784,7 +790,10 @@ class AsyncSubstrateInterface:
                         or asyncio.iscoroutinefunction(result_handler)
                     ):
                         if response := await ws.retrieve(item_id):
-                            if asyncio.iscoroutinefunction(result_handler):
+                            if (
+                                asyncio.iscoroutinefunction(result_handler)
+                                and not subscription_added
+                            ):
                                 # handles subscriptions, overwrites the previous mapping of {item_id : payload_id}
                                 # with {subscription_id : payload_id}
                                 item_id = request_manager.overwrite_request(
@@ -792,6 +801,7 @@ class AsyncSubstrateInterface:
                                 )
                             decoded_response, complete = await self._process_response(
                                 response,
+                                item_id,
                                 value_scale_type,
                                 storage_item,
                                 runtime,
@@ -800,6 +810,12 @@ class AsyncSubstrateInterface:
                             request_manager.add_response(
                                 item_id, decoded_response, complete
                             )
+                    if (
+                        asyncio.iscoroutinefunction(result_handler)
+                        and not subscription_added
+                    ):
+                        subscription_added = True
+                        break
 
                 if request_manager.is_complete:
                     break
@@ -1157,6 +1173,7 @@ class AsyncSubstrateInterface:
         params: Optional[list] = None,
         block_hash: Optional[str] = None,
         raw_storage_key: bytes = None,
+        subscription_handler=None,
         reuse_block_hash: bool = False,
     ) -> "ScaleType":
         """
@@ -1186,7 +1203,11 @@ class AsyncSubstrateInterface:
         storage_item = preprocessed.storage_item
 
         responses = await self._make_rpc_request(
-            payload, value_scale_type, storage_item, runtime
+            payload,
+            value_scale_type,
+            storage_item,
+            runtime,
+            result_handler=subscription_handler,
         )
         return responses[preprocessed.queryable][0]
 

--- a/bittensor/utils/async_substrate.py
+++ b/bittensor/utils/async_substrate.py
@@ -1156,7 +1156,6 @@ class AsyncSubstrateInterface:
         storage_function: str,
         params: Optional[list] = None,
         block_hash: Optional[str] = None,
-        subscription_handler: callable = None,
         raw_storage_key: bytes = None,
         reuse_block_hash: bool = False,
     ) -> "ScaleType":

--- a/tests/test_substrate/test_runtime_call.py
+++ b/tests/test_substrate/test_runtime_call.py
@@ -29,34 +29,38 @@ async def test_core_version(substrate):
     async with substrate:
         result = await substrate.runtime_call("Core", "version")
 
-    assert result.value['spec_version'] > 0
-    assert result.value['spec_name'] == 'polkadot'
+    assert result.value["spec_version"] > 0
+    assert result.value["spec_name"] == "polkadot"
 
 
 @pytest.mark.asyncio
 async def test_core_version_at_not_best_block(substrate):
     async with substrate:
         parent_hash = substrate.substrate.get_block_header()
-        parent_hash = parent_hash['header']['parentHash']
+        parent_hash = parent_hash["header"]["parentHash"]
         result = await substrate.runtime_call("Core", "version", block_hash=parent_hash)
 
-    assert result.value['spec_version'] > 0
-    assert result.value['spec_name'] == 'polkadot'
+    assert result.value["spec_version"] > 0
+    assert result.value["spec_name"] == "polkadot"
 
 
 @pytest.mark.asyncio
 async def test_metadata_call_info(substrate):
     async with substrate:
-        runtime_call = substrate.substrate.get_metadata_runtime_call_function("TransactionPaymentApi", "query_fee_details")
+        runtime_call = substrate.substrate.get_metadata_runtime_call_function(
+            "TransactionPaymentApi", "query_fee_details"
+        )
         param_info = runtime_call.get_param_info()
-    assert param_info[0] == 'Extrinsic'
-    assert param_info[1] == 'u32'
+    assert param_info[0] == "Extrinsic"
+    assert param_info[1] == "u32"
 
     async with substrate:
-        runtime_call = substrate.substrate.get_metadata_runtime_call_function("Core", "initialise_block")
+        runtime_call = substrate.substrate.get_metadata_runtime_call_function(
+            "Core", "initialise_block"
+        )
         param_info = runtime_call.get_param_info()
-    assert param_info[0]['number'] == 'u32'
-    assert param_info[0]['parent_hash'] == 'h256'
+    assert param_info[0]["number"] == "u32"
+    assert param_info[0]["parent_hash"] == "h256"
 
 
 @pytest.mark.asyncio
@@ -66,5 +70,5 @@ async def test_unknown_runtime_call(substrate):
             await substrate.runtime_call("Foo", "bar")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/tests/test_substrate/test_runtime_call.py
+++ b/tests/test_substrate/test_runtime_call.py
@@ -1,0 +1,70 @@
+import pytest
+from bittensor.utils.async_substrate import AsyncSubstrateInterface
+from substrateinterface import Keypair
+import settings
+
+
+@pytest.fixture
+def kusama_substrate():
+    return AsyncSubstrateInterface(
+        chain_endpoint=settings.KUSAMA_NODE_URL,
+    )
+
+
+@pytest.fixture
+def substrate():
+    return AsyncSubstrateInterface(
+        chain_endpoint=settings.POLKADOT_NODE_URL,
+    )
+
+
+@pytest.fixture(scope="module")
+def keypair():
+    mnemonic = Keypair.generate_mnemonic()
+    return Keypair.create_from_mnemonic(mnemonic)
+
+
+@pytest.mark.asyncio
+async def test_core_version(substrate):
+    async with substrate:
+        result = await substrate.runtime_call("Core", "version")
+
+    assert result.value['spec_version'] > 0
+    assert result.value['spec_name'] == 'polkadot'
+
+
+@pytest.mark.asyncio
+async def test_core_version_at_not_best_block(substrate):
+    async with substrate:
+        parent_hash = substrate.substrate.get_block_header()
+        parent_hash = parent_hash['header']['parentHash']
+        result = await substrate.runtime_call("Core", "version", block_hash=parent_hash)
+
+    assert result.value['spec_version'] > 0
+    assert result.value['spec_name'] == 'polkadot'
+
+
+@pytest.mark.asyncio
+async def test_metadata_call_info(substrate):
+    async with substrate:
+        runtime_call = substrate.substrate.get_metadata_runtime_call_function("TransactionPaymentApi", "query_fee_details")
+        param_info = runtime_call.get_param_info()
+    assert param_info[0] == 'Extrinsic'
+    assert param_info[1] == 'u32'
+
+    async with substrate:
+        runtime_call = substrate.substrate.get_metadata_runtime_call_function("Core", "initialise_block")
+        param_info = runtime_call.get_param_info()
+    assert param_info[0]['number'] == 'u32'
+    assert param_info[0]['parent_hash'] == 'h256'
+
+
+@pytest.mark.asyncio
+async def test_unknown_runtime_call(substrate):
+    async with substrate:
+        with pytest.raises(ValueError):
+            await substrate.runtime_call("Foo", "bar")
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/tests/test_substrate/test_subscriptions.py
+++ b/tests/test_substrate/test_subscriptions.py
@@ -1,0 +1,27 @@
+import pytest
+from bittensor.utils.async_substrate import AsyncSubstrateInterface
+import settings
+
+
+@pytest.fixture
+def substrate():
+    return AsyncSubstrateInterface(
+        chain_endpoint=settings.POLKADOT_NODE_URL,
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_subscription(substrate):
+    async def subscription_handler(obj, subscription_id):
+        return {"subscription_id": subscription_id}, True
+
+    async with substrate:
+        result = await substrate.query(
+            "System", "Events", [], subscription_handler=subscription_handler
+        )
+
+    assert result["subscription_id"] is not None
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
Refactors the order for extrinsics subscription handling, and adds tests.
