### PR TITLE
CI/E2E test improvements

### DIFF
--- a/tests/e2e_tests/multistep/test_axon.py
+++ b/tests/e2e_tests/multistep/test_axon.py
@@ -31,12 +31,13 @@ are set correctly, and that the miner is currently running
 
 @pytest.mark.asyncio
 async def test_axon(local_chain):
+    netuid = 1
     # Register root as Alice
     alice_keypair, exec_command, wallet = setup_wallet("//Alice")
     exec_command(RegisterSubnetworkCommand, ["s", "create"])
 
-    # Verify subnet 1 created successfully
-    assert local_chain.query("SubtensorModule", "NetworksAdded", [1]).serialize()
+    # Verify subnet <netuid> created successfully
+    assert local_chain.query("SubtensorModule", "NetworksAdded", [netuid]).serialize()
 
     # Register a neuron to the subnet
     exec_command(
@@ -45,11 +46,11 @@ async def test_axon(local_chain):
             "s",
             "register",
             "--netuid",
-            "1",
+            str(netuid),
         ],
     )
 
-    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945")
+    metagraph = bittensor.metagraph(netuid=netuid, network="ws://localhost:9945")
 
     # validate one miner with ip of none
     old_axon = metagraph.axons[0]
@@ -69,7 +70,7 @@ async def test_axon(local_chain):
             f'"{template_path}{templates_repo}/neurons/miner.py"',
             "--no_prompt",
             "--netuid",
-            "1",
+            str(netuid),
             "--subtensor.network",
             "local",
             "--subtensor.chain_endpoint",
@@ -94,7 +95,7 @@ async def test_axon(local_chain):
     )  # wait for 5 seconds for the metagraph to refresh with latest data
 
     # refresh metagraph
-    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945")
+    metagraph = bittensor.metagraph(netuid=netuid, network="ws://localhost:9945")
     updated_axon = metagraph.axons[0]
     external_ip = networking.get_external_ip()
 

--- a/tests/e2e_tests/multistep/test_dendrite.py
+++ b/tests/e2e_tests/multistep/test_dendrite.py
@@ -35,12 +35,13 @@ Verify that:
 
 @pytest.mark.asyncio
 async def test_dendrite(local_chain):
+    netuid = 1
     # Register root as Alice - the subnet owner
     alice_keypair, exec_command, wallet = setup_wallet("//Alice")
     exec_command(RegisterSubnetworkCommand, ["s", "create"])
 
-    # Verify subnet 1 created successfully
-    assert local_chain.query("SubtensorModule", "NetworksAdded", [1]).serialize()
+    # Verify subnet <netuid> created successfully
+    assert local_chain.query("SubtensorModule", "NetworksAdded", [netuid]).serialize()
 
     bob_keypair, exec_command, wallet_path = setup_wallet("//Bob")
 
@@ -51,15 +52,15 @@ async def test_dendrite(local_chain):
             "s",
             "register",
             "--netuid",
-            "1",
+            str(netuid),
         ],
     )
 
-    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945")
+    metagraph = bittensor.metagraph(netuid=netuid, network="ws://localhost:9945")
     subtensor = bittensor.subtensor(network="ws://localhost:9945")
 
     # assert one neuron is Bob
-    assert len(subtensor.neurons(netuid=1)) == 1
+    assert len(subtensor.neurons(netuid=netuid)) == 1
     neuron = metagraph.neurons[0]
     assert neuron.hotkey == bob_keypair.ss58_address
     assert neuron.coldkey == bob_keypair.ss58_address
@@ -79,7 +80,7 @@ async def test_dendrite(local_chain):
     )
 
     # refresh metagraph
-    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945")
+    metagraph = bittensor.metagraph(netuid=netuid, network="ws://localhost:9945")
     neuron = metagraph.neurons[0]
     # assert stake is 10000
     assert neuron.stake.tao == 10_000.0
