### PR TITLE
Return the metagraph to the style of use familiar to users

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -325,6 +325,7 @@ from .btlogging import logging
 
 # Allows avoiding name spacing conflicts and continue access to the `subtensor` module with `subtensor_module` name
 from . import subtensor as subtensor_module
+
 # Allows avoiding name spacing conflicts and continue access to the `metagraph` module with `metagraph_module` name
 from . import metagraph as metagraph_module
 

--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -325,6 +325,8 @@ from .btlogging import logging
 
 # Allows avoiding name spacing conflicts and continue access to the `subtensor` module with `subtensor_module` name
 from . import subtensor as subtensor_module
+# Allows avoiding name spacing conflicts and continue access to the `metagraph` module with `metagraph_module` name
+from . import metagraph as metagraph_module
 
 # Double import allows using class `Subtensor` by referencing `bittensor.Subtensor` and `bittensor.subtensor`.
 # This will be available for a while until we remove reference `bittensor.subtensor`
@@ -332,7 +334,7 @@ from .subtensor import Subtensor
 from .subtensor import Subtensor as subtensor
 
 from .cli import Cli as cli, COMMANDS as ALL_COMMANDS
-from .metagraph import metagraph as metagraph_class
+from .metagraph import metagraph
 from .threadpool import PriorityThreadPoolExecutor as PriorityThreadPoolExecutor
 
 from .synapse import TerminalInfo, Synapse
@@ -355,14 +357,3 @@ configs = [
     logging.get_config(),
 ]
 defaults = config.merge_all(configs)
-
-
-async def metagraph(
-    netuid: int,
-    network: str = "finney",
-    lite: bool = True,
-    sync: bool = True,
-    subtensor: Optional["Subtensor"] = None,
-):
-    async with metagraph_class(netuid, network, lite, sync, subtensor) as m:
-        return m

--- a/bittensor/commands/metagraph.py
+++ b/bittensor/commands/metagraph.py
@@ -94,9 +94,7 @@ class MetagraphCommand:
         console.print(
             f":satellite: Syncing with chain: [white]{cli.config.subtensor.network}[/white] ..."
         )
-        metagraph: bittensor.metagraph = await subtensor.metagraph(
-            netuid=cli.config.netuid
-        )
+        metagraph: bittensor.metagraph = subtensor.metagraph(netuid=cli.config.netuid)
         metagraph.save()
 
         difficulty, total_issuance_ = await asyncio.gather(

--- a/bittensor/commands/root.py
+++ b/bittensor/commands/root.py
@@ -284,7 +284,7 @@ class RootSetBoostCommand:
         """Set weights for root network."""
         wallet = bittensor.wallet(config=cli.config)
 
-        root = await subtensor.metagraph(0, lite=False)
+        root = subtensor.metagraph(netuid=0, lite=False)
         try:
             my_uid = root.hotkeys.index(wallet.hotkey.ss58_address)
         except ValueError:
@@ -406,7 +406,7 @@ class RootSetSlashCommand:
                 cli.config.netuid, cli.config.amount
             )
         )
-        root = await subtensor.metagraph(0, lite=False)
+        root = subtensor.metagraph(netuid=0, lite=False)
         try:
             my_uid = root.hotkeys.index(wallet.hotkey.ss58_address)
         except ValueError:

--- a/bittensor/metagraph.py
+++ b/bittensor/metagraph.py
@@ -30,7 +30,7 @@ from numpy.typing import NDArray
 
 import bittensor
 from bittensor.chain_data import AxonInfo
