### PR TITLE
btlogging/loggingmachine.py: Fix bw compat API.

### DIFF
--- a/bittensor/btlogging/loggingmachine.py
+++ b/bittensor/btlogging/loggingmachine.py
@@ -22,6 +22,7 @@ Default, Debug, Trace, and Disabled.
 """
 
 import argparse
+import platform
 import atexit
 import copy
 import logging as stdlogging
@@ -343,45 +344,54 @@ class LoggingMachine(StateMachine):
         """
         return self.current_state_value == "Trace"
 
-    def trace(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def trace(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps trace message with prefix and suffix."""
         msg = f"{prefix} - {msg} - {suffix}"
-        self._logger.trace(msg, *args, **kwargs)
+        self._logger.trace(msg, *args, **kwargs, stacklevel=2)
 
-    def debug(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def debug(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps debug message with prefix and suffix."""
         msg = f"{prefix} - {msg} - {suffix}"
-        self._logger.debug(msg, *args, **kwargs)
+        self._logger.debug(msg, *args, **kwargs, stacklevel=2)
 
-    def info(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def info(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps info message with prefix and suffix."""
         msg = f"{prefix} - {msg} - {suffix}"
-        self._logger.info(msg, *args, **kwargs)
+        self._logger.info(msg, *args, **kwargs, stacklevel=2)
 
-    def success(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def success(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps success message with prefix and suffix."""
         msg = f"{prefix} - {msg} - {suffix}"
-        self._logger.success(msg, *args, **kwargs)
+        self._logger.success(msg, *args, **kwargs, stacklevel=2)
 
-    def warning(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def warning(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps warning message with prefix and suffix."""
         msg = f"{prefix} - {msg} - {suffix}"
-        self._logger.warning(msg, *args, **kwargs)
+        self._logger.warning(msg, *args, **kwargs, stacklevel=2)
 
-    def error(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def error(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps error message with prefix and suffix."""
         msg = f"{prefix} - {msg} - {suffix}"
-        self._logger.error(msg, *args, **kwargs)
+        self._logger.error(msg, *args, **kwargs, stacklevel=2)
 
-    def critical(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def critical(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps critical message with prefix and suffix."""
         msg = f"{prefix} - {msg} - {suffix}"
-        self._logger.critical(msg, *args, **kwargs)
+        self._logger.critical(msg, *args, **kwargs, stacklevel=2)
 
-    def exception(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def exception(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps exception message with prefix and suffix."""
         msg = f"{prefix} - {msg} - {suffix}"
-        self._logger.exception(msg, *args, **kwargs)
+        stacklevel = 2
+        if (
+            platform.python_implementation() == "CPython"
+            and platform.sys.version_info.major == 3
+            and platform.sys.version_info.minor < 11
+        ):
+            # Note that, on CPython < 3.11, exception() calls through to
+            # error() without adjusting stacklevel, so we have to increment it.
+            stacklevel += 1
+        self._logger.exception(msg, *args, **kwargs, stacklevel=stacklevel)
 
     def on(self):
         """Enable default state."""

--- a/bittensor/btlogging/loggingmachine.py
+++ b/bittensor/btlogging/loggingmachine.py
@@ -344,44 +344,48 @@ class LoggingMachine(StateMachine):
         """
         return self.current_state_value == "Trace"
 
+    @staticmethod
+    def _concat_msg(*args):
+        return " - ".join(el for el in args if el != "")
+
     def trace(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps trace message with prefix and suffix."""
-        msg = f"{prefix} - {msg} - {suffix}"
+        msg = self._concat_msg(prefix, msg, suffix)
         self._logger.trace(msg, *args, **kwargs, stacklevel=2)
 
     def debug(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps debug message with prefix and suffix."""
-        msg = f"{prefix} - {msg} - {suffix}"
+        msg = self._concat_msg(prefix, msg, suffix)
         self._logger.debug(msg, *args, **kwargs, stacklevel=2)
 
     def info(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps info message with prefix and suffix."""
-        msg = f"{prefix} - {msg} - {suffix}"
+        msg = self._concat_msg(prefix, msg, suffix)
         self._logger.info(msg, *args, **kwargs, stacklevel=2)
 
     def success(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps success message with prefix and suffix."""
-        msg = f"{prefix} - {msg} - {suffix}"
+        msg = self._concat_msg(prefix, msg, suffix)
         self._logger.success(msg, *args, **kwargs, stacklevel=2)
 
     def warning(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps warning message with prefix and suffix."""
-        msg = f"{prefix} - {msg} - {suffix}"
+        msg = self._concat_msg(prefix, msg, suffix)
         self._logger.warning(msg, *args, **kwargs, stacklevel=2)
 
     def error(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps error message with prefix and suffix."""
-        msg = f"{prefix} - {msg} - {suffix}"
+        msg = self._concat_msg(prefix, msg, suffix)
         self._logger.error(msg, *args, **kwargs, stacklevel=2)
 
     def critical(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps critical message with prefix and suffix."""
-        msg = f"{prefix} - {msg} - {suffix}"
+        msg = self._concat_msg(prefix, msg, suffix)
         self._logger.critical(msg, *args, **kwargs, stacklevel=2)
 
     def exception(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps exception message with prefix and suffix."""
-        msg = f"{prefix} - {msg} - {suffix}"
+        msg = self._concat_msg(prefix, msg, suffix)
         stacklevel = 2
         if (
             platform.python_implementation() == "CPython"


### PR DESCRIPTION
The bt logging mechanism breaks regular logging in various ways, that are solved by this commit.

### Bug

Logging from outside of bittensor is broken, for instance, `retry` logs using:

    logger.warning('%s, retrying in %s seconds...', e, _delay)

and this will output the literal `%s`, as the `args` are hijacked by the attempt at bw compatibility in bittensor, because the args `e` and `_delay` would land on kwargs `prefix` and `suffix`.

Also, all logging originates quite visibly from `loggingmachine.py`, which, in a literal sense, is correct, but not very helpful information.

### Description of the Change

- add `stacklevel=2` so that the filename of the originating call is logged (requires Python >= 3.8)
- move `*args` before `prefix` and `suffix` kwargs so regular logging calls using `args`, such as in `retry`, still work as intended

### Alternate Designs

Reworking the logging entirely is also a possibility. But this seemed to be the easy fix.

### Possible Drawbacks

Any code relying on prefix and suffix also being positional arguments, is now broken. This is intentional.

### Verification Process

I ran code that relies on `bittensor` and `btlogging` to verify that logging is now better.

### Release Notes

- Fixed and improved logging
