### PR TITLE
Remove `retry` and fix tests

### DIFF
--- a/bittensor/core/extrinsics/commit_weights.py
+++ b/bittensor/core/extrinsics/commit_weights.py
@@ -19,8 +19,6 @@
 
 from typing import Optional, TYPE_CHECKING
 
-from retry import retry
-
 from bittensor.core.extrinsics.utils import submit_extrinsic
 from bittensor.utils import format_error_message
 from bittensor.utils.btlogging import logging
@@ -60,37 +58,33 @@ def do_commit_weights(
     This method ensures that the weight commitment is securely recorded on the Bittensor blockchain, providing a verifiable record of the neuron's weight distribution at a specific point in time.
     """
 
-    @retry(delay=1, tries=3, backoff=2, max_delay=4)
-    def make_substrate_call_with_retry():
-        call = self.substrate.compose_call(
-            call_module="SubtensorModule",
-            call_function="commit_weights",
-            call_params={
-                "netuid": netuid,
-                "commit_hash": commit_hash,
-            },
-        )
-        extrinsic = self.substrate.create_signed_extrinsic(
-            call=call,
-            keypair=wallet.hotkey,
-        )
-        response = submit_extrinsic(
-            substrate=self.substrate,
-            extrinsic=extrinsic,
-            wait_for_inclusion=wait_for_inclusion,
-            wait_for_finalization=wait_for_finalization,
-        )
+    call = self.substrate.compose_call(
+        call_module="SubtensorModule",
+        call_function="commit_weights",
+        call_params={
+            "netuid": netuid,
+            "commit_hash": commit_hash,
+        },
+    )
+    extrinsic = self.substrate.create_signed_extrinsic(
+        call=call,
+        keypair=wallet.hotkey,
+    )
+    response = submit_extrinsic(
+        substrate=self.substrate,
+        extrinsic=extrinsic,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+    )
 
-        if not wait_for_finalization and not wait_for_inclusion:
-            return True, None
+    if not wait_for_finalization and not wait_for_inclusion:
+        return True, None
 
-        response.process_events()
-        if response.is_success:
-            return True, None
-        else:
-            return False, response.error_message
-
-    return make_substrate_call_with_retry()
+    response.process_events()
+    if response.is_success:
+        return True, None
+    else:
+        return False, response.error_message
 
 
 def commit_weights_extrinsic(
@@ -174,40 +168,36 @@ def do_reveal_weights(
     This method ensures that the weight revelation is securely recorded on the Bittensor blockchain, providing transparency and accountability for the neuron's weight distribution.
     """
 
-    @retry(delay=1, tries=3, backoff=2, max_delay=4)
-    def make_substrate_call_with_retry():
-        call = self.substrate.compose_call(
-            call_module="SubtensorModule",
-            call_function="reveal_weights",
-            call_params={
-                "netuid": netuid,
-                "uids": uids,
-                "values": values,
-                "salt": salt,
-                "version_key": version_key,
-            },
-        )
-        extrinsic = self.substrate.create_signed_extrinsic(
-            call=call,
-            keypair=wallet.hotkey,
-        )
-        response = submit_extrinsic(
-            substrate=self.substrate,
-            extrinsic=extrinsic,
-            wait_for_inclusion=wait_for_inclusion,
-            wait_for_finalization=wait_for_finalization,
-        )
+    call = self.substrate.compose_call(
+        call_module="SubtensorModule",
+        call_function="reveal_weights",
+        call_params={
+            "netuid": netuid,
+            "uids": uids,
+            "values": values,
+            "salt": salt,
+            "version_key": version_key,
+        },
+    )
+    extrinsic = self.substrate.create_signed_extrinsic(
+        call=call,
+        keypair=wallet.hotkey,
+    )
+    response = submit_extrinsic(
+        substrate=self.substrate,
+        extrinsic=extrinsic,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+    )
 
-        if not wait_for_finalization and not wait_for_inclusion:
-            return True, None
+    if not wait_for_finalization and not wait_for_inclusion:
+        return True, None
 
-        response.process_events()
-        if response.is_success:
-            return True, None
-        else:
-            return False, response.error_message
-
-    return make_substrate_call_with_retry()
+    response.process_events()
+    if response.is_success:
+        return True, None
+    else:
+        return False, response.error_message
 
 
 def reveal_weights_extrinsic(

--- a/bittensor/core/extrinsics/root.py
+++ b/bittensor/core/extrinsics/root.py
@@ -4,7 +4,6 @@ from typing import Optional, Union, TYPE_CHECKING
 import numpy as np
 from bittensor_wallet.errors import KeyFileError
 from numpy.typing import NDArray
-from retry import retry
 
 from bittensor.core.settings import version_as_int
 from bittensor.utils import format_error_message, weight_utils
@@ -24,38 +23,34 @@ def _do_root_register(
     wait_for_inclusion: bool = False,
     wait_for_finalization: bool = True,
 ) -> tuple[bool, Optional[str]]:
-    @retry(delay=1, tries=3, backoff=2, max_delay=4)
-    def make_substrate_call_with_retry():
-        # create extrinsic call
-        call = self.substrate.compose_call(
-            call_module="SubtensorModule",
-            call_function="root_register",
-            call_params={"hotkey": wallet.hotkey.ss58_address},
-        )
-        extrinsic = self.substrate.create_signed_extrinsic(
-            call=call, keypair=wallet.coldkey
-        )
-        response = self.substrate.submit_extrinsic(
-            extrinsic,
-            wait_for_inclusion=wait_for_inclusion,
-            wait_for_finalization=wait_for_finalization,
-        )
+    # create extrinsic call
+    call = self.substrate.compose_call(
+        call_module="SubtensorModule",
+        call_function="root_register",
+        call_params={"hotkey": wallet.hotkey.ss58_address},
+    )
+    extrinsic = self.substrate.create_signed_extrinsic(
+        call=call, keypair=wallet.coldkey
+    )
+    response = self.substrate.submit_extrinsic(
+        extrinsic,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+    )
 
-        # We only wait here if we expect finalization.
-        if not wait_for_finalization and not wait_for_inclusion:
-            return True
+    # We only wait here if we expect finalization.
+    if not wait_for_finalization and not wait_for_inclusion:
+        return True, None
 
-        # process if registration successful, try again if pow is still valid
-        response.process_events()
-        if not response.is_success:
-            return False, format_error_message(
-                response.error_message, substrate=self.substrate
-            )
-        # Successful registration
-        else:
-            return True, None
-
-    return make_substrate_call_with_retry()
+    # process if registration successful, try again if pow is still valid
+    response.process_events()
+    if not response.is_success:
+        return False, format_error_message(
+            response.error_message, substrate=self.substrate
+        )
+    # Successful registration
+    else:
+        return True, None
 
 
 def root_register_extrinsic(
@@ -147,41 +142,37 @@ def _do_set_root_weights(
     This method is vital for the dynamic weighting mechanism in Bittensor, where neurons adjust their trust in other neurons based on observed performance and contributions on the root network.
     """
 
-    @retry(delay=2, tries=3, backoff=2, max_delay=4)
-    def make_substrate_call_with_retry():
-        call = self.substrate.compose_call(
-            call_module="SubtensorModule",
-            call_function="set_root_weights",
-            call_params={
-                "dests": uids,
-                "weights": vals,
-                "netuid": netuid,
-                "version_key": version_key,
-                "hotkey": wallet.hotkey.ss58_address,
-            },
-        )
-        # Period dictates how long the extrinsic will stay as part of waiting pool
-        extrinsic = self.substrate.create_signed_extrinsic(
-            call=call,
-            keypair=wallet.coldkey,
-            era={"period": 5},
-        )
-        response = self.substrate.submit_extrinsic(
-            extrinsic,
-            wait_for_inclusion=wait_for_inclusion,
-            wait_for_finalization=wait_for_finalization,
-        )
-        # We only wait here if we expect finalization.
-        if not wait_for_finalization and not wait_for_inclusion:
-            return True, "Not waiting for finalziation or inclusion."
+    call = self.substrate.compose_call(
+        call_module="SubtensorModule",
+        call_function="set_root_weights",
+        call_params={
+            "dests": uids,
+            "weights": vals,
+            "netuid": netuid,
+            "version_key": version_key,
+            "hotkey": wallet.hotkey.ss58_address,
+        },
+    )
+    # Period dictates how long the extrinsic will stay as part of waiting pool
+    extrinsic = self.substrate.create_signed_extrinsic(
+        call=call,
+        keypair=wallet.coldkey,
+        era={"period": 5},
+    )
+    response = self.substrate.submit_extrinsic(
+        extrinsic,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+    )
+    # We only wait here if we expect finalization.
+    if not wait_for_finalization and not wait_for_inclusion:
+        return True, "Not waiting for finalziation or inclusion."
 
-        response.process_events()
-        if response.is_success:
-            return True, "Successfully set weights."
-        else:
-            return False, response.error_message
-
-    return make_substrate_call_with_retry()
+    response.process_events()
+    if response.is_success:
+        return True, "Successfully set weights."
+    else:
+        return False, response.error_message
 
 
 @legacy_torch_api_compat

--- a/bittensor/core/extrinsics/set_weights.py
+++ b/bittensor/core/extrinsics/set_weights.py
@@ -20,7 +20,6 @@ from typing import Union, Optional, TYPE_CHECKING
 
 import numpy as np
 from numpy.typing import NDArray
-from retry import retry
 
 from bittensor.core.extrinsics.utils import submit_extrinsic
 from bittensor.core.settings import version_as_int
@@ -66,43 +65,39 @@ def do_set_weights(
     This method is vital for the dynamic weighting mechanism in Bittensor, where neurons adjust their trust in other neurons based on observed performance and contributions.
     """
 
-    @retry(delay=1, tries=3, backoff=2, max_delay=4)
-    def make_substrate_call_with_retry():
-        call = self.substrate.compose_call(
-            call_module="SubtensorModule",
-            call_function="set_weights",
-            call_params={
-                "dests": uids,
-                "weights": vals,
-                "netuid": netuid,
-                "version_key": version_key,
-            },
-        )
-        # Period dictates how long the extrinsic will stay as part of waiting pool
-        extrinsic = self.substrate.create_signed_extrinsic(
-            call=call,
-            keypair=wallet.hotkey,
-            era={"period": 5},
-        )
-        response = submit_extrinsic(
-            substrate=self.substrate,
-            extrinsic=extrinsic,
-            wait_for_inclusion=wait_for_inclusion,
-            wait_for_finalization=wait_for_finalization,
-        )
-        # We only wait here if we expect finalization.
-        if not wait_for_finalization and not wait_for_inclusion:
-            return True, "Not waiting for finalization or inclusion."
+    call = self.substrate.compose_call(
+        call_module="SubtensorModule",
+        call_function="set_weights",
+        call_params={
+            "dests": uids,
+            "weights": vals,
+            "netuid": netuid,
+            "version_key": version_key,
+        },
+    )
+    # Period dictates how long the extrinsic will stay as part of waiting pool
+    extrinsic = self.substrate.create_signed_extrinsic(
+        call=call,
+        keypair=wallet.hotkey,
+        era={"period": 5},
+    )
+    response = submit_extrinsic(
+        substrate=self.substrate,
+        extrinsic=extrinsic,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+    )
+    # We only wait here if we expect finalization.
+    if not wait_for_finalization and not wait_for_inclusion:
+        return True, "Not waiting for finalization or inclusion."
 
-        response.process_events()
-        if response.is_success:
-            return True, "Successfully set weights."
-        else:
-            return False, format_error_message(
-                response.error_message, substrate=self.substrate
-            )
-
-    return make_substrate_call_with_retry()
+    response.process_events()
+    if response.is_success:
+        return True, "Successfully set weights."
+    else:
+        return False, format_error_message(
+            response.error_message, substrate=self.substrate
+        )
 
 
 # Community uses this extrinsic directly and via `subtensor.set_weights`

--- a/bittensor/core/extrinsics/transfer.py
+++ b/bittensor/core/extrinsics/transfer.py
@@ -17,8 +17,6 @@
 
 from typing import Optional, Union, TYPE_CHECKING
 
-from retry import retry
-
 from bittensor.core.extrinsics.utils import submit_extrinsic
 from bittensor.core.settings import NETWORK_EXPLORER_MAP
 from bittensor.utils import (
@@ -62,35 +60,31 @@ def do_transfer(
         error (dict): Error message from subtensor if transfer failed.
     """
 
-    @retry(delay=1, tries=3, backoff=2, max_delay=4)
-    def make_substrate_call_with_retry():
-        call = self.substrate.compose_call(
-            call_module="Balances",
-            call_function="transfer_allow_death",
-            call_params={"dest": dest, "value": transfer_balance.rao},
-        )
-        extrinsic = self.substrate.create_signed_extrinsic(
-            call=call, keypair=wallet.coldkey
-        )
-        response = submit_extrinsic(
-            substrate=self.substrate,
-            extrinsic=extrinsic,
-            wait_for_inclusion=wait_for_inclusion,
-            wait_for_finalization=wait_for_finalization,
-        )
-        # We only wait here if we expect finalization.
-        if not wait_for_finalization and not wait_for_inclusion:
-            return True, None, None
+    call = self.substrate.compose_call(
+        call_module="Balances",
+        call_function="transfer_allow_death",
+        call_params={"dest": dest, "value": transfer_balance.rao},
+    )
+    extrinsic = self.substrate.create_signed_extrinsic(
+        call=call, keypair=wallet.coldkey
+    )
+    response = submit_extrinsic(
+        substrate=self.substrate,
+        extrinsic=extrinsic,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+    )
+    # We only wait here if we expect finalization.
+    if not wait_for_finalization and not wait_for_inclusion:
+        return True, None, None
 
-        # Otherwise continue with finalization.
-        response.process_events()
-        if response.is_success:
-            block_hash = response.block_hash
-            return True, block_hash, None
-        else:
-            return False, None, response.error_message
-
-    return make_substrate_call_with_retry()
+    # Otherwise continue with finalization.
+    response.process_events()
+    if response.is_success:
+        block_hash = response.block_hash
+        return True, block_hash, None
+    else:
+        return False, None, response.error_message
 
 
 # Community uses this extrinsic directly and via `subtensor.transfer`

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -30,7 +30,6 @@ import numpy as np
 import scalecodec
 from bittensor_wallet import Wallet
 from numpy.typing import NDArray
-from retry import retry
 from scalecodec.base import RuntimeConfiguration
 from scalecodec.exceptions import RemainingScaleBytesNotEmptyException
 from scalecodec.type_registry import load_type_registry_preset
@@ -450,18 +449,14 @@ class Subtensor:
         This query function is essential for accessing detailed information about the network and its neurons, providing valuable insights into the state and dynamics of the Bittensor ecosystem.
         """
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=logging)
-        def make_substrate_call_with_retry() -> "ScaleType":
-            return self.substrate.query(
-                module="SubtensorModule",
-                storage_function=name,
-                params=params,
-                block_hash=(
-                    None if block is None else self.substrate.get_block_hash(block)
-                ),
-            )
-
-        return make_substrate_call_with_retry()
+        return self.substrate.query(
+            module="SubtensorModule",
+            storage_function=name,
+            params=params,
+            block_hash=(
+                None if block is None else self.substrate.get_block_hash(block)
+            ),
+        )
 
     @networking.ensure_connected
     def query_map_subtensor(
@@ -480,19 +475,14 @@ class Subtensor:
 
         This function is particularly useful for analyzing and understanding complex network structures and relationships within the Bittensor ecosystem, such as inter-neuronal connections and stake distributions.
         """
-
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=logging)
-        def make_substrate_call_with_retry():
-            return self.substrate.query_map(
-                module="SubtensorModule",
-                storage_function=name,
-                params=params,
-                block_hash=(
-                    None if block is None else self.substrate.get_block_hash(block)
-                ),
-            )
-
-        return make_substrate_call_with_retry()
+        return self.substrate.query_map(
+            module="SubtensorModule",
+            storage_function=name,
+            params=params,
+            block_hash=(
+                None if block is None else self.substrate.get_block_hash(block)
+            ),
+        )
 
     def query_runtime_api(
         self,
@@ -563,16 +553,11 @@ class Subtensor:
 
         The state call function provides a more direct and flexible way of querying blockchain data, useful for specific use cases where standard queries are insufficient.
         """
-
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=logging)
-        def make_substrate_call_with_retry() -> dict[Any, Any]:
-            block_hash = None if block is None else self.substrate.get_block_hash(block)
-            return self.substrate.rpc_request(
-                method="state_call",
-                params=[method, data, block_hash] if block_hash else [method, data],
-            )
-
-        return make_substrate_call_with_retry()
+        block_hash = None if block is None else self.substrate.get_block_hash(block)
+        return self.substrate.rpc_request(
+            method="state_call",
+            params=[method, data, block_hash] if block_hash else [method, data],
+        )
 
     @networking.ensure_connected
     def query_map(
@@ -596,19 +581,14 @@ class Subtensor:
 
         This function is particularly useful for retrieving detailed and structured data from various blockchain modules, offering insights into the network's state and the relationships between its different components.
         """
-
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=logging)
-        def make_substrate_call_with_retry() -> "QueryMapResult":
-            return self.substrate.query_map(
-                module=module,
-                storage_function=name,
-                params=params,
-                block_hash=(
-                    None if block is None else self.substrate.get_block_hash(block)
-                ),
-            )
-
-        return make_substrate_call_with_retry()
+        return self.substrate.query_map(
+            module=module,
+            storage_function=name,
+            params=params,
+            block_hash=(
+                None if block is None else self.substrate.get_block_hash(block)
+            ),
+        )
 
     @networking.ensure_connected
     def query_constant(
@@ -627,18 +607,13 @@ class Subtensor:
 
         Constants queried through this function can include critical network parameters such as inflation rates, consensus rules, or validation thresholds, providing a deeper understanding of the Bittensor network's operational parameters.
         """
-
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=logging)
-        def make_substrate_call_with_retry():
-            return self.substrate.get_constant(
-                module_name=module_name,
-                constant_name=constant_name,
-                block_hash=(
-                    None if block is None else self.substrate.get_block_hash(block)
-                ),
-            )
-
-        return make_substrate_call_with_retry()
+        return self.substrate.get_constant(
+            module_name=module_name,
+            constant_name=constant_name,
+            block_hash=(
+                None if block is None else self.substrate.get_block_hash(block)
+            ),
+        )
 
     @networking.ensure_connected
     def query_module(
@@ -662,19 +637,14 @@ class Subtensor:
 
         This versatile query function is key to accessing a wide range of data and insights from different parts of the Bittensor blockchain, enhancing the understanding and analysis of the network's state and dynamics.
         """
-
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=logging)
-        def make_substrate_call_with_retry() -> "ScaleType":
-            return self.substrate.query(
-                module=module,
-                storage_function=name,
-                params=params,
-                block_hash=(
-                    None if block is None else self.substrate.get_block_hash(block)
-                ),
-            )
-
-        return make_substrate_call_with_retry()
+        return self.substrate.query(
+            module=module,
+            storage_function=name,
+            params=params,
+            block_hash=(
+                None if block is None else self.substrate.get_block_hash(block)
+            ),
+        )
 
     # Common subtensor methods
     def metagraph(
@@ -777,12 +747,7 @@ class Subtensor:
 
         Knowing the current block number is essential for querying real-time data and performing time-sensitive operations on the blockchain. It serves as a reference point for network activities and data synchronization.
         """
-
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=logging)
-        def make_substrate_call_with_retry():
-            return self.substrate.get_block_number(None)  # type: ignore
-
-        return make_substrate_call_with_retry()
+        return self.substrate.get_block_number(None)  # type: ignore
 
     def is_hotkey_registered_any(
         self, hotkey_ss58: str, block: Optional[int] = None
@@ -1230,18 +1195,15 @@ class Subtensor:
         if uid is None:
             return NeuronInfo.get_null_neuron()
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=logging)
-        def make_substrate_call_with_retry():
-            block_hash = None if block is None else self.substrate.get_block_hash(block)
-            params = [netuid, uid]
-            if block_hash:
-                params = params + [block_hash]
-            return self.substrate.rpc_request(
-                method="neuronInfo_getNeuron",
-                params=params,  # custom rpc method
-            )
+        block_hash = None if block is None else self.substrate.get_block_hash(block)
+        params = [netuid, uid]
+        if block_hash:
+            params = params + [block_hash]
 
-        json_body = make_substrate_call_with_retry()
+        json_body = self.substrate.rpc_request(
+            method="neuronInfo_getNeuron",
+            params=params,  # custom rpc method
+        )
 
         if not (result := json_body.get("result", None)):
             return NeuronInfo.get_null_neuron()
@@ -1454,17 +1416,12 @@ class Subtensor:
 
         Gaining insights into the subnets' details assists in understanding the network's composition, the roles of different subnets, and their unique features.
         """
+        block_hash = None if block is None else self.substrate.get_block_hash(block)
 
-        @retry(delay=1, tries=3, backoff=2, max_delay=4)
-        def make_substrate_call_with_retry():
-            block_hash = None if block is None else self.substrate.get_block_hash(block)
-
-            return self.substrate.rpc_request(
-                method="subnetInfo_getSubnetsInfo",  # custom rpc method
-                params=[block_hash] if block_hash else [],
-            )
-
-        json_body = make_substrate_call_with_retry()
+        json_body = self.substrate.rpc_request(
+            method="subnetInfo_getSubnetsInfo",  # custom rpc method
+            params=[block_hash] if block_hash else [],
+        )
 
         if not (result := json_body.get("result", None)):
             return []
@@ -1662,25 +1619,21 @@ class Subtensor:
         This function is important for monitoring account holdings and managing financial transactions within the Bittensor ecosystem. It helps in assessing the economic status and capacity of network participants.
         """
         try:
-
-            @retry(delay=1, tries=3, backoff=2, max_delay=4, logger=logging)
-            def make_substrate_call_with_retry():
-                return self.substrate.query(
-                    module="System",
-                    storage_function="Account",
-                    params=[address],
-                    block_hash=(
-                        None if block is None else self.substrate.get_block_hash(block)
-                    ),
-                )
-
-            result = make_substrate_call_with_retry()
+            result = self.substrate.query(
+                module="System",
+                storage_function="Account",
+                params=[address],
+                block_hash=(
+                    None if block is None else self.substrate.get_block_hash(block)
+                ),
+            )
 
         except RemainingScaleBytesNotEmptyException:
             logging.error(
                 "Received a corrupted message. This likely points to an error with the network or subnet."
             )
             return Balance(1000)
+
         return Balance(result.value["data"]["free"])
 
     # Used in community via `bittensor.core.subtensor.Subtensor.transfer`
@@ -1967,20 +1920,14 @@ class Subtensor:
 
         This function is essential for understanding the roles and influence of delegate neurons within the Bittensor network's consensus and governance structures.
         """
-
-        @retry(delay=1, tries=3, backoff=2, max_delay=4)
-        def make_substrate_call_with_retry(encoded_hotkey_: list[int]):
-            block_hash = None if block is None else self.substrate.get_block_hash(block)
-
-            return self.substrate.rpc_request(
-                method="delegateInfo_getDelegate",  # custom rpc method
-                params=(
-                    [encoded_hotkey_, block_hash] if block_hash else [encoded_hotkey_]
-                ),
-            )
-
         encoded_hotkey = ss58_to_vec_u8(hotkey_ss58)
-        json_body = make_substrate_call_with_retry(encoded_hotkey)
+
+        block_hash = None if block is None else self.substrate.get_block_hash(block)
+
+        json_body = self.substrate.rpc_request(
+            method="delegateInfo_getDelegate",  # custom rpc method
+            params=([encoded_hotkey, block_hash] if block_hash else [encoded_hotkey]),
+        )
 
         if not (result := json_body.get("result", None)):
             return None

--- a/bittensor/utils/registration.py
+++ b/bittensor/utils/registration.py
@@ -740,9 +740,7 @@ def _solve_for_difficulty_fast(
 
 
 @retry(Exception, tries=3, delay=1)
-def _get_block_with_retry(
-    subtensor: "Subtensor", netuid: int
-) -> tuple[int, int, bytes]:
+def _get_block_with_retry(subtensor: "Subtensor", netuid: int) -> tuple[int, int, str]:
     """
     Gets the current block number, difficulty, and block hash from the substrate node.
 

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2069,34 +2069,6 @@ def test_get_all_subnets_info_no_data(mocker, subtensor, result_):
     subtensor_module.SubnetInfo.list_from_vec_u8.assert_not_called()
 
 
-def test_get_all_subnets_info_retry(mocker, subtensor):
-    """Test get_all_subnets_info retries on failure."""
-    # Prep
-    block = 123
-    subnet_data = [1, 2, 3]
-    mocker.patch.object(
-        subtensor.substrate, "get_block_hash", return_value="mock_block_hash"
-    )
-    mock_response = {"result": subnet_data}
-    mock_rpc_request = mocker.patch.object(
-        subtensor.substrate,
-        "rpc_request",
-        side_effect=[Exception, Exception, mock_response],
-    )
-    mocker.patch.object(
-        subtensor_module.SubnetInfo, "list_from_vec_u8", return_value=["some_data"]
-    )
-
-    # Call
-    result = subtensor.get_all_subnets_info(block)
-
-    # Asserts
-    subtensor.substrate.get_block_hash.assert_called_with(block)
-    assert mock_rpc_request.call_count == 3
-    subtensor_module.SubnetInfo.list_from_vec_u8.assert_called_once_with(subnet_data)
-    assert result == ["some_data"]
-
-
 def test_get_delegate_take_success(subtensor, mocker):
     """Verify `get_delegate_take` method successful path."""
     # Preps


### PR DESCRIPTION
The historical idea of ​​retry was that regardless of any Errors, it repeated its attempts 3 times.
Now the SDK code is much more functional and cleaner. I catch different errors at different places.
1. `ConnectionRefusedError` error is caught during the initialization of the Subtensor
2. The connection failure error is handled by decorator `@networking.ensure_connected`
3. Only the subtensor response error remains based on the data passed by the user or based on the current state of the subtensor. In this case, if the first response was an error, then all three attempts return exactly the same result. We are just unnecessarily loading the chain with additional calls. We tested this behavior many times. This is the reason why we abandoned retry in the async impl of the Subtensor and AsyncSubstrateInterface.

Also, an important point is that SDK is a Python package that is intended for use in scripts. It is not an interactive package. All responsibility for processing the results is in the hands of the user. This should be considered as a more flexible way then in btcli. The user will be able to regulate the retries themselves if they want. If the data was wrong during the request and the response is not successful, then it is easier to process and make a request based on other data than to make 3 calls and then change the data.