### PR TITLE
fix bittensor not installing under Python 3.13

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -11,7 +11,7 @@ fuzzywuzzy>=0.18.0
 fastapi~=0.110.1
 munch~=2.5.0
 netaddr
-numpy==1.26.4
+numpy~=1.26
 msgpack-numpy-opentensor~=0.5.0
 nest_asyncio
 packaging
@@ -19,9 +19,9 @@ pycryptodome>=3.18.0,<4.0.0
 pyyaml
 password_strength
 pydantic>=2.3, <3
-PyNaCl>=1.3.0,<=1.5.0
+PyNaCl~=1.3
 python-Levenshtein
-python-statemachine~=2.1.2
+python-statemachine~=2.1
 retry
 requests
 rich
@@ -30,5 +30,5 @@ shtab~=1.6.5
 substrate-interface~=1.7.5
 termcolor
 tqdm
-uvicorn<=0.30
+uvicorn
 wheel


### PR DESCRIPTION
### Bug

bittensor is not installable under python 3.13

### Description of the Change

This is very similar to #1967 , as change is quite simple - loosen up dependency version specifiers to allow for a wider range of environments and easier development with current versions.

Currently, under python 3.13 following error pops up:
```
ERROR: Ignored the following yanked versions: 1.0.0, 1.0.1, 1.0.2
ERROR: Ignored the following versions that require a different python version: 1.21.2 Requires-Python >=3.7,<3.11; 1.21.3 Requires-Python >=3.7,<3.11; 1.21.4 Requires-Python >=3.7,<3.11; 1.21.5 Requires-Python >=3.7,<3.11; 1.21.6 Requires-Python >=3.7,<3.11; 1.26.0 Requires-Python <3.13,>=3.9; 1.26.0b1 Requires-Python <3.13,>=3.9; 1.26.0rc1 Requires-Python <3.13,>=3.9; 1.26.1 Requires-Python <3.13,>=3.9; 2.0.0 Requires-Python >=3.7,<3.12; 2.1.0 Requires-Python >=3.7,<3.12; 2.1.1 Requires-Python >=3.7,<3.12; 2.1.2 Requires-Python >=3.7,<3.13; 2.2.0 Requires-Python <3.13,>=3.9
ERROR: Could not find a version that satisfies the requirement python-statemachine~=2.1.2 (from bittensor) (from versions: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.2, 0.4.3, 0.4.4, 0.5.0, 0.5.1, 0.6.0, 0.6.1, 0.6.2, 0.7.0, 0.7.1, 0.8.0, 0.9.0, 1.0.3, 2.3.0, 2.3.1)
ERROR: No matching distribution found for python-statemachine~=2.1.2
```

This PR fixes that.

### Alternate Designs

none sensible I could come up with

### Possible Drawbacks

same as #1967 ; tl;dr outweighed by benefits

### Verification Process

Manual installation under python 3.13
+ regression tested with bittensor unittests under all supported python versions i.e. excluding Python 3.13.
This is just so installation passes.

### Release Notes

* make bittensor package installable under Python 3.13 . This doesn't mean Python 3.13 is already officially supported, but it is a step towards that goal.