### PR TITLE
Adds feature to get arbitration period for coldkey swap

### DIFF
--- a/bittensor/commands/schedule_coldkey_swap.py
+++ b/bittensor/commands/schedule_coldkey_swap.py
@@ -4,6 +4,7 @@ import sys
 from rich.prompt import Confirm, Prompt
 
 import bittensor
+from bittensor.utils.formatting import convert_blocks_to_time
 from . import defaults
 
 console = bittensor.__console__
@@ -118,9 +119,15 @@ class ScheduleColdKeySwapCommand:
                 "Good news. There has been no previous key swap initiated for your coldkey swap."
             )
         if arbitration_check == 1:
+            arbitration_remaining = subtensor.get_remaining_arbitration_period(wallet.coldkey.ss58_address)
+            hours, minutes, seconds = convert_blocks_to_time(arbitration_remaining)
             bittensor.__console__.print(
                 ":warning:[yellow]There has been a swap request made for this key previously."
                 " By proceeding, you understand this will initiate arbitration for your key.[/yellow]"
+            )
+            bittensor.__console__.print(
+                f"[yellow]Your key swap is scheduled for {hours} hours, {minutes} minutes, {seconds} seconds"
+                f" from now.[/yellow]"
             )
         if arbitration_check > 1:
             bittensor.__console__.print(

--- a/bittensor/commands/schedule_coldkey_swap.py
+++ b/bittensor/commands/schedule_coldkey_swap.py
@@ -119,7 +119,9 @@ class ScheduleColdKeySwapCommand:
                 "Good news. There has been no previous key swap initiated for your coldkey swap."
             )
         if arbitration_check == 1:
-            arbitration_remaining = subtensor.get_remaining_arbitration_period(wallet.coldkey.ss58_address)
+            arbitration_remaining = subtensor.get_remaining_arbitration_period(
+                wallet.coldkey.ss58_address
+            )
             hours, minutes, seconds = convert_blocks_to_time(arbitration_remaining)
             bittensor.__console__.print(
                 ":warning:[yellow]There has been a swap request made for this key previously."

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -44,8 +44,7 @@ from bittensor.btlogging import logging as _logger
 from bittensor.utils import torch, weight_utils, format_error_message
 from bittensor.utils.registration import (
     POWSolution,
-    create_pow,
-    torch,
+    create_pow
 )
 
 from .chain_data import (
@@ -113,7 +112,6 @@ from .utils import (
     networking,
 )
 from .utils.balance import Balance
-from .utils.registration import POWSolution
 from .utils.registration import legacy_torch_api_compat
 from .utils.subtensor import get_subtensor_errors
 

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -28,6 +28,7 @@ import socket
 import time
 from typing import List, Dict, Union, Optional, Tuple, TypedDict, Any
 
+import base58
 import numpy as np
 import scalecodec
 from numpy.typing import NDArray
@@ -2409,6 +2410,25 @@ class Subtensor:
                 "SubtensorModule", "ColdkeySwapDestinations", params=[ss58_address]
             )
         )
+    
+    def check_remaining_arbitration_period(self, ss58_address: str) -> int:
+        """
+        Checks
+        """
+        params = [
+            {
+                "name": "coldkey",
+                "type": "u64"
+            }
+        ]
+        decoded_bytes = base58.b58decode(ss58_address)
+        u64_value = int.from_bytes(decoded_bytes, byteorder='little')
+        encoded = scalecodec.ss58_encode(decoded_bytes, 32)
+        print(encoded)
+        result = self.state_call(
+            "get_remaining_arbitration_period", encoded
+        )
+        return result
 
     ##########
     # Senate #

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -42,10 +42,7 @@ from substrateinterface.exceptions import SubstrateRequestException
 import bittensor
 from bittensor.btlogging import logging as _logger
 from bittensor.utils import torch, weight_utils, format_error_message
