### PR TITLE
Testing e2e directory parallelization

### DIFF
--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -10,7 +10,7 @@ on:
 
   pull_request:
     branches: [main, development, staging]
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [opened, synchronize, reopened, ready_for_review]
 
   workflow_dispatch:
     inputs:
@@ -23,23 +23,22 @@ env:
   CARGO_TERM_COLOR: always
   VERBOSE: ${{ github.event.inputs.verbose }}
 
-# job to run tests in parallel
 jobs:
-  # Job to find all test files
+  # Job to find all test subfolders to run in parallel
   find-tests:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     outputs:
-      test-files: ${{ steps.get-tests.outputs.test-files }}
+      test-subfolders: ${{ steps.get-tests.outputs.test-subfolders }}
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v2
 
-      - name: Find test files
+      - name: Find test subfolders
         id: get-tests
         run: |
-          test_files=$(find tests/e2e_tests -name "test*.py" | jq -R -s -c 'split("\n") | map(select(. != ""))')
-          echo "::set-output name=test-files::$test_files"
+          test_dirs=$(find tests/e2e_tests -type f -name "test*.py" -exec dirname {} \; | sort | uniq | jq -R -s -c 'split("\n") | map(select(. != ""))')
+          echo "::set-output name=test-subfolders::$test_dirs"
         shell: bash
 
   # Job to run tests in parallel
@@ -57,7 +56,8 @@ jobs:
           - x86_64-unknown-linux-gnu
         os:
           - ubuntu-latest
-        test-file: ${{ fromJson(needs.find-tests.outputs.test-files) }}
+        test-subfolder: ${{ fromJson(needs.find-tests.outputs.test-subfolders) }}
+    name: Runing tests in ${{ matrix.test-subfolder }}
     env:
       RELEASE_NAME: development
       RUSTV: ${{ matrix.rust-branch }}
@@ -92,14 +92,17 @@ jobs:
         working-directory: ${{ github.workspace }}/subtensor
         run: git checkout testnet
 
+      - name: List tests
+        run: ls -l ${{ matrix.test-subfolder }}
+
       - name: Run tests
         run: |
           python3 -m pip install -e .[dev] pytest
-          LOCALNET_SH_PATH="${{ github.workspace }}/subtensor/scripts/localnet.sh" pytest ${{ matrix.test-file }} -s
+          LOCALNET_SH_PATH="${{ github.workspace }}/subtensor/scripts/localnet.sh" pytest ${{ matrix.test-subfolder }} -s
 
       - name: Retry failed tests
         if: failure()
         run: |
           sleep 10
           python3 -m pip install -e .[dev] pytest
-          LOCALNET_SH_PATH="${{ github.workspace }}/subtensor/scripts/localnet.sh" pytest ${{ matrix.test-file }} -s
+          LOCALNET_SH_PATH="${{ github.workspace }}/subtensor/scripts/localnet.sh" pytest ${{ matrix.test-subfolder }} -s

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: List tests
         run: ls -l ${{ matrix.test-subfolder }}
 
-      - name: Run tests
+      - name: Run e2e tests
         run: |
           python3 -m pip install -e .[dev] pytest
           LOCALNET_SH_PATH="${{ github.workspace }}/subtensor/scripts/localnet.sh" pytest ${{ matrix.test-subfolder }} -s


### PR DESCRIPTION
This PR splits the E2E tests into a directory running approach instead of file. 
Here, the CI will identify the folders and spawn 1 machine for each directory instead of 1 machine for each test. 