### PR TITLE
Add substrate reconnection logic

### DIFF
--- a/bittensor/core/settings.py
+++ b/bittensor/core/settings.py
@@ -74,7 +74,7 @@ MINERS_DIR.mkdir(parents=True, exist_ok=True)
 FINNEY_ENTRYPOINT = "wss://entrypoint-finney.opentensor.ai:443"
 FINNEY_TEST_ENTRYPOINT = "wss://test.finney.opentensor.ai:443/"
 ARCHIVE_ENTRYPOINT = "wss://archive.chain.opentensor.ai:443/"
-LOCAL_ENTRYPOINT = os.getenv("BT_SUBTENSOR_CHAIN_ENDPOINT") or "ws://127.0.0.1:9944"
+LOCAL_ENTRYPOINT = os.getenv("BT_SUBTENSOR_CHAIN_ENDPOINT") or "ws://127.0.0.1:9946"
 
 # Currency Symbols Bittensor
 TAO_SYMBOL: str = chr(0x03C4)

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -87,11 +87,15 @@ def _ensure_connected(func):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         # Check the socket state before method execution
-        if self.substrate.websocket.sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR) != 0:
+        if (
+            self.substrate.websocket.sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
+            != 0
+        ):
             logging.info("Reconnection substrate...")
             self._get_substrate()
         # Execute the method if the connection is active or after reconnecting
         return func(self, *args, **kwargs)
+
     return wrapper
 
 
@@ -200,7 +204,6 @@ class Subtensor:
                 "To get ahead of this change, please run a local subtensor node and point to it."
             )
 
-        self.substrate = None
         self.log_verbose = log_verbose
         self._get_substrate()
 
@@ -218,7 +221,7 @@ class Subtensor:
     def close(self):
         """Cleans up resources for this subtensor instance like active websocket connection and active extensions."""
         self.substrate.close()
-        
+
     def _get_substrate(self):
         """Establishes a connection to the Substrate node using configured parameters."""
         try:
@@ -230,7 +233,9 @@ class Subtensor:
                 type_registry=settings.TYPE_REGISTRY,
             )
             if self.log_verbose:
-                logging.info(f"Connected to {self.network} network and {self.chain_endpoint}.")
+                logging.info(
+                    f"Connected to {self.network} network and {self.chain_endpoint}."
+                )
 
         except ConnectionRefusedError:
             logging.error(

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -233,7 +233,9 @@ def test_determine_chain_endpoint_and_network(
 def subtensor(mocker):
     fake_substrate = mocker.MagicMock()
     fake_substrate.websocket.sock.getsockopt.return_value = 0
-    mocker.patch.object(subtensor_module, "SubstrateInterface", return_value=fake_substrate)
+    mocker.patch.object(
+        subtensor_module, "SubstrateInterface", return_value=fake_substrate
+    )
     return Subtensor()
 
 
@@ -2164,7 +2166,8 @@ def test_get_transfer_fee(subtensor, mocker):
     )
 
     subtensor.substrate.get_payment_info.assert_called_once_with(
-        call=subtensor.substrate.compose_call.return_value, keypair=fake_wallet.coldkeypub
+        call=subtensor.substrate.compose_call.return_value,
+        keypair=fake_wallet.coldkeypub,
     )
 
     assert result == 2e10
@@ -2453,7 +2456,9 @@ def test_connect_without_substrate(mocker):
     # Prep
     fake_substrate = mocker.MagicMock()
     fake_substrate.websocket.sock.getsockopt.return_value = 1
-    mocker.patch.object(subtensor_module, "SubstrateInterface", return_value=fake_substrate)
+    mocker.patch.object(
+        subtensor_module, "SubstrateInterface", return_value=fake_substrate
+    )
     fake_subtensor = Subtensor()
     spy_get_substrate = mocker.spy(Subtensor, "_get_substrate")
 
@@ -2469,7 +2474,9 @@ def test_connect_with_substrate(mocker):
     # Prep
     fake_substrate = mocker.MagicMock()
     fake_substrate.websocket.sock.getsockopt.return_value = 0
-    mocker.patch.object(subtensor_module, "SubstrateInterface", return_value=fake_substrate)
+    mocker.patch.object(
+        subtensor_module, "SubstrateInterface", return_value=fake_substrate
+    )
     fake_subtensor = Subtensor()
     spy_get_substrate = mocker.spy(Subtensor, "_get_substrate")
 
@@ -2478,5 +2485,3 @@ def test_connect_with_substrate(mocker):
 
     # Assertions
     assert spy_get_substrate.call_count == 0
-
-


### PR DESCRIPTION

When the error `[Errno 32] Broken pipe` occurs after the connection has been idle, the connection check `substrate.websocket.connected` and `substrate.websocket.sock` still return `True`.
In order to get the real connection state, I used a low-level socket check via `substrate.websocket.sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)`.

Also, I've fixed and new tests.