### PR TITLE
ci: github workflow release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,72 @@
+name: Build and Publish Python Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release'
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: Build Python distribution
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build wheel twine
+
+    - name: Build package
+      run: python setup.py sdist bdist_wheel
+
+    - name: Check if package version already exists
+      run: |
+        PACKAGE_NAME=$(python setup.py --name)
+        PACKAGE_VERSION=${{ github.event.inputs.version }}
+        if twine check dist/*; then
+          if pip install $PACKAGE_NAME==$PACKAGE_VERSION; then
+            echo "Error: Version $PACKAGE_VERSION of $PACKAGE_NAME already exists on PyPI"
+            exit 1
+          else
+            echo "Version $PACKAGE_VERSION of $PACKAGE_NAME does not exist on PyPI. Proceeding with upload."
+          fi
+        else
+          echo "Error: Twine check failed."
+          exit 1
+        fi
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: dist/
+
+  approve-and-publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist/
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        verbose: true
+        print-hash: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - 'release/[0-9]+.[0-9]+.[0-9]+'
+      - 'hotfix/[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,9 @@ on:
         description: 'Version to release'
         required: true
         type: string
+  push:
+    branches:
+      - 'release/[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:


### PR DESCRIPTION
## Overview

- Adds pypi release workflow
- This setup eliminates the need for PyPI API tokens, making it more secure. The GitHub Actions runner will obtain a short-lived OIDC token that PyPI will trust based on the publisher configuration.