### PR TITLE
test_root_register_add_member_senate.py: improvements

### DIFF
--- a/bittensor/commands/stake.py
+++ b/bittensor/commands/stake.py
@@ -58,7 +58,7 @@ def get_netuid(
         )
         return False, -1
     netuid = cli.config.netuid
-    if netuid < 0 or netuid > 2**32 - 1:
+    if netuid < 0 or netuid > 65535:
         console.print(
             "[red]Invalid input. Please enter a valid integer for netuid in subnet range.[/red]"
         )

--- a/tests/e2e_tests/subcommands/stake/test_childkeys.py
+++ b/tests/e2e_tests/subcommands/stake/test_childkeys.py
@@ -54,7 +54,7 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
     assert local_chain.query("SubtensorModule", "NetworksAdded", [1]).serialize()
 
     for exec_command in [alice_exec_command, bob_exec_command, eve_exec_command]:
-        exec_command(RegisterCommand, ["s", "register", "--netuid", "4"])
+        exec_command(RegisterCommand, ["s", "register", "--netuid", "1"])
 
     alice_exec_command(StakeCommand, ["stake", "add", "--amount", "100000"])
 
@@ -75,8 +75,8 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
     await wait()
 
     children_with_proportions = [
-        [0.2, bob_keypair.ss58_address],
-        [0.1, eve_keypair.ss58_address],
+        [0.4, bob_keypair.ss58_address],
+        [0.2, eve_keypair.ss58_address],
     ]
 
     # Test 1: Set multiple children
@@ -86,7 +86,7 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
             "stake",
             "set_children",
             "--netuid",
-            "2",
+            "1",
             "--children",
             f"{children_with_proportions[0][1]},{children_with_proportions[1][1]}",
             "--hotkey",

--- a/tests/e2e_tests/subcommands/stake/test_childkeys.py
+++ b/tests/e2e_tests/subcommands/stake/test_childkeys.py
@@ -54,7 +54,7 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
     assert local_chain.query("SubtensorModule", "NetworksAdded", [1]).serialize()
 
     for exec_command in [alice_exec_command, bob_exec_command, eve_exec_command]:
-        exec_command(RegisterCommand, ["s", "register", "--netuid", "1"])
+        exec_command(RegisterCommand, ["s", "register", "--netuid", "4"])
 
     alice_exec_command(StakeCommand, ["stake", "add", "--amount", "100000"])
 
@@ -75,8 +75,8 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
     await wait()
 
     children_with_proportions = [
-        [0.4, bob_keypair.ss58_address],
-        [0.2, eve_keypair.ss58_address],
+        [0.2, bob_keypair.ss58_address],
+        [0.1, eve_keypair.ss58_address],
     ]
 
     # Test 1: Set multiple children
@@ -86,7 +86,7 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
             "stake",
             "set_children",
             "--netuid",
-            "1",
+            "2",
             "--children",
             f"{children_with_proportions[0][1]},{children_with_proportions[1][1]}",
             "--hotkey",


### PR DESCRIPTION
### Bug

The e2e test in `test_root_register_add_member_senate.py` searches for specific strings in specific lines (line numbers) of output. This does not make sense as the line number is not necessarily stable, nor relevant. When testing today the line numbers did not add up (did not investigate why exactly). 

### Description of the Change

As the ordering of items could be relevant, a function `assert_sequence()` is added that check whether expected items occur in the expected order. If lines would be injected between the expected lines, this doesn't affect the assertion. This is by design.

Also, the magic netuid number 1 is replaced by the variable netuid == 1.

### Alternate Designs

It was considered to also assert that lines are adjacent. In practice the `assert_sequence()` will be most useful if injection of additional lines doesn't break the test. Such checks may be added later as a flag. It was considered to place `assert_sequence()` in some `utils.py` but it was decided to keep the change local to `test_root_register_add_member_senate.py` for now.

### Possible Drawbacks

Not expected.

### Verification Process

The new logic was verified by changing the expected string and observing the assertion being triggered.

### Release Notes

N/A