-from bittensor.utils import weight_utils
+from bittensor.utils import weight_utils, get_async_result
 from bittensor.utils.registration import torch, use_torch
 
 METAGRAPH_STATE_DICT_NDARRAY_KEYS = [
@@ -947,14 +947,8 @@ class TorchMetaGraph(MetagraphMixin, BaseClass):  # type: ignore
         self.should_sync = sync
         self.lite = lite
         self.subtensor = subtensor
-
-    async def __aenter__(self):
-        if self.should_sync:
-            await self.sync(block=None, lite=self.lite, subtensor=self.subtensor)
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        pass
+        if sync:
+            get_async_result(self.sync, block=None, lite=self.lite, subtensor=subtensor)
 
     async def _set_metagraph_attributes(
         self, subtensor: "bittensor.subtensor", block: Optional[int] = None
@@ -1100,14 +1094,8 @@ class NonTorchMetagraph(MetagraphMixin):
         self.should_sync = sync
         self.lite = lite
         self.subtensor = subtensor
-
-    async def __aenter__(self):
-        if self.should_sync:
-            await self.sync(block=None, lite=self.lite, subtensor=self.subtensor)
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        pass
+        if sync:
+            get_async_result(self.sync, block=None, lite=self.lite, subtensor=subtensor)
 
     async def _set_metagraph_attributes(
         self, subtensor: "bittensor.subtensor", block: Optional[int] = None

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -5040,7 +5040,9 @@ class Subtensor:
         network's decentralized architecture, particularly in relation to neuron interconnectivity and consensus
             processes.
         """
-        return bittensor.metagraph(network=self.network, netuid=netuid, lite=lite, subtensor=self)
+        return bittensor.metagraph(
+            network=self.network, netuid=netuid, lite=lite, subtensor=self
+        )
 
     async def incentive(self, netuid: int, block: Optional[int] = None) -> List[int]:
         """

--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -2873,7 +2873,7 @@ class Subtensor:
         Returns:
             str: The commitment data as a string.
         """
-        metagraph = await self.metagraph(netuid)
+        metagraph = self.metagraph(netuid)
         hotkey = metagraph.hotkeys[uid]  # type: ignore
 
         metadata = await get_metadata(self, netuid, hotkey, block)
@@ -5018,7 +5018,7 @@ class Subtensor:
 
         return NeuronInfoLite.list_from_vec_u8(bytes_result)  # type: ignore
 
-    async def metagraph(
+    def metagraph(
         self,
         netuid: int,
         lite: bool = True,
@@ -5040,10 +5040,7 @@ class Subtensor:
         network's decentralized architecture, particularly in relation to neuron interconnectivity and consensus
             processes.
         """
-        metagraph_ = await bittensor.metagraph(
-            network=self.network, netuid=netuid, lite=lite, subtensor=self
-        )
-        return metagraph_
+        return bittensor.metagraph(network=self.network, netuid=netuid, lite=lite, subtensor=self)
 
     async def incentive(self, netuid: int, block: Optional[int] = None) -> List[int]:
         """

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -16,6 +16,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+import asyncio
 import hashlib
 from typing import Callable, List, Dict, Literal, Tuple
 
@@ -284,3 +285,49 @@ def format_error_message(error_message: dict) -> str:
         err_docs = error_message.get("docs", [])
         err_description = err_docs[0] if len(err_docs) > 0 else err_description
     return f"Subtensor returned `{err_name} ({err_type})` error. This means: `{err_description}`"
+
+
+def get_async_result(cor_func, *args, **kwargs):
+    """
+    Executes an asynchronous function and returns its result.
+
+    This function creates a new coroutine for the given asynchronous function to avoid the `cannot reuse already awaited coroutine` error, and runs it using `asyncio.run`.
+
+    Args:
+        cor_func (coroutine): The asynchronous function to be executed.
+        *args: Positional arguments to pass to the asynchronous function.
+        **kwargs: Keyword arguments to pass to the asynchronous function.
+
+    Returns:
+        The result of the asynchronous function.
+
+        Examples:
+        >>> async def sample_coroutine(x, y):
+        ...     # some async staff here
+        ...     return x + y
+        ...
+        >>> result = get_async_result(sample_coroutine, 2, 3)
+        >>> print(result)
+        5
+        >>> async def fetch_data(uri):
+        ...     async with aiohttp.ClientSession() as session:
+        ...         async with session.get(uri) as response:
+        ...             return await response.text()
+        ...
+        >>> url = "https://www.example.com"
+        >>> html_content = get_async_result(fetch_data, url)
+        >>> print(html_content)
+
+        >>> async def main():
+        ...     await asyncio.sleep(2)
+        ...     return "Finished"
+        ...
+        >>> result = get_async_result(main)
+        >>> print(result)
+        "Finished"
+    """
+    # To avoid the `cannot reuse already awaited coroutine` error, I need to create a new coroutine every time.
+    def create_coroutine(cor_func_, *args_, **kwargs_):
+        return cor_func_(*args_, **kwargs_)
+
+    return asyncio.run(create_coroutine(cor_func, *args, **kwargs))

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -326,6 +326,7 @@ def get_async_result(cor_func, *args, **kwargs):
         >>> print(result)
         "Finished"
     """
+
     # To avoid the `cannot reuse already awaited coroutine` error, I need to create a new coroutine every time.
     def create_coroutine(cor_func_, *args_, **kwargs_):
         return cor_func_(*args_, **kwargs_)

--- a/bittensor/utils/weight_utils.py
+++ b/bittensor/utils/weight_utils.py
@@ -21,7 +21,7 @@ Conversion for weight between chain representation and np.array or torch.Tensor
 
 import hashlib
 import logging
-from typing import Tuple, List, Union
+from typing import Tuple, List, Union, Optional
 
 import numpy as np
 from numpy.typing import NDArray
@@ -239,7 +239,7 @@ def process_weights_for_netuid(
     weights: Union[NDArray[np.float32], "torch.Tensor"],
     netuid: int,
     subtensor: "bittensor.subtensor",
-    metagraph: "bittensor.metagraph" = None,
+    metagraph: Optional["bittensor.metagraph"] = None,
     exclude_quantile: int = 0,
 ) -> Union[
     Tuple["torch.Tensor", "torch.FloatTensor"],
@@ -253,7 +253,7 @@ def process_weights_for_netuid(
 
     # Get latest metagraph from chain if metagraph is None.
     if metagraph is None:
-        metagraph = subtensor.metagraph(netuid)
+        metagraph = subtensor.metagraph(netuid=netuid)
 
     # Cast weights to floats.
     if use_torch():

--- a/tests/e2e_tests/multistep/test_axon.py
+++ b/tests/e2e_tests/multistep/test_axon.py
@@ -48,7 +48,7 @@ async def test_axon(local_chain):
         ],
     )
     subtensor = bittensor.subtensor(network="ws://localhost:9945")
-    metagraph = await bittensor.metagraph(
+    metagraph = bittensor.metagraph(
         netuid=1, network="ws://localhost:9945", subtensor=subtensor
     )
 
@@ -84,7 +84,7 @@ async def test_axon(local_chain):
         ]
     )
 
-    axon_process = await asyncio.create_subprocess_shell(
+    await asyncio.create_subprocess_shell(
         cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
@@ -95,9 +95,7 @@ async def test_axon(local_chain):
 
     # refresh metagraph
     subtensor = bittensor.subtensor(network="ws://localhost:9945")
-    metagraph = await bittensor.metagraph(
-        netuid=1, network="ws://localhost:9945", sync=True, subtensor=subtensor
-    )
+    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945", sync=True, subtensor=subtensor)
     updated_axon = metagraph.axons[0]
     external_ip = networking.get_external_ip()
 

--- a/tests/e2e_tests/multistep/test_axon.py
+++ b/tests/e2e_tests/multistep/test_axon.py
@@ -95,7 +95,9 @@ async def test_axon(local_chain):
 
     # refresh metagraph
     subtensor = bittensor.subtensor(network="ws://localhost:9945")
-    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945", sync=True, subtensor=subtensor)
+    metagraph = bittensor.metagraph(
+        netuid=1, network="ws://localhost:9945", sync=True, subtensor=subtensor
+    )
     updated_axon = metagraph.axons[0]
     external_ip = networking.get_external_ip()
 

--- a/tests/e2e_tests/multistep/test_dendrite.py
+++ b/tests/e2e_tests/multistep/test_dendrite.py
@@ -54,7 +54,7 @@ async def test_dendrite(local_chain):
             "1",
         ],
     )
-    metagraph = await bittensor.metagraph(netuid=1, network="ws://localhost:9945")
+    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945")
     neuron = metagraph.neurons[0]
 
     subtensor = bittensor.subtensor(network="ws://localhost:9945")
@@ -80,9 +80,7 @@ async def test_dendrite(local_chain):
     )
 
     # refresh metagraph
-    metagraph = await bittensor.metagraph(
-        netuid=1, network="ws://localhost:9945", sync=True
-    )
+    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945", sync=True)
     neuron = metagraph.neurons[0]
     # assert stake is 10000
     assert neuron.stake.tao == 10_000.0
@@ -151,9 +149,7 @@ async def test_dendrite(local_chain):
     await wait_interval(360, subtensor)
 
     # refresh metagraph
-    metagraph = await bittensor.metagraph(
-        netuid=1, network="ws://localhost:9945", sync=True
-    )
+    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945", sync=True)
     # refresh validator neuron
     neuron = metagraph.neurons[0]
     assert len(metagraph.neurons) == 1

--- a/tests/e2e_tests/multistep/test_incentive.py
+++ b/tests/e2e_tests/multistep/test_incentive.py
@@ -227,7 +227,9 @@ async def test_incentive(local_chain):
     await wait_interval(360, subtensor)
 
     # refresh metagraph
-    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945", subtensor=subtensor)
+    metagraph = bittensor.metagraph(
+        netuid=1, network="ws://localhost:9945", subtensor=subtensor
+    )
 
     # get current emissions and validate that Alice has gotten tao
     bob_neuron = metagraph.neurons[1]

--- a/tests/e2e_tests/multistep/test_incentive.py
+++ b/tests/e2e_tests/multistep/test_incentive.py
@@ -190,7 +190,7 @@ async def test_incentive(local_chain):
     )
 
     # get latest metagraph
