### PR TITLE
Fixed a bug in the get_subnets function

### DIFF
--- a/bittensor/subtensor.py
+++ b/bittensor/subtensor.py
@@ -4253,11 +4253,11 @@ class Subtensor:
         available for neuron participation and collaboration.
         """
         result = self.query_map_subtensor("NetworksAdded", block)
-        return (
-            [network[0].value for network in result.records]
-            if result and hasattr(result, "records")
-            else []
-        )
+        subnets = []
+        if result and hasattr(result, "records"):
+            for record in result.records:
+                subnets.append(record[0].value)
+        return subnets
 
     def get_all_subnets_info(self, block: Optional[int] = None) -> List[SubnetInfo]:
         """

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -1914,6 +1914,24 @@ def test_get_subnets_no_block_specified(mocker, subtensor):
     subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", None)
 
 
+def test_get_subnets_correct_length(mocker, subtensor):
+    """Test get_subnets returns a list of the correct length."""
+    # Prep
+    block = 123
+    num_records = 50 
+    mock_records = [(mocker.MagicMock(value=i), True) for i in range(num_records)]
+    mock_result = mocker.MagicMock()
+    mock_result.records = mock_records
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=mock_result)
+
+    # Call
+    result = subtensor.get_subnets(block)
+
+    # Asserts
+    assert len(result) == num_records
+    subtensor.query_map_subtensor.assert_called_once_with("NetworksAdded", block)
+
+
 # `get_all_subnets_info` tests
 def test_get_all_subnets_info_success(mocker, subtensor):
     """Test get_all_subnets_info returns correct data when subnet information is found."""


### PR DESCRIPTION
### Bug

The get_subnets function was truncating to max. 100 results due to list comprehensions handling of iterators. The bug has been described in #2208.

### Description of the Change

Replaced list comprehension with a manual iteration to ensure all subnet UIDs are retrieved, addressing the issue of truncated results.

### Alternate Designs

Considered increasing fetch limits but chose manual iteration for more reliable results.

### Possible Drawbacks

No significant drawbacks, just a minor increase in code complexity.

### Verification Process

Added a test to check the length of the result list, ensuring all records are processed correctly. Ran all existing tests to confirm no regressions.

### Release Notes

Fixed an issue in get_subnets where the result list was being truncated, ensuring complete retrieval of subnets.