### PR TITLE
bittensor/config.py: improvements

### DIFF
--- a/bittensor/config.py
+++ b/bittensor/config.py
@@ -64,7 +64,7 @@ class config(DefaultMunch):
         self,
         parser: argparse.ArgumentParser = None,
         args: Optional[List[str]] = None,
-        strict: bool = False,
+        strict: bool = True,
         default: Optional[Any] = None,
     ) -> None:
         super().__init__(default)
@@ -182,7 +182,10 @@ class config(DefaultMunch):
             default_param_args = [_config.get("command"), _config.get("subcommand")]
 
         ## Get all args by name
-        default_params = parser.parse_args(args=default_param_args)
+        parser_no_required = copy.deepcopy(parser)
+        for i in range(len(parser_no_required._actions)):
+            parser_no_required._actions[i].required = False
+        default_params = parser_no_required.parse_args(args=default_param_args)
 
         all_default_args = default_params.__dict__.keys() | []
         ## Make a dict with keys as args and values as argparse.SUPPRESS


### PR DESCRIPTION
### Bug

- You can pass any argument to code that uses `bt.config()` with default kwargs and it will not complain. This leads to confusion.
- `bt.config()` does some special magic that kills the `required=True` feature of argparse; it will complain that the argument is not set, even when it is set. This leads to devs implementing workarounds such as setting semi-random default values and/or additional post-argparse checks that could/should already be done in argparse.

### Description of the Change

- set `strict=True` by default, so issues are easier to catch
- fix the inability to handle required=True

### Alternate Designs

Rework `bt.config`, as it is not clear what it intends to add to argparse, that already supports tons of features.

### Possible Drawbacks

People may experience code not starting anymore because they supply unknown arguments that now lead to errors due to strict checking. This is intended. Having non-functional arguments is not useful and confusing.

### Verification Process

I tested this on some bittensor code I'm writing right now, by adding a `required=True` argument and observing that the argument is now required *and* that the code doesn't bail out on a supposedly missing argument. I tested to see that I now cannot add `--whatevercrapinsertedhere` without argparse complaining about an unknown arg.

### Release Notes

N/A