@@ -97,7 +98,7 @@ async def test_dendrite(local_chain):
             f'"{template_path}{templates_repo}/neurons/validator.py"',
             "--no_prompt",
             "--netuid",
-            "1",
+            str(netuid),
             "--subtensor.network",
             "local",
             "--subtensor.chain_endpoint",
@@ -129,7 +130,7 @@ async def test_dendrite(local_chain):
             "root",
             "register",
             "--netuid",
-            "1",
+            str(netuid),
         ],
     )
 
@@ -139,7 +140,7 @@ async def test_dendrite(local_chain):
             "root",
             "boost",
             "--netuid",
-            "1",
+            str(netuid),
             "--increase",
             "1",
         ],
@@ -148,7 +149,7 @@ async def test_dendrite(local_chain):
     wait_interval(360, subtensor)
 
     # refresh metagraph
-    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945")
+    metagraph = bittensor.metagraph(netuid=netuid, network="ws://localhost:9945")
 
     # refresh validator neuron
     neuron = metagraph.neurons[0]

--- a/tests/e2e_tests/multistep/test_dendrite.py
+++ b/tests/e2e_tests/multistep/test_dendrite.py
@@ -16,7 +16,7 @@ from tests.e2e_tests.utils import (
     setup_wallet,
     template_path,
     templates_repo,
-    wait_interval,
+    wait_epoch,
 )
 
 
@@ -145,8 +145,8 @@ async def test_dendrite(local_chain):
             "1",
         ],
     )
-    # get current block, wait until 360 blocks pass (subnet tempo)
-    wait_interval(360, subtensor)
+    # get current block, wait until next epoch
+    await wait_epoch(subtensor, netuid=netuid)
 
     # refresh metagraph
     metagraph = bittensor.metagraph(netuid=netuid, network="ws://localhost:9945")

--- a/tests/e2e_tests/multistep/test_emissions.py
+++ b/tests/e2e_tests/multistep/test_emissions.py
@@ -47,11 +47,12 @@ are updated with proper values after an epoch has passed.
 
 @pytest.mark.asyncio
 async def test_emissions(local_chain):
+    netuid = 1
     # Register root as Alice - the subnet owner and validator
     alice_keypair, alice_exec_command, alice_wallet = setup_wallet("//Alice")
     alice_exec_command(RegisterSubnetworkCommand, ["s", "create"])
-    # Verify subnet 1 created successfully
-    assert local_chain.query("SubtensorModule", "NetworksAdded", [1]).serialize()
+    # Verify subnet <netuid> created successfully
+    assert local_chain.query("SubtensorModule", "NetworksAdded", [netuid]).serialize()
 
     # Register Bob as miner
     bob_keypair, bob_exec_command, bob_wallet = setup_wallet("//Bob")
@@ -63,7 +64,7 @@ async def test_emissions(local_chain):
             "s",
             "register",
             "--netuid",
-            "1",
+            str(netuid),
         ],
     )
 
@@ -74,13 +75,13 @@ async def test_emissions(local_chain):
             "s",
             "register",
             "--netuid",
-            "1",
+            str(netuid),
         ],
     )
 
     subtensor = bittensor.subtensor(network="ws://localhost:9945")
     # assert two neurons are in network
