### PR TITLE
async retry reraise logic

### DIFF
--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -864,7 +864,7 @@ class Subtensor:
         trust in other neurons based on observed performance and contributions.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -1006,7 +1006,7 @@ class Subtensor:
         verifiable record of the neuron's weight distribution at a specific point in time.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -1136,7 +1136,7 @@ class Subtensor:
         transparency and accountability for the neuron's weight distribution.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -1390,7 +1390,7 @@ class Subtensor:
                 message.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             # create extrinsic call
             call = await self.substrate.compose_call(
@@ -1451,7 +1451,7 @@ class Subtensor:
             Tuple[bool, Optional[str]]: A tuple containing a boolean indicating success or failure, and an optional error message.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             # create extrinsic call
             call = await self.substrate.compose_call(
@@ -1507,7 +1507,7 @@ class Subtensor:
                 error message.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             # create extrinsic call
             call = await self.substrate.compose_call(
@@ -1662,7 +1662,7 @@ class Subtensor:
             error (str): Error message if transfer failed.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="Balances",
@@ -1898,7 +1898,7 @@ class Subtensor:
         enhancing the decentralized computation capabilities of Bittensor.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -1961,7 +1961,7 @@ class Subtensor:
             error (:func:`Optional[str]`): Error message if serve prometheus failed, ``None`` otherwise.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -2010,7 +2010,7 @@ class Subtensor:
             error (:func:`Optional[str]`): Error message if associate IPs failed, None otherwise.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -2139,7 +2139,7 @@ class Subtensor:
             StakeError: If the extrinsic failed.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -2266,7 +2266,7 @@ class Subtensor:
             StakeError: If the extrinsic failed.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -2591,7 +2591,7 @@ class Subtensor:
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = True,
     ) -> Tuple[bool, Optional[str]]:
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             # create extrinsic call
             call = await self.substrate.compose_call(
@@ -2696,7 +2696,7 @@ class Subtensor:
         trust in other neurons based on observed performance and contributions to the root network.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -2762,7 +2762,7 @@ class Subtensor:
         network-specific details, providing insights into the neuron's role and status within the Bittensor network.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry() -> "ScaleType":
             return await self.substrate.query(
                 module="Registry",
@@ -2819,7 +2819,7 @@ class Subtensor:
         call_params = bittensor.utils.wallet_utils.create_identity_dict(**params)
         call_params["identified"] = identified
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry() -> bool:
             call = await self.substrate.compose_call(
                 call_module="Registry",
@@ -2909,7 +2909,7 @@ class Subtensor:
         providing valuable insights into the state and dynamics of the Bittensor ecosystem.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry() -> "ScaleType":
             return await self.substrate.query(
                 module="SubtensorModule",
@@ -2948,7 +2948,7 @@ class Subtensor:
         relationships within the Bittensor ecosystem, such as inter-neuronal connections and stake distributions.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             return await self.substrate.query_map(
                 module="SubtensorModule",
@@ -2982,7 +2982,7 @@ class Subtensor:
         operational parameters.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             return await self.substrate.get_constant(
                 module_name=module_name,
@@ -3022,7 +3022,7 @@ class Subtensor:
         parts of the Bittensor blockchain, enhancing the understanding and analysis of the network's state and dynamics.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry() -> "ScaleType":
             return await self.substrate.query(
                 module=module,
@@ -3063,7 +3063,7 @@ class Subtensor:
         modules, offering insights into the network's state and the relationships between its different components.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry() -> "QueryMapResult":
             return await self.substrate.query_map(
                 module=module,
@@ -3100,7 +3100,7 @@ class Subtensor:
         useful for specific use cases where standard queries are insufficient.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry() -> Dict[Any, Any]:
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4186,7 +4186,7 @@ class Subtensor:
         the roles of different subnets, and their unique features.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4222,7 +4222,7 @@ class Subtensor:
         subnet, including its governance, performance, and role within the broader network.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4383,7 +4383,7 @@ class Subtensor:
         the Bittensor network's consensus and governance structures.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry(encoded_hotkey_: List[int]):
             block_hash = None if block is None else self.substrate.get_block_hash(block)
 
@@ -4422,7 +4422,7 @@ class Subtensor:
 
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4456,7 +4456,7 @@ class Subtensor:
 
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             block_hash = (
                 None
@@ -4494,7 +4494,7 @@ class Subtensor:
         involvement in the network's delegation and consensus mechanisms.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry(encoded_coldkey_: List[int]):
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -4609,7 +4609,7 @@ class Subtensor:
             Exception: If the substrate call fails after the maximum number of retries.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             return await self.substrate.query(
                 module="SubtensorModule", storage_function="NominatorMinRequiredStake"
@@ -4875,7 +4875,7 @@ class Subtensor:
         if uid is None:
             return NeuronInfo.get_null_neuron()
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             block_hash = (
                 None if block is None else await self.substrate.get_block_hash(block)
@@ -5220,7 +5220,7 @@ class Subtensor:
             bool: ``True`` if the delegation is successful, ``False`` otherwise.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -5271,7 +5271,7 @@ class Subtensor:
             bool: ``True`` if the undelegation is successful, ``False`` otherwise.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -5321,7 +5321,7 @@ class Subtensor:
             bool: ``True`` if the nomination is successful, ``False`` otherwise.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -5372,7 +5372,7 @@ class Subtensor:
             bool: ``True`` if the take rate increase is successful, ``False`` otherwise.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -5426,7 +5426,7 @@ class Subtensor:
             bool: ``True`` if the take rate decrease is successful, ``False`` otherwise.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             call = await self.substrate.compose_call(
                 call_module="SubtensorModule",
@@ -5476,7 +5476,7 @@ class Subtensor:
         """
         try:
 
-            @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+            @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
             async def make_substrate_call_with_retry():
                 return await self.substrate.query(
                     module="System",
@@ -5509,7 +5509,7 @@ class Subtensor:
         operations on the blockchain. It serves as a reference point for network activities and data synchronization.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             return await self.substrate.get_block_number(None)  # type: ignore
 
@@ -5530,7 +5530,7 @@ class Subtensor:
         including the distribution of financial resources and the financial status of network participants.
         """
 
-        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
         async def make_substrate_call_with_retry():
             return await self.substrate.query_map(
                 module="System",


### PR DESCRIPTION
Added in reraising logic for all `@retry` attempts, to keep consistency with older retry logic.

The old `@retry` would reraise the last exception. This changes in tenacity. To get the same execution, I added the `reraise=True` arg to each call.
