### PR TITLE
Async block hash fix

### DIFF
--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -4464,7 +4464,8 @@ class Subtensor:
 
             return await self.substrate.rpc_request(
                 method="delegateInfo_getDelegates",  # custom rpc method
-                params=[block_hash] if block_hash else [],
+                params=[],
+                block_hash=block_hash
             )
 
         json_body = await make_substrate_call_with_retry()

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -3107,9 +3107,7 @@ class Subtensor:
             )
 
             return await self.substrate.rpc_request(
-                method="state_call",
-                params=[method, data],
-                block_hash=block_hash
+                method="state_call", params=[method, data], block_hash=block_hash
             )
 
         return await make_substrate_call_with_retry()
@@ -4196,7 +4194,7 @@ class Subtensor:
             return await self.substrate.rpc_request(
                 method="subnetInfo_getSubnetsInfo",  # custom rpc method
                 params=[],
-                block_hash=block_hash
+                block_hash=block_hash,
             )
 
         json_body = await make_substrate_call_with_retry()
@@ -4232,7 +4230,7 @@ class Subtensor:
             return await self.substrate.rpc_request(
                 method="subnetInfo_getSubnetInfo",  # custom rpc method
                 params=[netuid],
-                block_hash=block_hash
+                block_hash=block_hash,
             )
 
         json_body = await make_substrate_call_with_retry()
@@ -4388,12 +4386,14 @@ class Subtensor:
 
         @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
         async def make_substrate_call_with_retry(encoded_hotkey_: List[int]):
-            block_hash = None if block is None else self.substrate.get_block_hash(block)
+            block_hash = (
+                None if block is None else await self.substrate.get_block_hash(block)
+            )
 
             return await self.substrate.rpc_request(
                 method="delegateInfo_getDelegate",  # custom rpc method
                 params=[encoded_hotkey_],
-                block_hash=block_hash
+                block_hash=block_hash,
             )
 
         encoded_hotkey = ss58_to_vec_u8(hotkey_ss58)
@@ -4433,7 +4433,7 @@ class Subtensor:
             return await self.substrate.rpc_request(
                 method="delegateInfo_getDelegatesLite",  # custom rpc method
                 params=[],
-                block_hash=block_hash
+                block_hash=block_hash,
             )
 
         json_body = await make_substrate_call_with_retry()
@@ -4468,7 +4468,7 @@ class Subtensor:
             return await self.substrate.rpc_request(
                 method="delegateInfo_getDelegates",  # custom rpc method
                 params=[],
-                block_hash=block_hash
+                block_hash=block_hash,
             )
 
         json_body = await make_substrate_call_with_retry()
@@ -4505,7 +4505,7 @@ class Subtensor:
             return await self.substrate.rpc_request(
                 method="delegateInfo_getDelegated",
                 params=[encoded_coldkey_],
-                block_hash=block_hash
+                block_hash=block_hash,
             )
 
         encoded_coldkey = ss58_to_vec_u8(coldkey_ss58)
@@ -4885,7 +4885,7 @@ class Subtensor:
             return await self.substrate.rpc_request(
                 method="neuronInfo_getNeuron",
                 params=params,  # custom rpc method
-                block_hash=block_hash
+                block_hash=block_hash,
             )
 
         json_body = await make_substrate_call_with_retry()

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -3108,7 +3108,8 @@ class Subtensor:
 
             return await self.substrate.rpc_request(
                 method="state_call",
-                params=[method, data, block_hash] if block_hash else [method, data],
+                params=[method, data],
+                block_hash=block_hash
             )
 
         return await make_substrate_call_with_retry()
@@ -4194,7 +4195,8 @@ class Subtensor:
 
             return await self.substrate.rpc_request(
                 method="subnetInfo_getSubnetsInfo",  # custom rpc method
-                params=[block_hash] if block_hash else [],
+                params=[],
+                block_hash=block_hash
             )
 
         json_body = await make_substrate_call_with_retry()
@@ -4229,7 +4231,8 @@ class Subtensor:
             )
             return await self.substrate.rpc_request(
                 method="subnetInfo_getSubnetInfo",  # custom rpc method
-                params=[netuid, block_hash] if block_hash else [netuid],
+                params=[netuid],
+                block_hash=block_hash
             )
 
         json_body = await make_substrate_call_with_retry()
@@ -4389,9 +4392,8 @@ class Subtensor:
 
             return await self.substrate.rpc_request(
                 method="delegateInfo_getDelegate",  # custom rpc method
-                params=(
-                    [encoded_hotkey_, block_hash] if block_hash else [encoded_hotkey_]
-                ),
+                params=[encoded_hotkey_],
+                block_hash=block_hash
             )
 
         encoded_hotkey = ss58_to_vec_u8(hotkey_ss58)
@@ -4430,7 +4432,8 @@ class Subtensor:
 
             return await self.substrate.rpc_request(
                 method="delegateInfo_getDelegatesLite",  # custom rpc method
-                params=[block_hash] if block_hash else [],
+                params=[],
+                block_hash=block_hash
             )
 
         json_body = await make_substrate_call_with_retry()