-from bittensor.utils.registration import (
-    POWSolution,
-    create_pow
-)
+from bittensor.utils.registration import POWSolution, create_pow
 
 from .chain_data import (
     DelegateInfoLite,
@@ -2411,7 +2408,7 @@ class Subtensor:
         )
 
     def get_remaining_arbitration_period(
-            self, coldkey_ss58: str, block: Optional[int] = None
+        self, coldkey_ss58: str, block: Optional[int] = None
     ) -> Optional[int]:
         """
         Retrieves the remaining arbitration period for a given coldkey.
@@ -2431,7 +2428,7 @@ class Subtensor:
 
         if block is None:
             block = self.block
-        
+
         if arbitration_block.value > block:
             return arbitration_block.value - block
         else:

--- a/bittensor/utils/formatting.py
+++ b/bittensor/utils/formatting.py
@@ -20,3 +20,11 @@ def millify(n: int):
     )
 
     return "{:.2f}{}".format(n / 10 ** (3 * millidx), millnames[millidx])
+
+
+def convert_blocks_to_time(blocks: int, block_time: int = 12) -> tuple[int, int, int]:
+    seconds = blocks * block_time
+    hours = seconds // 3600
+    minutes = (seconds % 3600) // 60
+    remaining_seconds = seconds % 60
+    return hours, minutes, remaining_seconds

--- a/bittensor/utils/formatting.py
+++ b/bittensor/utils/formatting.py
@@ -23,6 +23,14 @@ def millify(n: int):
 
 
 def convert_blocks_to_time(blocks: int, block_time: int = 12) -> tuple[int, int, int]:
+    """
+    Converts number of blocks into number of hours, minutes, seconds.
+
+    :param blocks: number of blocks
+    :param block_time: time per block, by default this is 12
+
+    :return: tuple containing number of hours, number of minutes, number of seconds
+    """
     seconds = blocks * block_time
     hours = seconds // 3600
     minutes = (seconds % 3600) // 60

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2294,3 +2294,24 @@ def test_get_remaining_arbitration_period(subtensor, mocker):
     )
     # if we change the methods logic in the future we have to be make sure the returned type is correct
     assert result == 0
+
+
+def test_get_remaining_arbitration_period_happy(subtensor, mocker):
+    """Tests successful retrieval of total stake for hotkey."""
+    # Prep
+    subtensor.query_subtensor = mocker.MagicMock(
+        return_value=mocker.MagicMock(value=2000)
+    )
+    fake_ss58_address = "12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU"
+
+    # Call
+    result = subtensor.get_remaining_arbitration_period(
+        coldkey_ss58=fake_ss58_address, block=200
+    )
+
+    # Assertions
+    subtensor.query_subtensor.assert_called_once_with(
+        name="ColdkeyArbitrationBlock", block=200, params=[fake_ss58_address]
+    )
+    # if we change the methods logic in the future we have to be make sure the returned type is correct
+    assert result == 1800  # 2000 - 200

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2277,3 +2277,20 @@ def test_get_delegate_take_no_data(mocker, subtensor):
     subtensor.query_subtensor.assert_called_once_with("Delegates", block, [hotkey_ss58])
     spy_u16_normalized_float.assert_not_called()
     assert result is None
+
+
+def test_get_remaining_arbitration_period(subtensor, mocker):
+    """Tests successful retrieval of total stake for hotkey."""
+    # Prep
+    subtensor.query_subtensor = mocker.MagicMock(return_value=mocker.MagicMock(value=0))
+    fake_ss58_address = "12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU"
+
+    # Call
+    result = subtensor.get_remaining_arbitration_period(coldkey_ss58=fake_ss58_address)
+
+    # Assertions
+    subtensor.query_subtensor.assert_called_once_with(
+        name="ColdkeyArbitrationBlock", block=None, params=[fake_ss58_address]
+    )
+    # if we change the methods logic in the future we have to be make sure the returned type is correct
+    assert result == 0


### PR DESCRIPTION
Adds method in subtensor to get remaining blocks til previously scheduled coldkey swap. Displays this in human readable time when the user begins a coldkey swap using the btcli with a key that has already been scheduled.