### PR TITLE
Updates timeout type in dendrite.py

### DIFF
--- a/bittensor/dendrite.py
+++ b/bittensor/dendrite.py
@@ -23,6 +23,7 @@ import asyncio
 import uuid
 import time
 import aiohttp
+from aiohttp import ClientTimeout
 
 import bittensor
 from typing import Optional, List, Union, AsyncGenerator, Any
@@ -521,7 +522,7 @@ class DendriteMixin:
                 url,
                 headers=synapse.to_headers(),
                 json=synapse.model_dump(),
-                timeout=timeout,
+                timeout=ClientTimeout(total=timeout),
             ) as response:
                 # Extract the JSON response from the server
                 json_response = await response.json()
@@ -603,7 +604,7 @@ class DendriteMixin:
                 url,
                 headers=synapse.to_headers(),
                 json=synapse.model_dump(),
-                timeout=timeout,
+                timeout=ClientTimeout(total=timeout),
             ) as response:
                 # Use synapse subclass' process_streaming_response method to yield the response chunks
                 async for chunk in synapse.process_streaming_response(response):  # type: ignore


### PR DESCRIPTION
This updates the timeout types as per newest update of aiohttp==3.10.0
Ref: https://github.com/opentensor/bittensor/pull/2196