### PR TITLE
fix: updates test_axon verify body async tests

### DIFF
--- a/tests/unit_tests/test_axon.py
+++ b/tests/unit_tests/test_axon.py
@@ -285,6 +285,7 @@ async def test_priority_pass(middleware):
         ),
     ],
 )
+@pytest.mark.asyncio
 async def test_verify_body_integrity_happy_path(
     mock_request, axon_instance, body, expected
 ):
@@ -301,11 +302,12 @@ async def test_verify_body_integrity_happy_path(
 @pytest.mark.parametrize(
     "body, expected_exception_message",
     [
-        (b"", "EOFError"),  # Empty body
-        (b"not_json", "JSONDecodeError"),  # Non-JSON body
+        (b"", "Expecting value: line 1 column 1 (char 0)"),  # Empty body
+        (b"not_json", "Expecting value: line 1 column 1 (char 0)"),  # Non-JSON body
     ],
     ids=["empty_body", "non_json_body"],
 )
+@pytest.mark.asyncio
 async def test_verify_body_integrity_edge_cases(
     mock_request, axon_instance, body, expected_exception_message
 ):
@@ -326,6 +328,7 @@ async def test_verify_body_integrity_edge_cases(
         ("incorrect_hash", ValueError),
     ],
 )
+@pytest.mark.asyncio
 async def test_verify_body_integrity_error_cases(
     mock_request, axon_instance, computed_hash, expected_error
 ):


### PR DESCRIPTION
## Overview

-  use `@pytest.mark.asyncio` decorator for async tests
- updates error to correct value