### PR TITLE
ci: auto assigns cortex to opened PRs

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,10 @@
+# Set to true to add assignees to pull requests
+addAssignees: true
+
+# A list of team slugs to add as assignees
+teamAssignees:
+  - opentensor/cortex
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+numberOfAssignees: 0

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,15 @@
+name: Auto Assign Cortex to Pull Requests
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Auto-assign Cortex Team
+      uses: kentaro-m/auto-assign-action@v1.2.4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/auto_assign.yml


### PR DESCRIPTION
## Overview
- assigns @opentensor/cortex  to opened pull requests