### PR TITLE
Fix e2e tests

### DIFF
--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -48,7 +48,6 @@ def local_chain(request):
     # install neuron templates
     logging.info("downloading and installing neuron templates from github")
     # TODO: remove `specific_commit=get_latest_commit_hash()` logging after async migration done
-    # last commit of https://github.com/opentensor/bittensor-subnet-template/commits/async-metagraph-for-async-e2e-tests-only/
     templates_dir = clone_or_update_templates(specific_commit=get_latest_commit_hash())
     install_templates(templates_dir)
 

--- a/tests/e2e_tests/multistep/test_axon.py
+++ b/tests/e2e_tests/multistep/test_axon.py
@@ -12,7 +12,6 @@ from tests.e2e_tests.utils import (
     setup_wallet,
     template_path,
     templates_repo,
-    write_output_log_to_file,
 )
 
 """
@@ -90,14 +89,6 @@ async def test_axon(local_chain):
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-
-    # TODO: remove `write_output_log_to_file` logging after async migration done
-    # record logs of process
-    # Create tasks to read stdout and stderr concurrently
-    # ignore, don't await coroutine, just write logs to file
-    asyncio.create_task(write_output_log_to_file("axon_stdout", axon_process.stdout))
-    # ignore, dont await coroutine, just write logs to file
-    asyncio.create_task(write_output_log_to_file("axon_stderr", axon_process.stderr))
 
     # wait for 5 seconds for the metagraph to refresh with latest data
     await asyncio.sleep(5)

--- a/tests/e2e_tests/multistep/test_axon.py
+++ b/tests/e2e_tests/multistep/test_axon.py
@@ -29,10 +29,6 @@ are set correctly, and that the miner is currently running
 """
 
 
-# TODO: fix metagraph definition on https://github.com/opentensor/bittensor-subnet-template/blob/main/template/base/neuron.py#L82-L93
-@pytest.mark.skip(
-    "metagraph have to be fixed here https://github.com/opentensor/bittensor-subnet-template/blob/main/template/base/neuron.py#L82-L93"
-)
 @pytest.mark.asyncio
 async def test_axon(local_chain):
     # Register root as Alice

--- a/tests/e2e_tests/multistep/test_dendrite.py
+++ b/tests/e2e_tests/multistep/test_dendrite.py
@@ -17,7 +17,6 @@ from tests.e2e_tests.utils import (
     template_path,
     templates_repo,
     wait_interval,
-    write_output_log_to_file,
 )
 
 
@@ -120,18 +119,6 @@ async def test_dendrite(local_chain):
         cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
-    )
-
-    # TODO: remove `write_output_log_to_file` logging after async migration done
-    # record logs of process
-    # Create tasks to read stdout and stderr concurrently
-    # ignore, dont await coroutine, just write logs to file
-    asyncio.create_task(
-        write_output_log_to_file("dendrite_stdout", dendrite_process.stdout)
-    )
-    # ignore, dont await coroutine, just write logs to file
-    asyncio.create_task(
-        write_output_log_to_file("dendrite_stderr", dendrite_process.stderr)
     )
 
     await asyncio.sleep(

--- a/tests/e2e_tests/multistep/test_incentive.py
+++ b/tests/e2e_tests/multistep/test_incentive.py
@@ -17,7 +17,6 @@ from tests.e2e_tests.utils import (
     template_path,
     templates_repo,
     wait_interval,
-    write_output_log_to_file,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -118,13 +117,6 @@ async def test_incentive(local_chain):
         stderr=asyncio.subprocess.PIPE,
     )
 
-    # TODO: remove `write_output_log_to_file` logging after async migration done
-    # Create tasks to read stdout and stderr concurrently
-    # ignore, don't await coroutine, just write logs to file
-    asyncio.create_task(write_output_log_to_file("miner_stdout", miner_process.stdout))
-    # ignore, dont await coroutine, just write logs to file
-    asyncio.create_task(write_output_log_to_file("miner_stderr", miner_process.stderr))
-
     await asyncio.sleep(
         5
     )  # wait for 5 seconds for the metagraph to refresh with latest data
@@ -156,17 +148,6 @@ async def test_incentive(local_chain):
         cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
-    )
-
-    # TODO: remove `write_output_log_to_file` logging after async migration done
-    # Create tasks to read stdout and stderr concurrently and write output to log file
-    # ignore, don't await coroutine, just write logs to file
-    asyncio.create_task(
-        write_output_log_to_file("validator_stdout", validator_process.stdout)
-    )
-    # ignore, dont await coroutine, just write logs to file
-    asyncio.create_task(
-        write_output_log_to_file("validator_stderr", validator_process.stderr)
     )
 
     await asyncio.sleep(

--- a/tests/e2e_tests/subcommands/hyperparams/test_liquid_alpha.py
+++ b/tests/e2e_tests/subcommands/hyperparams/test_liquid_alpha.py
@@ -20,8 +20,6 @@ Verify that:
 """
 
 
-# TODO: fix test after merge
-@pytest.mark.skip("debugging of the result by log lines is required")
 @pytest.mark.asyncio
 async def test_liquid_alpha_enabled(local_chain, capsys):
     # Register root as Alice

--- a/tests/e2e_tests/subcommands/stake/test_stake_show.py
+++ b/tests/e2e_tests/subcommands/stake/test_stake_show.py
@@ -4,8 +4,6 @@ from bittensor.commands.stake import StakeShow
 from ...utils import setup_wallet
 
 
-# TODO: fix test after merge
-@pytest.mark.skip("debugging of the result by log lines is required")
 @pytest.mark.asyncio
 async def test_stake_show(local_chain, capsys):
     keypair, exec_command, wallet = await setup_wallet("//Alice")
@@ -42,10 +40,10 @@ async def test_stake_show(local_chain, capsys):
     assert values2[2] == "0/d", f"Expected '0/d', got {values2[2]}."
 
     # Check the third line of data
-    values3 = lines[3].strip().split()
+    values3 = lines[4].strip().split()
     assert (
         values3[0].replace("τ", "") == "1000000.00000"
-    ), f"Expected '1000000.00000', got {values3[0]}."
+    ), f"Expected '1000000.00000', got {values3[1]}."
     assert (
         values3[1].replace("τ", "") == "0.00000"
     ), f"Expected '0.00000', got {values3[1]}."

--- a/tests/e2e_tests/utils.py
+++ b/tests/e2e_tests/utils.py
@@ -15,7 +15,7 @@ template_path = os.getcwd() + "/neurons/"
 templates_repo = "templates repository"
 
 # TODO: remove `ASYNC_TEMPL_URL` logging after async migration done
-ASYNC_TEMPL_URL = "https://api.github.com/repos/opentensor/bittensor-subnet-template/commits/async-metagraph-for-async-e2e-tests-only"
+ASYNC_TEMPL_URL = "https://api.github.com/repos/opentensor/bittensor-subnet-template/commits/for-async-e2e-tests-only-do-not-use-for-cloning"
 
 
 async def setup_wallet(uri: str):


### PR DESCRIPTION
PR fixes 3 e2e tests:
- `tests/e2e_tests/multistep/test_axon.py`
-  `tests/e2e_tests/subcommands/hyperparams/test_liquid_alpha.py`
-  `tests/e2e_tests/subcommands/stake/test_stake_show.py`

For this PR, the "https://github.com/opentensor/bittensor-subnet-template/commits/async-metagraph-for-async-e2e-tests-only/" branch for asynchronous execution of e2e tests was updated.