### PR TITLE
fix(subtensor.set_weights): break early if no wait flags are set

### DIFF
--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -759,7 +759,6 @@ class Subtensor:
     ###############
     # Set Weights #
     ###############
-    # TODO: still needed? Can't find any usage of this method.
     def set_weights(
         self,
         wallet: "bittensor.wallet",
@@ -817,6 +816,8 @@ class Subtensor:
                     wait_for_finalization=wait_for_finalization,
                     prompt=prompt,
                 )
+                if not wait_for_finalization and not wait_for_inclusion:
+                    break
             except Exception as e:
                 _logger.error(f"Error setting weights: {e}")
             finally:


### PR DESCRIPTION
### Bug

subtensor.set_weights will try to double fire if neither wait flag is set

### Description of the Change

break early if both wait flags are unset

### Alternate Designs

N/A

### Possible Drawbacks

N/A

### Verification Process

Manually patched in local bittensor package

### Release Notes

- Fixes set_weights throwing `priority too low` when neither wait flags are set
