### PR TITLE
Fix multiprocessing POW errors and No Torch logging errors

### DIFF
--- a/bittensor/utils/registration.py
+++ b/bittensor/utils/registration.py
@@ -781,7 +781,7 @@ class _UsingSpawnStartMethod:
     def __enter__(self):
         self._old_start_method = multiprocessing.get_start_method(allow_none=True)
         if self._old_start_method is None:
-            self._old_start_method = "spawn"  # default to spawnn
+            self._old_start_method = "spawn"  # default to spawn
 
         multiprocessing.set_start_method("spawn", force=self._force)
 

--- a/bittensor/utils/registration.py
+++ b/bittensor/utils/registration.py
@@ -1089,6 +1089,7 @@ def _terminate_workers_and_wait_for_exit(
         if isinstance(worker, multiprocessing.queues.Queue):
             worker.join_thread()
         else:
+            worker.terminate()
             worker.join()
         worker.close()
 

--- a/bittensor/utils/registration.py
+++ b/bittensor/utils/registration.py
@@ -74,7 +74,7 @@ def _get_real_torch():
 
 
 def log_no_torch_error():
-    bittensor.btlogging.error(
+    bittensor.logging.error(
         "This command requires torch. You can install torch for bittensor"
         ' with `pip install bittensor[torch]` or `pip install ".[torch]"`'
         " if installing from source, and then run the command with USE_TORCH=1 {command}"

--- a/bittensor/utils/registration.py
+++ b/bittensor/utils/registration.py
@@ -562,7 +562,7 @@ def _solve_for_difficulty_fast(
         while still updating the block information after a different number of nonces,
         to increase the transparency of the process while still keeping the speed.
     """
-    if num_processes == None:
+    if num_processes is None:
         # get the number of allowed processes for this process
         num_processes = min(1, get_cpu_count())
 
@@ -780,8 +780,8 @@ class _UsingSpawnStartMethod:
 
     def __enter__(self):
         self._old_start_method = multiprocessing.get_start_method(allow_none=True)
-        if self._old_start_method == None:
-            self._old_start_method = "spawn"  # default to spawn
+        if self._old_start_method is None:
+            self._old_start_method = "spawn"  # default to spawnn
 
         multiprocessing.set_start_method("spawn", force=self._force)
 

--- a/tests/unit_tests/utils/test_registration.py
+++ b/tests/unit_tests/utils/test_registration.py
@@ -14,7 +14,7 @@ class MockBittensorLogging:
 @pytest.fixture
 def mock_bittensor_logging(monkeypatch):
     mock_logger = MockBittensorLogging()
-    monkeypatch.setattr("bittensor.btlogging", mock_logger)
+    monkeypatch.setattr("bittensor.logging", mock_logger)
     return mock_logger
 
 


### PR DESCRIPTION
The was a hidden error from the registration POW that was previously hidden, until logging was fixed in https://github.com/opentensor/bittensor/commit/54b7f3d84f74e2bbd89442e118a39573ddadbc2a. Fixes #2185. The `join` being called before termination was causing a Thread-2 exception because of the GIL (see: https://bugs.python.org/issue12488). Also includes a fix where `bittensor.btlogging.error` was called instead of `bittensor.logging.error`.