-    assert len(subtensor.neurons(netuid=1)) == 2
+    assert len(subtensor.neurons(netuid=netuid)) == 2
 
     # Alice to stake to become to top neuron after the first epoch
     alice_exec_command(
@@ -104,7 +105,7 @@ async def test_emissions(local_chain):
             f'"{template_path}{templates_repo}/neurons/validator.py"',
             "--no_prompt",
             "--netuid",
-            "1",
+            str(netuid),
             "--subtensor.network",
             "local",
             "--subtensor.chain_endpoint",
@@ -135,7 +136,7 @@ async def test_emissions(local_chain):
             "root",
             "register",
             "--netuid",
-            "1",
+            str(netuid),
             "--wait_for_inclusion",
             "True",
             "--wait_for_finalization",
@@ -151,7 +152,7 @@ async def test_emissions(local_chain):
             "root",
             "boost",
             "--netuid",
-            "1",
+            str(netuid),
             "--increase",
             "1000",
             "--wait_for_inclusion",
@@ -168,7 +169,7 @@ async def test_emissions(local_chain):
             f'"{template_path}{templates_repo}/neurons/miner.py"',
             "--no_prompt",
             "--netuid",
-            "1",
+            str(netuid),
             "--subtensor.network",
             "local",
             "--subtensor.chain_endpoint",
@@ -198,7 +199,7 @@ async def test_emissions(local_chain):
             "root",
             "weights",
             "--netuid",
-            "1",
+            str(netuid),
             "--weights",
             "0.3",
             "--wallet.name",
@@ -223,7 +224,7 @@ async def test_emissions(local_chain):
             "set",
             "hyperparameters",
             "--netuid",
-            "1",
+            str(netuid),
             "--wallet.name",
             alice_wallet.name,
             "--param",
@@ -249,9 +250,9 @@ async def test_emissions(local_chain):
 
     # get current emissions and validate that Alice has gotten tao
     weights = [(0, [(0, 65535), (1, 65535)])]
-    assert subtensor.weights(netuid=1) == weights
+    assert subtensor.weights(netuid=netuid) == weights
 
-    neurons = subtensor.neurons(netuid=1)
+    neurons = subtensor.neurons(netuid=netuid)
     bob = neurons[1]
     alice = neurons[0]
 
@@ -271,5 +272,5 @@ async def test_emissions(local_chain):
     assert alice.weights == [(0, 65535), (1, 65535)]
 
     assert (
-        subtensor.get_emission_value_by_subnet(netuid=1) > 0
+        subtensor.get_emission_value_by_subnet(netuid=netuid) > 0
     )  # emission on this subnet is strictly greater than 0

--- a/tests/e2e_tests/multistep/test_emissions.py
+++ b/tests/e2e_tests/multistep/test_emissions.py
@@ -19,7 +19,7 @@ from tests.e2e_tests.utils import (
     setup_wallet,
     template_path,
     templates_repo,
-    wait_interval,
+    wait_epoch,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -144,7 +144,7 @@ async def test_emissions(local_chain):
         ],
     )
 
-    wait_interval(360, subtensor)
+    await wait_epoch(subtensor, netuid=netuid)
 
     alice_exec_command(
         RootSetBoostCommand,
@@ -190,7 +190,7 @@ async def test_emissions(local_chain):
         stderr=asyncio.subprocess.PIPE,
     )
 
-    wait_interval(360, subtensor)
+    await wait_epoch(subtensor)
 
     logging.warning("Setting root set weights")
     alice_exec_command(
@@ -239,7 +239,7 @@ async def test_emissions(local_chain):
     )
 
     # wait epoch until for emissions to get distributed
-    wait_interval(360, subtensor)
+    await wait_epoch(subtensor)
 
     await asyncio.sleep(
         5

--- a/tests/e2e_tests/multistep/test_incentive.py
+++ b/tests/e2e_tests/multistep/test_incentive.py
@@ -43,11 +43,12 @@ are updated with proper values after an epoch has passed.
 
 @pytest.mark.asyncio
 async def test_incentive(local_chain):
+    netuid = 1
     # Register root as Alice - the subnet owner and validator
     alice_keypair, alice_exec_command, alice_wallet = setup_wallet("//Alice")
     alice_exec_command(RegisterSubnetworkCommand, ["s", "create"])
-    # Verify subnet 1 created successfully
-    assert local_chain.query("SubtensorModule", "NetworksAdded", [1]).serialize()
+    # Verify subnet <netuid> created successfully
+    assert local_chain.query("SubtensorModule", "NetworksAdded", [netuid]).serialize()
 
     # Register Bob as miner
     bob_keypair, bob_exec_command, bob_wallet = setup_wallet("//Bob")
@@ -59,7 +60,7 @@ async def test_incentive(local_chain):
             "s",
             "register",
             "--netuid",
-            "1",
+            str(netuid),
         ],
     )
 
