### PR TITLE
Tests for metagraph, highlighting bug

### DIFF
--- a/bittensor/commands/stake.py
+++ b/bittensor/commands/stake.py
@@ -58,7 +58,7 @@ def get_netuid(
         )
         return False, -1
     netuid = cli.config.netuid
-    if netuid < 0 or netuid > 2**32 - 1:
+    if netuid < 0 or netuid > 65535:
         console.print(
             "[red]Invalid input. Please enter a valid integer for netuid in subnet range.[/red]"
         )

--- a/tests/e2e_tests/subcommands/stake/test_childkeys.py
+++ b/tests/e2e_tests/subcommands/stake/test_childkeys.py
@@ -54,7 +54,7 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
     assert local_chain.query("SubtensorModule", "NetworksAdded", [1]).serialize()
 
     for exec_command in [alice_exec_command, bob_exec_command, eve_exec_command]:
-        exec_command(RegisterCommand, ["s", "register", "--netuid", "4"])
+        exec_command(RegisterCommand, ["s", "register", "--netuid", "1"])
 
     alice_exec_command(StakeCommand, ["stake", "add", "--amount", "100000"])
 
@@ -75,8 +75,8 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
     await wait()
 
     children_with_proportions = [
-        [0.2, bob_keypair.ss58_address],
-        [0.1, eve_keypair.ss58_address],
+        [0.4, bob_keypair.ss58_address],
+        [0.2, eve_keypair.ss58_address],
     ]
 
     # Test 1: Set multiple children
@@ -86,7 +86,7 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
             "stake",
             "set_children",
             "--netuid",
-            "2",
+            "1",
             "--children",
             f"{children_with_proportions[0][1]},{children_with_proportions[1][1]}",
             "--hotkey",

--- a/tests/e2e_tests/subcommands/stake/test_childkeys.py
+++ b/tests/e2e_tests/subcommands/stake/test_childkeys.py
@@ -54,7 +54,7 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
     assert local_chain.query("SubtensorModule", "NetworksAdded", [1]).serialize()
 
     for exec_command in [alice_exec_command, bob_exec_command, eve_exec_command]:
-        exec_command(RegisterCommand, ["s", "register", "--netuid", "1"])
+        exec_command(RegisterCommand, ["s", "register", "--netuid", "4"])
 
     alice_exec_command(StakeCommand, ["stake", "add", "--amount", "100000"])
 
@@ -75,8 +75,8 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
     await wait()
 
     children_with_proportions = [
-        [0.4, bob_keypair.ss58_address],
-        [0.2, eve_keypair.ss58_address],
+        [0.2, bob_keypair.ss58_address],
+        [0.1, eve_keypair.ss58_address],
     ]
 
     # Test 1: Set multiple children
@@ -86,7 +86,7 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
             "stake",
             "set_children",
             "--netuid",
-            "1",
+            "2",
             "--children",
             f"{children_with_proportions[0][1]},{children_with_proportions[1][1]}",
             "--hotkey",

--- a/tests/e2e_tests/subcommands/subnet/test_metagraph.py
+++ b/tests/e2e_tests/subcommands/subnet/test_metagraph.py
@@ -21,15 +21,19 @@ Verify that:
 
 def test_metagraph_command(local_chain, capsys):
     logging.info("Testing test_metagraph_command")
-    netuid = 1
     # Register root as Alice
     keypair, exec_command, wallet = setup_wallet("//Alice")
-    exec_command(RegisterSubnetworkCommand, ["s", "create"])
 
-    # Verify subnet <netuid> created successfully
-    assert local_chain.query(
-        "SubtensorModule", "NetworksAdded", [netuid]
-    ).serialize(), "Subnet wasn't created successfully"
+    # The rest of the test will use subnet 2
+    netuid = 2
+
+    for i in range(netuid):
+        # Register subnet <i+1>
+        exec_command(RegisterSubnetworkCommand, ["s", "create"])
+        # Verify subnet <i+1> created successfully
+        assert local_chain.query(
+            "SubtensorModule", "NetworksAdded", [i + 1]
+        ).serialize(), f"Subnet {netuid+1} wasn't created successfully"
 
     subtensor = bittensor.subtensor(network="ws://localhost:9945")
 

