### PR TITLE
fix: coldkeypub usage instead of coldkey for arbitration_stats

### DIFF
--- a/bittensor/commands/check_coldkey_swap.py
+++ b/bittensor/commands/check_coldkey_swap.py
@@ -30,14 +30,16 @@ def fetch_arbitration_stats(subtensor, wallet):
     """
     Performs a check of the current arbitration data (if any), and displays it through the bittensor console.
     """
-    arbitration_check = len(subtensor.check_in_arbitration(wallet.coldkey.ss58_address))
+    arbitration_check = len(
+        subtensor.check_in_arbitration(wallet.coldkeypub.ss58_address)
+    )
     if arbitration_check == 0:
         bittensor.__console__.print(
             "[green]There has been no previous key swap initiated for your coldkey.[/green]"
         )
     if arbitration_check == 1:
         arbitration_remaining = subtensor.get_remaining_arbitration_period(
-            wallet.coldkey.ss58_address
+            wallet.coldkeypub.ss58_address
         )
         hours, minutes, seconds = convert_blocks_to_time(arbitration_remaining)
         bittensor.__console__.print(


### PR DESCRIPTION
### Usage of the coldkeypub instead of coldkey

Change the method that performs a check of the current arbitration data (if any), use the coldkeypub instead of the coldkey.
It increases the performance as the file decryption doesn't need to occur.
It's also more secure as the password should not be required for that stat.

### Quantitative Performance Benefits

Few seconds.

### Verification Process

Re-ran the method and it works correctly.

### Release Notes

- The Arbitration stats check method now use coldkeypub to improve the performance and the security.