### PR TITLE
Subtensor verbose False by default, debug logging for subtensor connected

### DIFF
--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -134,7 +134,7 @@ class Subtensor:
         network: Optional[str] = None,
         config: Optional["Config"] = None,
         _mock: bool = False,
-        log_verbose: bool = True,
+        log_verbose: bool = False,
         connection_timeout: int = 600,
     ) -> None:
         """
@@ -214,7 +214,7 @@ class Subtensor:
                 type_registry=settings.TYPE_REGISTRY,
             )
             if self.log_verbose:
-                logging.info(
+                logging.debug(
                     f"Connected to {self.network} network and {self.chain_endpoint}."
                 )
 

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -79,6 +79,6 @@ def local_chain(request):
     # Ensure the process has terminated
     process.wait()
 
-    # uninstall templates
+    # Uninstall templates
     logging.info("uninstalling neuron templates")
     uninstall_templates(template_path)

--- a/tests/unit_tests/commands/test_utils.py
+++ b/tests/unit_tests/commands/test_utils.py
@@ -54,5 +54,7 @@ def test_get_delegates_details_error(mocker):
 
     # Assertions
     mocked_sub.get_delegate_identities.assert_called_once()
-    bittensor.logging.exception.assert_called_once_with(f"Unable to get Delegates Identities. Error: {test_error_message}")
+    bittensor.logging.exception.assert_called_once_with(
+        f"Unable to get Delegates Identities. Error: {test_error_message}"
+    )
     assert result is None

--- a/tests/unit_tests/commands/test_utils.py
+++ b/tests/unit_tests/commands/test_utils.py
@@ -1,0 +1,58 @@
+# The MIT License (MIT)
+# Copyright © 2021 Yuma Rao
+# Copyright © 2022 Opentensor Foundation
+# Copyright © 2023 Opentensor Technologies Inc
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import pytest
+from bittensor.commands.utils import get_delegates_details
+import bittensor
+
+
+def test_get_delegates_details_success(mocker):
+    """Tests the get_delegates_details function to ensure it successfully retrieves delegate details."""
+    # Prep
+    mocked_sub = mocker.MagicMock()
+    mocker.patch("bittensor.subtensor", return_value=mocked_sub)
+
+    # Call
+
+    fake_subtensor = bittensor.subtensor()
+    result = get_delegates_details(fake_subtensor)
+
+    # Assertions
+    mocked_sub.get_delegate_identities.assert_called_once()
+    assert result == mocked_sub.get_delegate_identities.return_value
+
+
+def test_get_delegates_details_error(mocker):
+    """Tests the get_delegates_details function to ensure it handles errors correctly."""
+    # Prep
+    test_error_message = "Test exception"
+    mocked_sub = mocker.MagicMock()
+    mocked_sub.get_delegate_identities.side_effect = Exception(test_error_message)
+
+    mocker.patch("bittensor.subtensor", return_value=mocked_sub)
+    mocker.patch("bittensor.logging.exception")
+
+    # Call
+    fake_subtensor = bittensor.subtensor()
+    result = get_delegates_details(fake_subtensor)
+
+    # Assertions
+    mocked_sub.get_delegate_identities.assert_called_once()
+    bittensor.logging.exception.assert_called_once_with(f"Unable to get Delegates Identities. Error: {test_error_message}")
+    assert result is None

--- a/tests/unit_tests/utils/test_wallet_utils.py
+++ b/tests/unit_tests/utils/test_wallet_utils.py
@@ -27,9 +27,7 @@ def test_decode_hex_identity_dict():
         "additional": [
             (
                 {"Raw11": "0x6465736372697074696f6e"},
-                {
-                    "Raw64": "0x46616b65206465736372697074696f6e"
-                },
+                {"Raw64": "0x46616b65206465736372697074696f6e"},
             )
         ],
         "display": {"Raw17": "0x46616b654e616d65"},
@@ -43,9 +41,7 @@ def test_decode_hex_identity_dict():
     }
 
     expected_result = {
-        "additional": [
-            ("description", "Fake description")
-        ],
+        "additional": [("description", "Fake description")],
         "display": "FakeName",
         "legal": "None",
         "web": "http://www.blabla-test.com",
@@ -62,5 +58,3 @@ def test_decode_hex_identity_dict():
 
     # Assertions
     assert result == expected_result
-
-

--- a/tests/unit_tests/utils/test_wallet_utils.py
+++ b/tests/unit_tests/utils/test_wallet_utils.py
@@ -1,0 +1,66 @@
+# The MIT License (MIT)
+# Copyright © 2021 Yuma Rao
+# Copyright © 2022 Opentensor Foundation
+# Copyright © 2023 Opentensor Technologies Inc
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+from bittensor.utils.wallet_utils import decode_hex_identity_dict
+
+
+def test_decode_hex_identity_dict():
+    """Tests the decode_hex_identity_dict function to ensure it correctly decodes a hex-encoded identity dictionary."""
+    # Prep
+    fake_info_dictionary = {
+        "additional": [
+            (
+                {"Raw11": "0x6465736372697074696f6e"},
+                {
+                    "Raw64": "0x46616b65206465736372697074696f6e"
+                },
+            )
+        ],
+        "display": {"Raw17": "0x46616b654e616d65"},
+        "legal": "None",
+        "web": {"Raw22": "0x687474703a2f2f7777772e626c61626c612d746573742e636f6d"},
+        "riot": "None",
+        "email": "None",
+        "pgp_fingerprint": None,
+        "image": "None",
+        "twitter": "None",
+    }
+
+    expected_result = {
+        "additional": [
+            ("description", "Fake description")
+        ],
+        "display": "FakeName",
+        "legal": "None",
+        "web": "http://www.blabla-test.com",
+        "riot": "None",
+        "email": "None",
+        "pgp_fingerprint": None,
+        "image": "None",
+        "twitter": "None",
+    }
+
+    # Call
+
+    result = decode_hex_identity_dict(fake_info_dictionary)
+
+    # Assertions
+    assert result == expected_result
+
+


### PR DESCRIPTION
This sets `Subtensor.log_verbose` to `False` by default, and changes the logging level for subtensor connected to debug.