--- a/tests/e2e_tests/subcommands/subnet/test_metagraph.py
+++ b/tests/e2e_tests/subcommands/subnet/test_metagraph.py
@@ -85,6 +85,9 @@ def test_metagraph_command(local_chain, capsys):
         f"Metagraph: net: local:{netuid}" in captured.out and "N: 1/1" in captured.out
     ), "Neuron isn't displayed in metagraph"
 
+    # Create a secondary metagraph to test .load() later on
+    metagraph_pre_dave = subtensor.metagraph(netuid=netuid)
+
     # Register Dave as neuron to the subnet
     dave_keypair, dave_exec_command, dave_wallet = setup_wallet("//Dave")
     dave_exec_command(
@@ -120,5 +123,20 @@ def test_metagraph_command(local_chain, capsys):
     # Assert the neuron is registered and displayed
     assert f"Metagraph: net: local:{netuid}" in captured.out
     assert "N: 2/2" in captured.out
+
+    # Check save/load cycle
+    metagraph.save()
+    metagraph_pre_dave.load()
+
+    # Assert in progressive detail
+    assert len(metagraph.uids) == len(metagraph_pre_dave.uids)
+    assert (metagraph.uids == metagraph_pre_dave.uids).all()
+
+    assert len(metagraph.axons) == len(metagraph_pre_dave.axons)
+    assert metagraph.axons[1].hotkey == metagraph_pre_dave.axons[1].hotkey
+    assert metagraph.axons == metagraph_pre_dave.axons
+
+    assert len(metagraph.neurons) == len(metagraph_pre_dave.neurons)
+    assert metagraph.neurons == metagraph_pre_dave.neurons
 
     logging.info("Passed test_metagraph_command")

--- a/tests/e2e_tests/subcommands/subnet/test_metagraph.py
+++ b/tests/e2e_tests/subcommands/subnet/test_metagraph.py
@@ -81,7 +81,7 @@ def test_metagraph_command(local_chain, capsys):
 
     # Assert the neuron is registered and displayed
     assert (
-        "Metagraph: net: local:1" and "N: 1/1" in captured.out
+        "Metagraph: net: local:1" in captured.out and "N: 1/1" in captured.out
     ), "Neuron isn't displayed in metagraph"
 
     # Register Dave as neuron to the subnet
@@ -117,6 +117,7 @@ def test_metagraph_command(local_chain, capsys):
     captured = capsys.readouterr()
 
     # Assert the neuron is registered and displayed
-    assert "Metagraph: net: local:1" and "N: 2/2" in captured.out
+    assert "Metagraph: net: local:1" in captured.out
+    assert "N: 2/2" in captured.out
 
     logging.info("Passed test_metagraph_command")

--- a/tests/e2e_tests/subcommands/subnet/test_metagraph.py
+++ b/tests/e2e_tests/subcommands/subnet/test_metagraph.py
@@ -21,32 +21,33 @@ Verify that:
 
 def test_metagraph_command(local_chain, capsys):
     logging.info("Testing test_metagraph_command")
+    netuid = 1
     # Register root as Alice
     keypair, exec_command, wallet = setup_wallet("//Alice")
     exec_command(RegisterSubnetworkCommand, ["s", "create"])
 
-    # Verify subnet 1 created successfully
+    # Verify subnet <netuid> created successfully
     assert local_chain.query(
-        "SubtensorModule", "NetworksAdded", [1]
+        "SubtensorModule", "NetworksAdded", [netuid]
     ).serialize(), "Subnet wasn't created successfully"
 
     subtensor = bittensor.subtensor(network="ws://localhost:9945")
 
-    metagraph = subtensor.metagraph(netuid=1)
+    metagraph = subtensor.metagraph(netuid=netuid)
 
     # Assert metagraph is empty
     assert len(metagraph.uids) == 0, "Metagraph is not empty"
 
     # Execute btcli metagraph command
-    exec_command(MetagraphCommand, ["subnet", "metagraph", "--netuid", "1"])
+    exec_command(MetagraphCommand, ["subnet", "metagraph", "--netuid", str(netuid)])
 
     captured = capsys.readouterr()
 
-    # Assert metagraph is printed for netuid 1
+    # Assert metagraph is printed for netuid
 
     assert (
-        "Metagraph: net: local:1" in captured.out
-    ), "Netuid 1 was not displayed in metagraph"
+        f"Metagraph: net: local:{netuid}" in captured.out
+    ), f"Netuid {netuid} was not displayed in metagraph"
 
     # Register Bob as neuron to the subnet
     bob_keypair, bob_exec_command, bob_wallet = setup_wallet("//Bob")