@@ -70,13 +71,13 @@ async def test_incentive(local_chain):
             "s",
             "register",
             "--netuid",
-            "1",
+            str(netuid),
         ],
     )
 
     subtensor = bittensor.subtensor(network="ws://localhost:9945")
     # assert two neurons are in network
-    assert len(subtensor.neurons(netuid=1)) == 2
+    assert len(subtensor.neurons(netuid=netuid)) == 2
 
     # Alice to stake to become to top neuron after the first epoch
     alice_exec_command(
@@ -96,7 +97,7 @@ async def test_incentive(local_chain):
             f'"{template_path}{templates_repo}/neurons/miner.py"',
             "--no_prompt",
             "--netuid",
-            "1",
+            str(netuid),
             "--subtensor.network",
             "local",
             "--subtensor.chain_endpoint",
@@ -128,7 +129,7 @@ async def test_incentive(local_chain):
             f'"{template_path}{templates_repo}/neurons/validator.py"',
             "--no_prompt",
             "--netuid",
-            "1",
+            str(netuid),
             "--subtensor.network",
             "local",
             "--subtensor.chain_endpoint",
@@ -161,7 +162,7 @@ async def test_incentive(local_chain):
             "root",
             "register",
             "--netuid",
-            "1",
+            str(netuid),
             "--wallet.name",
             "default",
             "--wallet.hotkey",
@@ -177,7 +178,7 @@ async def test_incentive(local_chain):
             "root",
             "boost",
             "--netuid",
-            "1",
+            str(netuid),
             "--increase",
             "100",
             "--wallet.name",
@@ -190,7 +191,7 @@ async def test_incentive(local_chain):
     )
 
     # get latest metagraph
-    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945")
+    metagraph = bittensor.metagraph(netuid=netuid, network="ws://localhost:9945")
 
     # get current emissions
     bob_neuron = metagraph.neurons[1]
@@ -215,7 +216,7 @@ async def test_incentive(local_chain):
         wallet=alice_wallet,
         uids=[1],
         vals=[65535],
-        netuid=1,
+        netuid=netuid,
         version_key=0,
         wait_for_inclusion=True,
         wait_for_finalization=True,
@@ -225,7 +226,7 @@ async def test_incentive(local_chain):
     wait_interval(360, subtensor)
 
     # refresh metagraph
-    metagraph = bittensor.metagraph(netuid=1, network="ws://localhost:9945")
+    metagraph = bittensor.metagraph(netuid=netuid, network="ws://localhost:9945")
 
     # get current emissions and validate that Alice has gotten tao
     bob_neuron = metagraph.neurons[1]

--- a/tests/e2e_tests/multistep/test_incentive.py
+++ b/tests/e2e_tests/multistep/test_incentive.py
@@ -16,7 +16,7 @@ from tests.e2e_tests.utils import (
     setup_wallet,
     template_path,
     templates_repo,
-    wait_interval,
+    wait_epoch,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -206,8 +206,8 @@ async def test_incentive(local_chain):
     assert alice_neuron.stake.tao == 10_000.0
     assert alice_neuron.validator_trust == 0
 
-    # wait until 360 blocks pass (subnet tempo)
-    wait_interval(360, subtensor)
+    # wait until next epoch
+    await wait_epoch(subtensor)
 
     # for some reason the weights do not get set through the template. Set weight manually.
     alice_wallet = bittensor.wallet()
@@ -223,7 +223,7 @@ async def test_incentive(local_chain):
     )
 
     # wait epoch until weight go into effect
