### PR TITLE
Removes extra no_prompts in commands

### DIFF
--- a/bittensor/commands/metagraph.py
+++ b/bittensor/commands/metagraph.py
@@ -16,8 +16,11 @@
 # DEALINGS IN THE SOFTWARE.
 
 import argparse
-import bittensor
+
 from rich.table import Table
+
+import bittensor
+
 from .utils import check_netuid_set
 
 console = bittensor.__console__  # type: ignore
@@ -259,13 +262,6 @@ class MetagraphCommand:
             dest="netuid",
             type=int,
             help="""Set the netuid to get the metagraph of""",
-            default=False,
-        )
-        metagraph_parser.add_argument(
-            "--no_prompt",
-            dest="no_prompt",
-            action="store_true",
-            help="""Set true to avoid prompting the user.""",
             default=False,
         )
 

--- a/bittensor/commands/network.py
+++ b/bittensor/commands/network.py
@@ -534,13 +534,6 @@ class SubnetHyperparamsCommand:
         parser.add_argument(
             "--netuid", dest="netuid", type=int, required=False, default=False
         )
-        parser.add_argument(
-            "--no_prompt",
-            dest="no_prompt",
-            action="store_true",
-            help="""Set true to avoid prompting the user.""",
-            default=False,
-        )
         bittensor.subtensor.add_args(parser)
 
 
@@ -638,13 +631,6 @@ class SubnetGetHyperparamsCommand:
         parser = parser.add_parser("get", help="""View subnet hyperparameters""")
         parser.add_argument(
             "--netuid", dest="netuid", type=int, required=False, default=False
-        )
-        parser.add_argument(
-            "--no_prompt",
-            dest="no_prompt",
-            action="store_true",
-            help="""Set true to avoid prompting the user.""",
-            default=False,
         )
         bittensor.subtensor.add_args(parser)
 

--- a/bittensor/commands/wallets.py
+++ b/bittensor/commands/wallets.py
@@ -16,15 +16,18 @@
 # DEALINGS IN THE SOFTWARE.
 
 import argparse
-import bittensor
 import os
 import sys
-from rich.prompt import Prompt, Confirm
-from rich.table import Table
-from typing import Optional, List, Tuple
-from . import defaults
+from typing import List, Optional, Tuple
+
 import requests
+from rich.prompt import Confirm, Prompt
+from rich.table import Table
+
+import bittensor
+
 from ..utils import RAOPERTAO
+from . import defaults
 
 
 class RegenColdkeyCommand:
@@ -637,7 +640,6 @@ class UpdateWalletCommand:
 
     Optional arguments:
         - ``--all`` (bool): When set, updates all legacy wallets.
-        - ``--no_prompt`` (bool): Disables user prompting during the update process.
 
     Example usage::
 

--- a/bittensor/wallet.py
+++ b/bittensor/wallet.py
@@ -17,13 +17,15 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import os
-import copy
 import argparse
-import bittensor
-from termcolor import colored
+import copy
+import os
+from typing import Dict, Optional, Tuple, Union, overload
+
 from substrateinterface import Keypair
-from typing import Optional, Union, Tuple, Dict, overload
+from termcolor import colored
+
+import bittensor
 from bittensor.utils import is_valid_bittensor_address_or_public_key
 
 
@@ -138,18 +140,11 @@ class wallet:
             parser (argparse.ArgumentParser): Argument parser object.
             prefix (str): Argument prefix.
         """
-        prefix_str = "" if prefix == None else prefix + "."
+        prefix_str = "" if prefix is None else prefix + "."
         try:
             default_name = os.getenv("BT_WALLET_NAME") or "default"
             default_hotkey = os.getenv("BT_WALLET_NAME") or "default"
             default_path = os.getenv("BT_WALLET_PATH") or "~/.bittensor/wallets/"
-            parser.add_argument(
-                "--no_prompt",
-                dest="no_prompt",
-                action="store_true",
-                help="""Set true to avoid prompting the user.""",
-                default=False,
-            )
             parser.add_argument(
                 "--" + prefix_str + "wallet.name",
                 required=False,


### PR DESCRIPTION
This PR removes additional `no_prompt` args added directly in the command parsers and wallet.py. 
We already get `no_prompt` functionality through the default config which is passed in every command. 