### PR TITLE
Fix default wait flags in stake script.

### DIFF
--- a/bittensor/commands/stake.py
+++ b/bittensor/commands/stake.py
@@ -735,14 +735,12 @@ class SetChildKeyTakeCommand:
         set_childkey_take_parser.add_argument(
             "--wait_for_inclusion",
             dest="wait_for_inclusion",
-            action="store_true",
             default=True,
             help="""Wait for the transaction to be included in a block.""",
         )
         set_childkey_take_parser.add_argument(
             "--wait_for_finalization",
             dest="wait_for_finalization",
-            action="store_true",
             default=True,
             help="""Wait for the transaction to be finalized.""",
         )
@@ -1053,14 +1051,12 @@ class SetChildrenCommand:
         set_children_parser.add_argument(
             "--wait_for_inclusion",
             dest="wait_for_inclusion",
-            action="store_true",
             default=True,
             help="""Wait for the transaction to be included in a block.""",
         )
         set_children_parser.add_argument(
             "--wait_for_finalization",
             dest="wait_for_finalization",
-            action="store_true",
             default=True,
             help="""Wait for the transaction to be finalized.""",
         )


### PR DESCRIPTION
Removed unnecessary "store_true" actions from `--wait_for_inclusion` and `--wait_for_finalization` flags in multiple argument parsers. This change ensures proper default behavior without requiring explicit action parameters.