-    wait_interval(360, subtensor)
+    await wait_epoch(subtensor)
 
     # refresh metagraph
     metagraph = bittensor.metagraph(netuid=netuid, network="ws://localhost:9945")

--- a/tests/e2e_tests/subcommands/register/test_swap_hotkey.py
+++ b/tests/e2e_tests/subcommands/register/test_swap_hotkey.py
@@ -227,7 +227,7 @@ async def test_swap_hotkey_validator_owner(local_chain):
     # wait rate limit, until we are allowed to change hotkeys
     rate_limit = subtensor.tx_rate_limit()
     curr_block = subtensor.get_current_block()
-    wait_interval(rate_limit + curr_block + 1, subtensor)
+    await wait_interval(rate_limit + curr_block + 1, subtensor)
 
     # swap hotkey
     alice_exec_command(
@@ -481,7 +481,7 @@ async def test_swap_hotkey_miner(local_chain):
     # wait rate limit, until we are allowed to change hotkeys
     rate_limit = subtensor.tx_rate_limit()
     curr_block = subtensor.get_current_block()
-    wait_interval(rate_limit + curr_block + 1, subtensor)
+    await wait_interval(rate_limit + curr_block + 1, subtensor)
 
     # swap hotkey
     bob_exec_command(

--- a/tests/e2e_tests/subcommands/weights/test_commit_weights.py
+++ b/tests/e2e_tests/subcommands/weights/test_commit_weights.py
@@ -1,6 +1,8 @@
 import re
 
 import numpy as np
+import asyncio
+import pytest
 
 import bittensor
 import bittensor.utils.weight_utils as weight_utils
@@ -27,7 +29,8 @@ Verify that:
 """
 
 
-def test_commit_and_reveal_weights(local_chain):
+@pytest.mark.asyncio
+async def test_commit_and_reveal_weights(local_chain):
     # Register root as Alice
     keypair, exec_command, wallet = setup_wallet("//Alice")
 
@@ -190,7 +193,7 @@ def test_commit_and_reveal_weights(local_chain):
     assert interval > 0, "Invalid WeightCommitRevealInterval"
 
     # Wait until the reveal block range
-    wait_interval(interval, subtensor)
+    await wait_interval(interval, subtensor)
 
     # Configure the CLI arguments for the RevealWeightCommand
     exec_command(

--- a/tests/e2e_tests/utils.py
+++ b/tests/e2e_tests/utils.py
@@ -1,4 +1,5 @@
 import logging
+import asyncio
 import os
 import shutil
 import subprocess
@@ -124,14 +125,29 @@ def call_add_proposal(substrate: SubstrateInterface, wallet: bittensor.wallet) -
     return response.is_success
 
 
-def wait_interval(tempo, subtensor, netuid=1):
+async def wait_epoch(subtensor, netuid=1):
+    q_tempo = [
+        v.value
+        for [k, v] in subtensor.query_map_subtensor("Tempo")
+        if k.value == netuid
+    ]
+    if len(q_tempo) == 0:
+        raise Exception("could not determine tempo")
+    tempo = q_tempo[0]
+    logging.info(f"tempo = {tempo}")
+    await wait_interval(tempo, subtensor, netuid)
+
+
+async def wait_interval(tempo, subtensor, netuid=1):
     interval = tempo + 1
     current_block = subtensor.get_current_block()
     last_epoch = current_block - 1 - (current_block + netuid + 1) % interval
     next_tempo_block_start = last_epoch + interval
     last_reported = None
     while current_block < next_tempo_block_start:
-        time.sleep(1)  # Wait for 1 second before checking the block number again
+        await asyncio.sleep(
+            1
+        )  # Wait for 1 second before checking the block number again
         current_block = subtensor.get_current_block()
         if last_reported is None or current_block - last_reported >= 10:
             last_reported = current_block

--- a/tests/e2e_tests/utils.py
+++ b/tests/e2e_tests/utils.py
@@ -34,6 +34,7 @@ def setup_wallet(uri: str):
             "--wallet.path",
             wallet_path,
         ]
+        logging.info(f'executing command: {command} {" ".join(args)}')
         config = bittensor.config(
             parser=parser,
             args=args,
@@ -123,18 +124,22 @@ def call_add_proposal(substrate: SubstrateInterface, wallet: bittensor.wallet) -
     return response.is_success
 
 
-def wait_interval(interval, subtensor):
+def wait_interval(tempo, subtensor, netuid=1):
+    interval = tempo + 1
     current_block = subtensor.get_current_block()
-    next_tempo_block_start = (current_block - (current_block % interval)) + interval
+    last_epoch = current_block - 1 - (current_block + netuid + 1) % interval
+    next_tempo_block_start = last_epoch + interval
+    last_reported = None
     while current_block < next_tempo_block_start:
         time.sleep(1)  # Wait for 1 second before checking the block number again
         current_block = subtensor.get_current_block()
-        if current_block % 10 == 0:
+        if last_reported is None or current_block - last_reported >= 10:
+            last_reported = current_block
             print(
-                f"Current Block: {current_block}  Next tempo at: {next_tempo_block_start}"
+                f"Current Block: {current_block}  Next tempo for netuid {netuid} at: {next_tempo_block_start}"
             )
             logging.info(
-                f"Current Block: {current_block}  Next tempo at: {next_tempo_block_start}"
+                f"Current Block: {current_block}  Next tempo for netuid {netuid} at: {next_tempo_block_start}"
             )
 
 
@@ -180,21 +185,6 @@ def uninstall_templates(install_dir):
     )
     # delete everything in directory
     shutil.rmtree(install_dir)
-
-
-def wait_epoch(interval, subtensor):
-    current_block = subtensor.get_current_block()
-    next_tempo_block_start = (current_block - (current_block % interval)) + interval
-    while current_block < next_tempo_block_start:
-        time.sleep(1)  # Wait for 1 second before checking the block number again
-        current_block = subtensor.get_current_block()
-        if current_block % 10 == 0:
-            print(
-                f"Current Block: {current_block}  Next tempo at: {next_tempo_block_start}"
-            )
-            logging.info(
-                f"Current Block: {current_block}  Next tempo at: {next_tempo_block_start}"
-            )
 
 
 async def write_output_log_to_file(name, stream):


### PR DESCRIPTION
### Bug

CI is broken because of issues in E2E tests. Issues are:
- epoch calculation is off in various ways
- time.sleep() is used in an asyncio context
- wait_for_epoch() was an unused duplicate of wait_for_interval()

This is more of a style / bug waiting to happen thing:
- various constants are hardcoded repeatedly ("magic constants")

### Description of the Change

- epoch calculation is now exact (derived mathematically and verified by comparing epoch block calculations with actual epoch blocks)
- wait_for_epoch() now waits for the epoch without the need to specify the tempo
- tempo is taken from chain instead of hardcoded value
- netuid==1 is now a variable and not a magic constant at several places

The epoch calculation is detailed in the related commit message, with reference to subtensor code.

### Alternate Designs

No alternate designs were considered. Looking forward however, the following is considered:
- using a different netuid should be possible, for example when creating multiple netuids or when testing whether the tempo logic (which takes netuid as a parameter) is correct.
- using a different tempo should be possible, one the one hand to speed up the test, on the other hand to validate all still works with a different tempo than 360. Code is locally available to do this via an extrinsic, but I have to find the root key first. Using a different tempo (for example 12 or 36), by hardcoding it in subtensor, resulted in some tests failing, which might hint at possible issues.

### Possible Drawbacks

N/A

### Verification Process

The E2E CI code was run locally and showed that the errors that were seen before, are now gone. No new errors appeared.

### Release Notes

N/A