### PR TITLE
Adds timeout for e2e tests

### DIFF
--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -46,6 +46,7 @@ jobs:
   run:
     needs: find-tests
     runs-on: SubtensorCI
+    timeout-minutes: 45
     strategy:
       fail-fast: false  # Allow other matrix jobs to run even if this job fails
       max-parallel: 8  # Set the maximum number of parallel jobs


### PR DESCRIPTION
In some cases where the e2e tests keep running indefinitely, we need a timeout to halt the tests to preserve credits. 
Currently, we've set 45 minutes - we will be observing if this is good enough with PRs in staging before rolling it out. 