@@ -56,7 +57,7 @@ def test_metagraph_command(local_chain, capsys):
             "s",
             "register",
             "--netuid",
-            "1",
+            str(netuid),
         ],
     )
 
@@ -67,7 +68,7 @@ def test_metagraph_command(local_chain, capsys):
     assert "✅ Registered" in captured.out, "Neuron was not registered"
 
     # Refresh the metagraph
-    metagraph = subtensor.metagraph(netuid=1)
+    metagraph = subtensor.metagraph(netuid=netuid)
 
     # Assert metagraph has registered neuron
     assert len(metagraph.uids) == 1, "Metagraph doesn't have exactly 1 neuron"
@@ -75,13 +76,13 @@ def test_metagraph_command(local_chain, capsys):
         metagraph.hotkeys[0] == "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
     ), "Neuron's hotkey in metagraph doesn't match"
     # Execute btcli metagraph command
-    exec_command(MetagraphCommand, ["subnet", "metagraph", "--netuid", "1"])
+    exec_command(MetagraphCommand, ["subnet", "metagraph", "--netuid", str(netuid)])
 
     captured = capsys.readouterr()
 
     # Assert the neuron is registered and displayed
     assert (
-        "Metagraph: net: local:1" in captured.out and "N: 1/1" in captured.out
+        f"Metagraph: net: local:{netuid}" in captured.out and "N: 1/1" in captured.out
     ), "Neuron isn't displayed in metagraph"
 
     # Register Dave as neuron to the subnet
@@ -92,7 +93,7 @@ def test_metagraph_command(local_chain, capsys):
             "s",
             "register",
             "--netuid",
-            "1",
+            str(netuid),
         ],
     )
 
@@ -103,7 +104,7 @@ def test_metagraph_command(local_chain, capsys):
     assert "✅ Registered" in captured.out, "Neuron was not registered"
 
     # Refresh the metagraph
-    metagraph = subtensor.metagraph(netuid=1)
+    metagraph = subtensor.metagraph(netuid=netuid)
 
     # Assert metagraph has registered neuron
     assert len(metagraph.uids) == 2
@@ -112,12 +113,12 @@ def test_metagraph_command(local_chain, capsys):
     ), "Neuron's hotkey in metagraph doesn't match"
 
     # Execute btcli metagraph command
-    exec_command(MetagraphCommand, ["subnet", "metagraph", "--netuid", "1"])
+    exec_command(MetagraphCommand, ["subnet", "metagraph", "--netuid", str(netuid)])
 
     captured = capsys.readouterr()
 
     # Assert the neuron is registered and displayed
-    assert "Metagraph: net: local:1" in captured.out
+    assert f"Metagraph: net: local:{netuid}" in captured.out
     assert "N: 2/2" in captured.out
 
     logging.info("Passed test_metagraph_command")


### PR DESCRIPTION
### Bug

The e2e test that tests metagraph has some flaws. Some assertions don't work as intended and a bug in metagraph is not caught. While I was at it I fixed some low hanging fruit, that is, some fragile constructions that may turn into bugs later on.

### Description of the Change

- don't split lines, assert particular strings in complete output so specific line number doesn't matter
- fix `assert 'a' and 'b' in s` as it doesn't test whether both `'a'` and `'b'` are in `s`
- replace magic constant `1` with `netuid`
- create an additional subnet to make the test coverage broader
- test `.save()` and `.load()` on metagraph

note that the last test fails, but that is due to a bug in bittensor that has to be solved. This PR demonstrates there is a bug, and provides a test to see whether a (to be written) fix solves the bug.

### Alternate Designs

Not relevant.

### Possible Drawbacks

N/A

### Verification Process

By doing `metagraph_pre_dave = subtensor.metagraph(netuid=netuid)` instead of `metagraph_pre_dave.load()` it was verified that the assertions comparing distinct metagraph objects should work, if the metagraphs are in sync.

### Release Notes

N/A