### PR TITLE
ensure msg is str in _concat_msg

### DIFF
--- a/bittensor/btlogging/loggingmachine.py
+++ b/bittensor/btlogging/loggingmachine.py
@@ -362,7 +362,7 @@ class LoggingMachine(StateMachine):
 
     @staticmethod
     def _concat_msg(*args):
-        return " - ".join(el for el in args if el != "")
+        return " - ".join(str(el) for el in args if el != "")
 
     def trace(self, msg="", *args, prefix="", suffix="", **kwargs):
         """Wraps trace message with prefix and suffix."""


### PR DESCRIPTION
Ensure that each element of the new `LoggingMachine._concat_msg` args is a str. This was changed in PR #2155, but breaks the `test_axon` e2e test because a config object is passed to the logger instead of a str.