### PR TITLE
Ruff complains about an extra line

### DIFF
--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -109,7 +109,6 @@ from .utils.subtensor import get_subtensor_errors
 KEY_NONCE: Dict[str, int] = {}
 
 
-
 class ParamWithTypes(TypedDict):
     name: str  # Name of the parameter.
     type: str  # ScaleType string of the parameter.


### PR DESCRIPTION
Somehow the state of the code base was destroyed when the ruff formatter missed a line by mistake. After this we get an error for all subsequent PRs