### PR TITLE
test: fix mocksubtensor query previous blocks

### DIFF
--- a/bittensor/mock/subtensor_mock.py
+++ b/bittensor/mock/subtensor_mock.py
@@ -624,7 +624,7 @@ class MockSubtensor(Subtensor):
             state_at_block = state.get(block, None)
             while state_at_block is None and block > 0:
                 block -= 1
-                state_at_block = self.state.get(block, None)
+                state_at_block = state.get(block, None)
             if state_at_block is not None:
                 return SimpleNamespace(value=state_at_block)
 

--- a/tests/integration_tests/test_subtensor_integration.py
+++ b/tests/integration_tests/test_subtensor_integration.py
@@ -115,6 +115,16 @@ class TestSubtensor(unittest.TestCase):
         block = self.subtensor.get_current_block()
         assert type(block) == int
 
+    def test_do_block_step(self):
+        self.subtensor.do_block_step()
+        block = self.subtensor.get_current_block()
+        assert type(block) == int
+
+    def test_do_block_step_query_previous_block(self):
+        self.subtensor.do_block_step()
+        block = self.subtensor.get_current_block()
+        self.subtensor.query_subtensor("NetworksAdded", block)
+
     def test_unstake(self):
         self.subtensor._do_unstake = MagicMock(return_value=True)
 


### PR DESCRIPTION
<!--

### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.

-->

### Bug
There is typo when `MockSubtensor.query_subtensor` function checks previous blocks
`self.state.get(block, None) -> state.get(block, None)`
<!-- Link to the issue describing the bug that you're fixing. -->

### Description of the Change
Discovered internally

Changed to proper variable name
Added tests
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
N/A
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks
N/A
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Verification Process
This functionality had no tests. All tests are passing
<!--

What process did you follow to verify that the change has not introduced any regressions?
Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes
* Fixed an issue where querying mock subtensor's older blocks led to an error
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->