-    metagraph = await bittensor.metagraph(
+    metagraph = bittensor.metagraph(
         netuid=1, network="ws://localhost:9945", subtensor=subtensor
     )
 
@@ -227,9 +227,7 @@ async def test_incentive(local_chain):
     await wait_interval(360, subtensor)
 
     # refresh metagraph
-    metagraph = await bittensor.metagraph(
-        netuid=1, network="ws://localhost:9945", subtensor=subtensor
-    )
+    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945", subtensor=subtensor)
 
     # get current emissions and validate that Alice has gotten tao
     bob_neuron = metagraph.neurons[1]

--- a/tests/e2e_tests/subcommands/register/tests_swap_hotkey.py
+++ b/tests/e2e_tests/subcommands/register/tests_swap_hotkey.py
@@ -169,7 +169,7 @@ async def test_swap_hotkey_validator_owner(local_chain):
     )
 
     # get latest metagraph
-    metagraph = await bittensor.metagraph(netuid=1, network="ws://localhost:9945")
+    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945")
     subtensor = bittensor.subtensor(network="ws://localhost:9945")
 
     # assert alice has old hotkey
@@ -251,7 +251,7 @@ async def test_swap_hotkey_validator_owner(local_chain):
     )
 
     # get latest metagraph
-    metagraph = await bittensor.metagraph(netuid=1, network="ws://localhost:9945")
+    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945")
     subtensor = bittensor.subtensor(network="ws://localhost:9945")
 
     # assert Alice has new hotkey
