### PR TITLE
Fix e2e test hanging

### DIFF
--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -42,16 +42,22 @@ def local_chain(request):
     )
 
     # Pattern match indicates node is compiled and ready
-    pattern = re.compile(r"Successfully ran block step\.")
+    pattern = re.compile(r"Imported #1")
 
     # install neuron templates
     logging.info("downloading and installing neuron templates from github")
     templates_dir = clone_or_update_templates()
     install_templates(templates_dir)
 
+    timestamp = int(time.time())
+
     def wait_for_node_start(process, pattern):
         for line in process.stdout:
             print(line.strip())
+            # 10 min as timeout
+            if int(time.time()) - timestamp > 10 * 60:
+                print("Subtensor not started in time")
+                break
             if pattern.search(line):
                 print("Node started!")
                 break


### PR DESCRIPTION
The e2e testing in subtensor side is hanging. I checked the log, not see the "Successfully ran block step" in the output.
Just change the pattern to imported 1. also add a timeout as 10 min, then it can break from loop if something wrong.