### PR TITLE
Check for participation before nomination call

### DIFF
--- a/bittensor/extrinsics/delegation.py
+++ b/bittensor/extrinsics/delegation.py
@@ -57,6 +57,14 @@ def nominate_extrinsic(
         )
         return False
 
+    if not subtensor.is_hotkey_registered_any(wallet.hotkey.ss58_address):
+        logger.error(
+            "Hotkey {} is not registered to any network".format(
+                wallet.hotkey.ss58_address
+            )
+        )
+        return False
+
     with bittensor.__console__.status(
         ":satellite: Sending nominate call on [white]{}[/white] ...".format(
             subtensor.network


### PR DESCRIPTION
This adds a check to see if the hotkey is part of a network or not before making the nomination call. This adds a check so users are less confused with the error message they get otherwise. 

Ref: https://github.com/opentensor/bittensor/issues/2160