### PR TITLE
Add transaction fee tests

### DIFF
--- a/tests/e2e_tests/subcommands/stake/test_stake_add_remove.py
+++ b/tests/e2e_tests/subcommands/stake/test_stake_add_remove.py
@@ -73,7 +73,8 @@ def test_stake_add(local_chain):
     # Ensure fees are not withdrawn for the add_stake extrinsic, i.e. balance is exactly lower by stake amount
     acc_after = local_chain.query("System", "Account", [wallet.coldkey.ss58_address])
     assert (
-        acc_before.value["data"]["free"] - acc_after.value["data"]["free"] == stake_amount * 1_000_000_000
+        acc_before.value["data"]["free"] - acc_after.value["data"]["free"]
+        == stake_amount * 1_000_000_000
     ), f"Expected no transaction fees for add_stake"
 
     # we can test remove after set the stake rate limit larger than 1

--- a/tests/e2e_tests/subcommands/wallet/test_transfer.py
+++ b/tests/e2e_tests/subcommands/wallet/test_transfer.py
@@ -32,4 +32,11 @@ def test_transfer(local_chain):
     assert (
         expected_transfer <= actual_difference <= expected_transfer + tolerance
     ), f"Expected transfer with tolerance: {expected_transfer} <= {actual_difference} <= {expected_transfer + tolerance}"
+
+    # Ensure the transaction fees are withdrawn
+    fees_lower_boundary = 50_000   # Transfer fees should be at least 50 microTAO
+    assert (
+        expected_transfer + fees_lower_boundary <= actual_difference
+    ), f"Expected transfer fees: {expected_transfer + fees_lower_boundary} <= {actual_difference}"
+
     logging.info("Passed test_transfer")

--- a/tests/e2e_tests/subcommands/wallet/test_transfer.py
+++ b/tests/e2e_tests/subcommands/wallet/test_transfer.py
@@ -34,7 +34,7 @@ def test_transfer(local_chain):
     ), f"Expected transfer with tolerance: {expected_transfer} <= {actual_difference} <= {expected_transfer + tolerance}"
 
     # Ensure the transaction fees are withdrawn
-    fees_lower_boundary = 50_000   # Transfer fees should be at least 50 microTAO
+    fees_lower_boundary = 50_000  # Transfer fees should be at least 50 microTAO
     assert (
         expected_transfer + fees_lower_boundary <= actual_difference
     ), f"Expected transfer fees: {expected_transfer + fees_lower_boundary} <= {actual_difference}"


### PR DESCRIPTION
### Description of the Change

Modified e2e tests to check that
- Non-zero transaction fee is applied for balance transfers
- No transaction fee is applied for add_stake extrinsic

### Quantitative Performance Benefits

Not relevant. We don't have a template for adding tests.

### Possible Drawbacks

If later we decide to lower transaction fees for balance transfers (e.g. to high TAO price), we will have to maintain this test.

### Verification Process
Run:

```bash
LOCALNET_SH_PATH=<---=== replace with your path to subtensor repository===--- >/subtensor/scripts/localnet.sh pytest ./tests/e2e_tests/subcommands/wallet/test_transfer.py

LOCALNET_SH_PATH=<---=== replace with your path to subtensor repository===--- >/subtensor/scripts/localnet.sh pytest ./tests/e2e_tests/subcommands/stake/test_stake_add_remove.py
```

### Applicable Issues

https://github.com/orgs/opentensor/projects/19/views/7?pane=issue&itemId=80965602 

### Release Notes

This is subtensor e2e test, no release notes should be added for BitTensor.