@@ -432,7 +432,7 @@ async def test_swap_hotkey_miner(local_chain):
     )
 
     # get latest metagraph
-    metagraph = await bittensor.metagraph(netuid=1, network="ws://localhost:9945")
+    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945")
     subtensor = bittensor.subtensor(network="ws://localhost:9945")
 
     # assert bob has old hotkey
@@ -509,7 +509,7 @@ async def test_swap_hotkey_miner(local_chain):
     )
 
     # get latest metagraph
-    metagraph = await bittensor.metagraph(netuid=1, network="ws://localhost:9945")
+    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945")
     subtensor = bittensor.subtensor(network="ws://localhost:9945")
 
     # assert bob has new hotkey

--- a/tests/e2e_tests/utils.py
+++ b/tests/e2e_tests/utils.py
@@ -15,7 +15,7 @@ template_path = os.getcwd() + "/neurons/"
 templates_repo = "templates repository"
 
 # TODO: remove `ASYNC_TEMPL_URL` logging after async migration done
-ASYNC_TEMPL_URL = "https://api.github.com/repos/opentensor/bittensor-subnet-template/commits/for-async-e2e-tests-only-do-not-use-for-cloning"
+ASYNC_TEMPL_URL = "https://api.github.com/repos/opentensor/bittensor-subnet-template/commits/for-staging-async-only-do-not-use-for-cloning"
 
 
 async def setup_wallet(uri: str):

--- a/tests/integration_tests/test_metagraph_integration.py
+++ b/tests/integration_tests/test_metagraph_integration.py
@@ -41,9 +41,7 @@ def setUpModule():
 class TestMetagraph:
     def setup_method(self):
         self.sub = MockSubtensor()
-        self.metagraph = asyncio.run(
-            bittensor.metagraph(netuid=3, network="mock", sync=False)
-        )
+        self.metagraph = bittensor.metagraph(netuid=3, network="mock", sync=False)
 
     def test_print_empty(self):
         print(self.metagraph)

--- a/tests/unit_tests/test_metagraph.py
+++ b/tests/unit_tests/test_metagraph.py
@@ -58,7 +58,7 @@ def mock_environment():
 @pytest.mark.asyncio
 async def test_set_metagraph_attributes(mock_environment):
     subtensor, neurons = mock_environment
-    metagraph = await bittensor.metagraph(1)
+    metagraph = bittensor.metagraph(1)
     metagraph.neurons = neurons
     await metagraph._set_metagraph_attributes(subtensor=subtensor, block=5)
 
@@ -97,7 +97,7 @@ async def test_set_metagraph_attributes(mock_environment):
 @pytest.mark.asyncio
 async def test_process_weights_or_bonds(mock_environment):
     _, neurons = mock_environment
-    metagraph = await bittensor.metagraph(1)
+    metagraph = bittensor.metagraph(1)
     metagraph.neurons = neurons
 
     # Test weights processing


### PR DESCRIPTION
- added a function for reusing coroutines
- fixed the call to the async method in the metagraph
- fixed tests
- it was necessary to create a separate branch https://github.com/opentensor/bittensor-subnet-template/tree/for-staging-async-only-do-not-use-for-cloning with a fixed use of the metagraph. 