@@ -4501,9 +4504,8 @@ class Subtensor:
 
             return await self.substrate.rpc_request(
                 method="delegateInfo_getDelegated",
-                params=(
-                    [block_hash, encoded_coldkey_] if block_hash else [encoded_coldkey_]
-                ),
+                params=[encoded_coldkey_],
+                block_hash=block_hash
             )
 
         encoded_coldkey = ss58_to_vec_u8(coldkey_ss58)
@@ -4880,11 +4882,10 @@ class Subtensor:
                 None if block is None else await self.substrate.get_block_hash(block)
             )
             params = [netuid, uid]
-            if block_hash:
-                params = params + [block_hash]
             return await self.substrate.rpc_request(
                 method="neuronInfo_getNeuron",
                 params=params,  # custom rpc method
+                block_hash=block_hash
             )
 
         json_body = await make_substrate_call_with_retry()

--- a/tests/unit_tests/test_axon.py
+++ b/tests/unit_tests/test_axon.py
@@ -269,6 +269,7 @@ async def test_priority_pass(middleware):
     assert synapse.axon.status_code != 408
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "body, expected",
     [
@@ -295,6 +296,7 @@ async def test_verify_body_integrity_happy_path(
     assert result == expected, "The parsed body should match the expected dictionary."
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "body, expected_exception_message",
     [
@@ -317,6 +319,7 @@ async def test_verify_body_integrity_edge_cases(
     ), "Expected specific exception message."
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "computed_hash, expected_error",
     [

--- a/tests/unit_tests/test_overview.py
+++ b/tests/unit_tests/test_overview.py
@@ -78,7 +78,7 @@ class MockCli:
         (True, True, True, 0, "edge_case_encrypted_wallet"),
     ],
 )
-def test_get_total_balance(
+async def test_get_total_balance(
     mock_subtensor,
     mock_wallet,
     config_all,
@@ -105,7 +105,7 @@ def test_get_total_balance(
         return_value=[mock_wallet],
     ):
         # Act
-        result_hotkeys, result_balance = OverviewCommand._get_total_balance(
+        result_hotkeys, result_balance = await OverviewCommand._get_total_balance(
             0, mock_subtensor, cli
         )
 
@@ -208,6 +208,7 @@ def netuids_list():
 
 
 # Test cases
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "test_id, results, expected_neurons, expected_netuids",
     [
@@ -253,11 +254,11 @@ def netuids_list():
         ),
     ],
 )
-def test_process_neuron_results(
+async def test_process_neuron_results(
     test_id, results, expected_neurons, expected_netuids, neurons_dict, netuids_list
 ):
     # Act
-    actual_neurons = OverviewCommand._process_neuron_results(
+    actual_neurons = await OverviewCommand._process_neuron_results(
         results, neurons_dict, netuids_list
     )
 

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2077,7 +2077,7 @@ async def test_get_all_subnets_info_success(mocker, subtensor):
     assert result == subtensor_module.SubnetInfo.list_from_vec_u8.return_value
     subtensor.substrate.get_block_hash.assert_called_once_with(block)
     subtensor.substrate.rpc_request.assert_called_once_with(
-        method="subnetInfo_getSubnetsInfo", params=["mock_block_hash"]
+        method="subnetInfo_getSubnetsInfo", params=[], block_hash="mock_block_hash"
     )
     subtensor_module.SubnetInfo.list_from_vec_u8.assert_called_once_with(subnet_data)
 
@@ -2106,7 +2106,7 @@ async def test_get_all_subnets_info_no_data(mocker, subtensor, result_):
     assert result == []
     subtensor.substrate.get_block_hash.assert_called_once_with(block)
     subtensor.substrate.rpc_request.assert_called_once_with(
-        method="subnetInfo_getSubnetsInfo", params=["mock_block_hash"]
+        method="subnetInfo_getSubnetsInfo", params=[], block_hash="mock_block_hash"
     )
     subtensor_module.SubnetInfo.list_from_vec_u8.assert_not_called()
 
@@ -2172,7 +2172,7 @@ async def test_get_subnet_info_success(mocker, subtensor):
     assert result == subtensor_module.SubnetInfo.from_vec_u8.return_value
     subtensor.substrate.get_block_hash.assert_called_once_with(block)
     subtensor.substrate.rpc_request.assert_called_once_with(
-        method="subnetInfo_getSubnetInfo", params=[netuid, "mock_block_hash"]
+        method="subnetInfo_getSubnetInfo", params=[netuid], block_hash="mock_block_hash"
     )
     subtensor_module.SubnetInfo.from_vec_u8.assert_called_once_with(subnet_data)
 
@@ -2204,7 +2204,7 @@ async def test_get_subnet_info_no_data(mocker, subtensor, result_):
     assert result is None
     subtensor.substrate.get_block_hash.assert_called_once_with(block)
     subtensor.substrate.rpc_request.assert_called_once_with(
-        method="subnetInfo_getSubnetInfo", params=[netuid, "mock_block_hash"]
+        method="subnetInfo_getSubnetInfo", params=[netuid], block_hash="mock_block_hash"
     )
     subtensor_module.SubnetInfo.from_vec_u8.assert_not_called()
 


### PR DESCRIPTION
Fixes calling block_hash as a kwarg instead of including in params in all calls to `substrate.rpc_request` in `Subtensor`.