### PR TITLE
btcli/bt.config: various improvements

### DIFF
--- a/bittensor/cli.py
+++ b/bittensor/cli.py
@@ -106,7 +106,6 @@ ALIAS_TO_COMMAND = {
 }
 COMMANDS = {
     "subnets": {
-        "name": "subnets",
         "aliases": ["s", "subnet"],
         "help": "Commands for managing and viewing subnetworks.",
         "commands": {
@@ -120,7 +119,6 @@ COMMANDS = {
         },
     },
     "root": {
-        "name": "root",
         "aliases": ["r", "roots"],
         "help": "Commands for managing and viewing the root network.",
         "commands": {
@@ -142,7 +140,6 @@ COMMANDS = {
         },
     },
     "wallet": {
-        "name": "wallet",
         "aliases": ["w", "wallets"],
         "help": "Commands for managing and viewing wallets.",
         "commands": {
@@ -167,7 +164,6 @@ COMMANDS = {
         },
     },
     "stake": {
-        "name": "stake",
         "aliases": ["st", "stakes"],
         "help": "Commands for staking and removing stake and setting child hotkey accounts.",
         "commands": {
@@ -182,7 +178,6 @@ COMMANDS = {
         },
     },
     "weights": {
-        "name": "weights",
         "aliases": ["wt", "weight"],
         "help": "Commands for managing weight for subnets.",
         "commands": {
@@ -191,7 +186,6 @@ COMMANDS = {
         },
     },
     "sudo": {
-        "name": "sudo",
         "aliases": ["su", "sudos"],
         "help": "Commands for subnet management",
         "commands": {
@@ -201,7 +195,6 @@ COMMANDS = {
         },
     },
     "legacy": {
-        "name": "legacy",
         "aliases": ["l"],
         "help": "Miscellaneous commands.",
         "commands": {
@@ -210,7 +203,6 @@ COMMANDS = {
         },
     },
     "info": {
-        "name": "info",
         "aliases": ["i"],
         "help": "Instructions for enabling autocompletion for the CLI.",
         "commands": {
@@ -304,21 +296,18 @@ class cli:
         # Add arguments for each sub-command.
         cmd_parsers = parser.add_subparsers(dest="command")
         # Add argument parsers for all available commands.
-        for command in COMMANDS.values():
-            if isinstance(command, dict):
-                subcmd_parser = cmd_parsers.add_parser(
-                    name=command["name"],
-                    aliases=command["aliases"],
-                    help=command["help"],
-                )
-                subparser = subcmd_parser.add_subparsers(
-                    help=command["help"], dest="subcommand", required=True
-                )
+        for name, command in COMMANDS.items():
+            subcmd_parser = cmd_parsers.add_parser(
+                name=name,
+                aliases=command["aliases"],
+                help=command["help"],
+            )
+            subparser = subcmd_parser.add_subparsers(
+                help=command["help"], dest="subcommand", required=True
+            )
 
-                for subcommand in command["commands"].values():
-                    subcommand.add_args(subparser)
-            else:
-                command.add_args(cmd_parsers)
+            for subcommand in command["commands"].values():
+                subcommand.add_args(subparser)
 
         return parser
 

--- a/bittensor/commands/stake.py
+++ b/bittensor/commands/stake.py
@@ -58,7 +58,7 @@ def get_netuid(
         )
         return False, -1
     netuid = cli.config.netuid
-    if netuid < 0 or netuid > 2**32 - 1:
+    if netuid < 0 or netuid > 65535:
         console.print(
             "[red]Invalid input. Please enter a valid integer for netuid in subnet range.[/red]"
         )

--- a/bittensor/config.py
+++ b/bittensor/config.py
@@ -148,7 +148,7 @@ class config(DefaultMunch):
         ## Make a dict with keys as args and values as argparse.SUPPRESS
         defaults_as_suppress = {key: argparse.SUPPRESS for key in all_default_args}
 
-        def local_set_defaults(local_parser:argparse.ArgumentParser):
+        def local_set_defaults(local_parser: argparse.ArgumentParser):
             ## Set the defaults to argparse.SUPPRESS, should remove them from the namespace
             local_parser.set_defaults(**defaults_as_suppress)
             local_parser._defaults.clear()  # Needed for quirk of argparse
@@ -173,7 +173,11 @@ class config(DefaultMunch):
         }
 
     @staticmethod
-    def apply_to_parser_recursive(parser:argparse.ArgumentParser, callback:Callable[[argparse.ArgumentParser],None], depth:int=0):
+    def apply_to_parser_recursive(
+        parser: argparse.ArgumentParser,
+        callback: Callable[[argparse.ArgumentParser], None],
+        depth: int = 0,
+    ):
         """
         Recursively apply callback() to parser and its subparsers.
         """
@@ -187,7 +191,7 @@ class config(DefaultMunch):
                 config.apply_to_parser_recursive(cmd_parser, callback, depth=depth + 1)
 
     @staticmethod
-    def add_args(parser:argparse.ArgumentParser):
+    def add_args(parser: argparse.ArgumentParser):
         """
         Add standard arguments to argument parser.
         """

--- a/tests/e2e_tests/subcommands/stake/test_childkeys.py
+++ b/tests/e2e_tests/subcommands/stake/test_childkeys.py
@@ -54,7 +54,7 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
     assert local_chain.query("SubtensorModule", "NetworksAdded", [1]).serialize()
 
     for exec_command in [alice_exec_command, bob_exec_command, eve_exec_command]:
-        exec_command(RegisterCommand, ["s", "register", "--netuid", "4"])
+        exec_command(RegisterCommand, ["s", "register", "--netuid", "1"])
 
     alice_exec_command(StakeCommand, ["stake", "add", "--amount", "100000"])
 
@@ -75,8 +75,8 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
     await wait()
 
     children_with_proportions = [
-        [0.2, bob_keypair.ss58_address],
-        [0.1, eve_keypair.ss58_address],
+        [0.4, bob_keypair.ss58_address],
+        [0.2, eve_keypair.ss58_address],
     ]
 
     # Test 1: Set multiple children
@@ -86,7 +86,7 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
             "stake",
             "set_children",
             "--netuid",
-            "2",
+            "1",
             "--children",
             f"{children_with_proportions[0][1]},{children_with_proportions[1][1]}",
             "--hotkey",

--- a/tests/e2e_tests/subcommands/stake/test_childkeys.py
+++ b/tests/e2e_tests/subcommands/stake/test_childkeys.py
@@ -54,7 +54,7 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
     assert local_chain.query("SubtensorModule", "NetworksAdded", [1]).serialize()
 
     for exec_command in [alice_exec_command, bob_exec_command, eve_exec_command]:
-        exec_command(RegisterCommand, ["s", "register", "--netuid", "1"])
+        exec_command(RegisterCommand, ["s", "register", "--netuid", "4"])
 
     alice_exec_command(StakeCommand, ["stake", "add", "--amount", "100000"])
 
@@ -75,8 +75,8 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
     await wait()
 
     children_with_proportions = [
-        [0.4, bob_keypair.ss58_address],
-        [0.2, eve_keypair.ss58_address],
+        [0.2, bob_keypair.ss58_address],
+        [0.1, eve_keypair.ss58_address],
     ]
 
     # Test 1: Set multiple children
@@ -86,7 +86,7 @@ async def test_set_revoke_children_multiple(local_chain, capsys):
             "stake",
             "set_children",
             "--netuid",
-            "1",
+            "2",
             "--children",
             f"{children_with_proportions[0][1]},{children_with_proportions[1][1]}",
             "--hotkey",

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -2506,8 +2506,6 @@ class TestCLIWithNetworkUsingArgs(unittest.TestCase):
                     "delegate",
                     "--subtensor.network",
                     "mock",  # Mock network
-                    "--wallet.name",
-                    "mock",
                     "--delegate_ss58key",
                     delegate_wallet.hotkey.ss58_address,
                     "--amount",

--- a/tests/integration_tests/test_cli_no_network.py
+++ b/tests/integration_tests/test_cli_no_network.py
@@ -1324,7 +1324,7 @@ class TestCLIDefaultsNoNetwork(unittest.TestCase):
                         cli = bittensor.cli(
                             args=base_args
                             + [
-                                "--proposal_hash",
+                                "--proposal",
                                 mock_proposal_hash,
                             ]
                         )

--- a/tests/integration_tests/test_cli_no_network.py
+++ b/tests/integration_tests/test_cli_no_network.py
@@ -1384,7 +1384,6 @@ class TestCLIDefaultsNoNetwork(unittest.TestCase):
                 args=[
                     "sudo",
                     "set",
-                    "hyperparameters",
                     "--netuid",
                     "1",
                     "--param",


### PR DESCRIPTION
### Bug

- You can pass any argument to code that uses `bt.config()` with default kwargs, and it will not complain. This leads to confusion on all levels (developers, devops, users).
- `bt.config()` does some special magic that kills the `required=True` feature of argparse; it will complain that the required argument is not set, even when it is set. This leads to developers implementing workarounds such as setting semi-random default values and/or additional post-argparse checks that could/should already be done in argparse. This bug seems to originate in the recursive nature of argparse as used in bittensor.
- When using `strict=True`, subparsers will wrongly complain about not recognizing arguments like `--no_prompt`

I'm not entirely sure what `bt.config` intends to do at every turn, but I think the changes described below don't make it worse.

### Description of the Change

While fixing the bugs described above, various other small (cosmetic) improvements were done. Taken from the commit message:

- implement recursive apply function for (sub^n)argparser
- use recursive apply to eliminate repeated code
- move adding standard bt.config args to separate function
- \* use recursive apply to add standard bt.config args to all parsers
- \* make strict=True the default
- eliminate redundant COMMANDS.item.name field
- remove obsolete COMMANDS looping code
- remove redundant dest= argument
- fix some comments

The changes marked * implement a functional improvement, the rest is for improved maintainability.

### Alternate Designs

Rework `bt.config`, as it is not clear what it intends to add to argparse, that already supports tons of features.

### Possible Drawbacks

People may experience code not starting anymore because they supply unknown arguments that now lead to errors due to strict checking. This is intended. Having non-functional arguments is not useful and confusing.

### Verification Process

I tested this on some bittensor code I'm writing right now, by adding a `required=True` argument and observing that the argument is now required and that the code doesn't bail out on a supposedly missing argument. I tested to see that I now cannot add `--whatevercrapinsertedhere` without argparse complaining about an unknown arg.

The CI checks further serve as a broad verification of the argparse mechanics.

### Release Notes

Any invalid arguments will now lead to an error, instead of being silently ignored, or treated otherwise depending on your exact implementation. In case you encounter an invalid argument error, as a first step remove the offending argument(s) and see what happens.