### PR TITLE
E2E tests - Increasing Subtensor coverage (Pt 1)

### DIFF
--- a/tests/e2e_tests/test_axon.py
+++ b/tests/e2e_tests/test_axon.py
@@ -4,9 +4,9 @@ import sys
 import pytest
 
 import bittensor
+from bittensor.core.subtensor import Subtensor
 from bittensor.utils import networking
-from bittensor.utils.btlogging import logging
-from tests.e2e_tests.utils.chain_interactions import register_neuron, register_subnet
+from tests.e2e_tests.utils.chain_interactions import register_subnet
 from tests.e2e_tests.utils.e2e_test_utils import (
     setup_wallet,
     template_path,
@@ -28,11 +28,13 @@ async def test_axon(local_chain):
         AssertionError: If any of the checks or verifications fail
     """
 
-    logging.info("Testing test_axon")
+    print("Testing test_axon")
 
     netuid = 1
     # Register root as Alice - the subnet owner
     alice_keypair, wallet = setup_wallet("//Alice")
+
+    subtensor = Subtensor(network="ws://localhost:9945")
 
     # Register a subnet, netuid 1
     assert register_subnet(local_chain, wallet), "Subnet wasn't created"
@@ -43,8 +45,8 @@ async def test_axon(local_chain):
     ).serialize(), "Subnet wasn't created successfully"
 
     # Register Alice to the network
-    assert register_neuron(
-        local_chain, wallet, netuid
+    assert subtensor.burned_register(
+        wallet, netuid
     ), f"Neuron wasn't registered to subnet {netuid}"
 
     metagraph = bittensor.Metagraph(netuid=netuid, network="ws://localhost:9945")
@@ -87,7 +89,7 @@ async def test_axon(local_chain):
         stderr=asyncio.subprocess.PIPE,
     )
 
-    logging.info("Neuron Alice is now mining")
+    print("Neuron Alice is now mining")
 
     # Waiting for 5 seconds for metagraph to be updated
     await asyncio.sleep(5)
@@ -124,4 +126,4 @@ async def test_axon(local_chain):
         updated_axon.coldkey == alice_keypair.ss58_address
     ), "Coldkey mismatch after mining"
 
-    logging.info("✅ Passed test_axon")
+    print("✅ Passed test_axon")

--- a/tests/e2e_tests/test_commit_weights.py
+++ b/tests/e2e_tests/test_commit_weights.py
@@ -5,11 +5,9 @@ import pytest
 
 from bittensor.core.subtensor import Subtensor
 from bittensor.utils.balance import Balance
-from bittensor.utils.btlogging import logging
 from bittensor.utils.weight_utils import convert_weights_and_uids_for_emit
 from tests.e2e_tests.utils.chain_interactions import (
     add_stake,
-    register_neuron,
     register_subnet,
     sudo_set_hyperparameter_bool,
     sudo_set_hyperparameter_values,
@@ -34,7 +32,7 @@ async def test_commit_and_reveal_weights(local_chain):
         AssertionError: If any of the checks or verifications fail
     """
     netuid = 1
-    logging.info("Testing test_commit_and_reveal_weights")
+    print("Testing test_commit_and_reveal_weights")
     # Register root as Alice
     keypair, alice_wallet = setup_wallet("//Alice")
     assert register_subnet(local_chain, alice_wallet), "Unable to register the subnet"
@@ -44,8 +42,11 @@ async def test_commit_and_reveal_weights(local_chain):
         "SubtensorModule", "NetworksAdded", [1]
     ).serialize(), "Subnet wasn't created successfully"
 
-    assert register_neuron(
-        local_chain, alice_wallet, netuid
+    subtensor = Subtensor(network="ws://localhost:9945")
+
+    # Register Alice to the subnet
+    assert subtensor.burned_register(
+        alice_wallet, netuid
     ), "Unable to register Alice as a neuron"
 
     # Stake to become to top neuron after the first epoch
@@ -60,7 +61,6 @@ async def test_commit_and_reveal_weights(local_chain):
         netuid,
     ), "Unable to enable commit reveal on the subnet"
 
-    subtensor = Subtensor(network="ws://localhost:9945")
     assert subtensor.get_subnet_hyperparameters(
         netuid=netuid,
     ).commit_reveal_weights_enabled, "Failed to enable commit/reveal"
@@ -169,4 +169,4 @@ async def test_commit_and_reveal_weights(local_chain):
     assert (
         weight_vals[0] == revealed_weights.value[0][1]
     ), f"Incorrect revealed weights. Expected: {weights[0]}, Actual: {revealed_weights.value[0][1]}"
-    logging.info("✅ Passed test_commit_and_reveal_weights")
+    print("✅ Passed test_commit_and_reveal_weights")

--- a/tests/e2e_tests/test_dendrite.py
+++ b/tests/e2e_tests/test_dendrite.py
@@ -8,7 +8,6 @@ from bittensor.core.subtensor import Subtensor
 from bittensor.utils.balance import Balance
 from bittensor.utils.btlogging import logging
 from tests.e2e_tests.utils.chain_interactions import (
-    register_neuron,
     register_subnet,
     add_stake,
     wait_epoch,
@@ -52,13 +51,14 @@ async def test_dendrite(local_chain):
     # Register Bob
     bob_keypair, bob_wallet = setup_wallet("//Bob")
 
+    subtensor = Subtensor(network="ws://localhost:9945")
+
     # Register Bob to the network
-    assert register_neuron(
-        local_chain, bob_wallet, netuid
-    ), f"Neuron wasn't registered to subnet {netuid}"
+    assert subtensor.burned_register(
+        bob_wallet, netuid
+    ), "Unable to register Bob as a neuron"
 
     metagraph = Metagraph(netuid=netuid, network="ws://localhost:9945")
-    subtensor = Subtensor(network="ws://localhost:9945")
 
     # Assert one neuron is Bob
     assert len(subtensor.neurons(netuid=netuid)) == 1

--- a/tests/e2e_tests/test_liquid_alpha.py
+++ b/tests/e2e_tests/test_liquid_alpha.py
@@ -3,7 +3,6 @@ from bittensor.utils.balance import Balance
 from bittensor.utils.btlogging import logging
 from tests.e2e_tests.utils.chain_interactions import (
     add_stake,
-    register_neuron,
     register_subnet,
     sudo_set_hyperparameter_bool,
     sudo_set_hyperparameter_values,
@@ -44,16 +43,16 @@ def test_liquid_alpha(local_chain):
     # Verify subnet 1 created successfully
     assert local_chain.query("SubtensorModule", "NetworksAdded", [1]).serialize()
 
-    # Register a neuron to the subnet
-    assert register_neuron(
-        local_chain, alice_wallet, netuid
+    # Register a neuron (Alice) to the subnet
+    subtensor = Subtensor(network="ws://localhost:9945")
+    assert subtensor.burned_register(
+        alice_wallet, netuid
     ), "Unable to register Alice as a neuron"
 
     # Stake to become to top neuron after the first epoch
     add_stake(local_chain, alice_wallet, Balance.from_tao(100_000))
 
     # Assert liquid alpha is disabled
-    subtensor = Subtensor(network="ws://localhost:9945")
     assert (
         subtensor.get_subnet_hyperparameters(netuid=netuid).liquid_alpha_enabled
         is False

--- a/tests/e2e_tests/test_metagraph.py
+++ b/tests/e2e_tests/test_metagraph.py
@@ -5,7 +5,6 @@ from bittensor.utils.balance import Balance
 from bittensor.utils.btlogging import logging
 from tests.e2e_tests.utils.chain_interactions import (
     add_stake,
-    register_neuron,
     register_subnet,
 )
 from tests.e2e_tests.utils.e2e_test_utils import (
@@ -72,8 +71,8 @@ def test_metagraph(local_chain):
     assert len(metagraph.uids) == 0, "Metagraph is not empty"
 
     # Register Bob to the subnet
-    assert register_neuron(
-        local_chain, bob_wallet, netuid
+    assert subtensor.burned_register(
+        bob_wallet, netuid
     ), "Unable to register Bob as a neuron"
 
     # Refresh the metagraph
@@ -108,8 +107,8 @@ def test_metagraph(local_chain):
     metagraph_pre_dave = subtensor.metagraph(netuid=1)
 
     # Register Dave as a neuron
-    assert register_neuron(
-        local_chain, dave_wallet, netuid
+    assert subtensor.burned_register(
+        dave_wallet, netuid
     ), "Unable to register Dave as a neuron"
 
     metagraph.sync(subtensor=subtensor)

--- a/tests/e2e_tests/test_subtensor_functions.py
+++ b/tests/e2e_tests/test_subtensor_functions.py
@@ -4,9 +4,8 @@ import sys
 import pytest
 
 from bittensor.core.subtensor import Subtensor
-from bittensor.utils.btlogging import logging
+from bittensor.utils.balance import Balance
 from tests.e2e_tests.utils.chain_interactions import (
-    register_neuron,
     register_subnet,
 )
 from tests.e2e_tests.utils.e2e_test_utils import (
@@ -14,6 +13,27 @@ from tests.e2e_tests.utils.e2e_test_utils import (
     template_path,
     templates_repo,
 )
+
+"""
+Verifies:
+
+* get_subnets()
+* get_total_subnets()
+* subnet_exists()
+* get_netuids_for_hotkey()
+* is_hotkey_registered_any()
+* is_hotkey_registered_on_subnet()
+* get_uid_for_hotkey_on_subnet()
+* get_neuron_for_pubkey_and_subnet()
+* get_balance()
+* get_subnet_burn_cost()
+* difficulty()
+* burned_register()
+* recycle()
+* get_existential_deposit() 
+* get_all_subnets_info()
+
+"""
 
 
 @pytest.mark.asyncio
@@ -31,6 +51,10 @@ async def test_subtensor_extrinsics(local_chain):
         AssertionError: If any of the checks or verifications fail
     """
     netuid = 1
+    # Initial balance for Alice, defined in the genesis file of localnet
+    initial_alice_balance = Balance.from_tao(1_000_000)
+    # Current Existential deposit for all accounts in bittensor
+    existential_deposit = Balance.from_tao(0.000_000_500)
     subtensor = Subtensor(network="ws://localhost:9945")
 
     # Subnets 0 and 3 are bootstrapped from the start
@@ -41,8 +65,31 @@ async def test_subtensor_extrinsics(local_chain):
     alice_keypair, alice_wallet = setup_wallet("//Alice")
     bob_keypair, bob_wallet = setup_wallet("//Bob")
 
+    # Assert correct balance is fetched for Alice
+    alice_balance = subtensor.get_balance(alice_wallet.coldkeypub.ss58_address)
+    assert (
+        alice_balance == initial_alice_balance
+    ), "Balance for Alice wallet doesn't match with pre-def value"
+
+    # Subnet burn cost is initially lower before we register a subnet
+    pre_subnet_creation_cost = subtensor.get_subnet_burn_cost()
+
     # Register subnet
     register_subnet(local_chain, alice_wallet), "Unable to register the subnet"
+
+    # Subnet burn cost is increased immediately after a subnet is registered
+    post_subnet_creation_cost = subtensor.get_subnet_burn_cost()
+
+    # Assert that the burn cost changed after registering a subnet
+    assert Balance.from_tao(pre_subnet_creation_cost) < Balance.from_tao(
+        post_subnet_creation_cost
+    ), "Burn cost did not change after subnet creation"
+
+    # Assert amount is deducted once a subnetwork is registered by Alice
+    alice_balance_post_sn = subtensor.get_balance(alice_wallet.coldkeypub.ss58_address)
+    assert (
+        alice_balance_post_sn + pre_subnet_creation_cost == initial_alice_balance
+    ), "Balance is the same even after registering a subnet"
 
     # Subnet 1 is added after registration
     assert subtensor.get_subnets() == [0, 1, 3]
@@ -52,10 +99,24 @@ async def test_subtensor_extrinsics(local_chain):
     assert local_chain.query("SubtensorModule", "NetworksAdded", [1]).serialize()
     assert subtensor.subnet_exists(netuid)
 
+    # Default subnetwork difficulty
+    assert (
+        subtensor.difficulty(netuid=1) == 10_000_000
+    ), "Couldn't fetch correct subnet difficulty"
+
     # Register Alice to the subnet
-    assert register_neuron(
-        local_chain, alice_wallet, netuid
+    assert subtensor.burned_register(
+        alice_wallet, netuid
     ), "Unable to register Alice as a neuron"
+
+    # Fetch recycle_amount to register to the subnet
+    recycle_amount = subtensor.recycle(netuid=1)
+    alice_balance_post_reg = subtensor.get_balance(alice_wallet.coldkeypub.ss58_address)
+
+    # Ensure recycled amount is only deducted from the balance after registration
+    assert (
+        alice_balance_post_sn - recycle_amount == alice_balance_post_reg
+    ), "Balance for Alice is not correct after burned register"
 
     # Verify Alice is registered to netuid 1 and Bob isn't registered to any
     assert subtensor.get_netuids_for_hotkey(hotkey_ss58=alice_keypair.ss58_address) == [
@@ -90,9 +151,9 @@ async def test_subtensor_extrinsics(local_chain):
     ), "UID for Alice's hotkey on netuid 1 is not 0 as expected"
 
     # Register Bob to the subnet
-    assert register_neuron(
-        local_chain, bob_wallet, netuid
-    ), "Unable to register Alice as a neuron"
+    assert subtensor.burned_register(
+        bob_wallet, netuid
+    ), "Unable to register Bob as a neuron"
 
     # Verify Bob's UID on netuid 1 is 1
     assert (
@@ -133,19 +194,42 @@ async def test_subtensor_extrinsics(local_chain):
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    logging.info("Neuron Alice is now validating")
+    print("Neuron Alice is now validating")
 
     await asyncio.sleep(
         5
     )  # wait for 5 seconds for the metagraph and subtensor to refresh with latest data
     subtensor = Subtensor(network="ws://localhost:9945")
 
-    # Verify neuron info is updated after running as a validator
-    neuron_info = subtensor.get_neuron_for_pubkey_and_subnet(
-        alice_keypair.ss58_address, netuid=netuid
-    )
-    assert (
-        neuron_info_old.axon_info != neuron_info.axon_info
-    ), "Neuron info not updated after running validator"
+    # # Verify neuron info is updated after running as a validator
+    # neuron_info = subtensor.get_neuron_for_pubkey_and_subnet(
+    #     alice_keypair.ss58_address, netuid=netuid
+    # )
+    # assert (
+    #     neuron_info_old.axon_info != neuron_info.axon_info
+    # ), "Neuron info not updated after running validator"
 
-    logging.info("✅ Passed test_subtensor_extrinsics")
+    # Fetch and assert existential deposit for an account in the network
+    assert (
+        subtensor.get_existential_deposit() == existential_deposit
+    ), "Existential deposit value doesn't match with pre-defined value"
+
+    # Fetching all subnets in the network
+    all_subnets = subtensor.get_all_subnets_info()
+
+    # Assert all netuids are present in all_subnets
+    expected_netuids = [0, 1, 3]
+    actual_netuids = [subnet.netuid for subnet in all_subnets]
+    assert (
+        actual_netuids == expected_netuids
+    ), f"Expected netuids {expected_netuids}, but found {actual_netuids}"
+
+    # Assert that the owner_ss58 of subnet 1 matches Alice's coldkey address
+    expected_owner = alice_wallet.coldkeypub.ss58_address
+    subnet_1 = next((subnet for subnet in all_subnets if subnet.netuid == 1), None)
+    actual_owner = subnet_1.owner_ss58
+    assert (
+        actual_owner == expected_owner
+    ), f"Expected owner {expected_owner}, but found {actual_owner}"
+
+    print("✅ Passed test_subtensor_extrinsics")

--- a/tests/e2e_tests/test_subtensor_functions.py
+++ b/tests/e2e_tests/test_subtensor_functions.py
@@ -32,7 +32,6 @@ Verifies:
 * recycle()
 * get_existential_deposit() 
 * get_all_subnets_info()
-
 """
 
 
@@ -201,13 +200,13 @@ async def test_subtensor_extrinsics(local_chain):
     )  # wait for 5 seconds for the metagraph and subtensor to refresh with latest data
     subtensor = Subtensor(network="ws://localhost:9945")
 
-    # # Verify neuron info is updated after running as a validator
-    # neuron_info = subtensor.get_neuron_for_pubkey_and_subnet(
-    #     alice_keypair.ss58_address, netuid=netuid
-    # )
-    # assert (
-    #     neuron_info_old.axon_info != neuron_info.axon_info
-    # ), "Neuron info not updated after running validator"
+    # Verify neuron info is updated after running as a validator
+    neuron_info = subtensor.get_neuron_for_pubkey_and_subnet(
+        alice_keypair.ss58_address, netuid=netuid
+    )
+    assert (
+        neuron_info_old.axon_info != neuron_info.axon_info
+    ), "Neuron info not updated after running validator"
 
     # Fetch and assert existential deposit for an account in the network
     assert (

--- a/tests/e2e_tests/test_transfer.py
+++ b/tests/e2e_tests/test_transfer.py
@@ -46,7 +46,7 @@ def test_transfer(local_chain):
 
     # Assert correct transfer calculations
     assert (
-        balance_before - transfer_fee - transfer_value== balance_after
+        balance_before - transfer_fee - transfer_value == balance_after
     ), f"Expected {balance_before - transfer_value - transfer_fee}, got {balance_after}"
 
     print("✅ Passed test_transfer")

--- a/tests/e2e_tests/test_transfer.py
+++ b/tests/e2e_tests/test_transfer.py
@@ -1,5 +1,5 @@
-from bittensor import Subtensor, logging
-from bittensor.core.subtensor import transfer_extrinsic
+from bittensor.core.subtensor import Subtensor
+from bittensor.utils.balance import Balance
 from tests.e2e_tests.utils.e2e_test_utils import setup_wallet
 
 
@@ -10,42 +10,43 @@ def test_transfer(local_chain):
     Steps:
         1. Create a wallet for Alice
         2. Calculate existing balance and transfer 2 Tao
-        3. Calculate balance after extrinsic call and verify calculations
+        3. Calculate balance after transfer call and verify calculations
     Raises:
         AssertionError: If any of the checks or verifications fail
     """
 
-    logging.info("Testing test_transfer")
+    print("Testing test_transfer")
 
     # Set up Alice wallet
     keypair, wallet = setup_wallet("//Alice")
+    subtensor = Subtensor(network="ws://localhost:9945")
+    transfer_value = Balance.from_tao(2)
+    dest_coldkey = "5GpzQgpiAKHMWNSH3RN4GLf96GVTDct9QxYEFAY7LWcVzTbx"
+
+    # Fetch transfer fee
+    transfer_fee = subtensor.get_transfer_fee(
+        wallet=wallet,
+        dest=dest_coldkey,
+        value=transfer_value,
+    )
 
     # Account details before transfer
-    acc_before = local_chain.query("System", "Account", [keypair.ss58_address])
+    balance_before = subtensor.get_balance(wallet.coldkeypub.ss58_address)
 
-    # Transfer Tao using extrinsic
-    subtensor = Subtensor(network="ws://localhost:9945")
-    transfer_extrinsic(
-        subtensor=subtensor,
+    # Transfer Tao
+    assert subtensor.transfer(
         wallet=wallet,
-        dest="5GpzQgpiAKHMWNSH3RN4GLf96GVTDct9QxYEFAY7LWcVzTbx",
-        amount=2,
+        dest=dest_coldkey,
+        amount=transfer_value,
         wait_for_finalization=True,
         wait_for_inclusion=True,
     )
-
     # Account details after transfer
-    acc_after = local_chain.query("System", "Account", [keypair.ss58_address])
+    balance_after = subtensor.get_balance(wallet.coldkeypub.ss58_address)
 
-    # Transfer calculation assertions
-    expected_transfer = 2_000_000_000
-    tolerance = 200_000  # Tx fee tolerance
-
-    actual_difference = (
-        acc_before.value["data"]["free"] - acc_after.value["data"]["free"]
-    )
+    # Assert correct transfer calculations
     assert (
-        expected_transfer <= actual_difference <= expected_transfer + tolerance
-    ), f"Expected transfer with tolerance: {expected_transfer} <= {actual_difference} <= {expected_transfer + tolerance}"
+        balance_before - transfer_fee == balance_after
+    ), f"Expected {balance_before - transfer_value - transfer_fee}, got {balance_after}"
 
-    logging.info("✅ Passed test_transfer")
+    print("✅ Passed test_transfer")

--- a/tests/e2e_tests/test_transfer.py
+++ b/tests/e2e_tests/test_transfer.py
@@ -46,7 +46,7 @@ def test_transfer(local_chain):
 
     # Assert correct transfer calculations
     assert (
-        balance_before - transfer_fee == balance_after
+        balance_before - transfer_fee - transfer_value== balance_after
     ), f"Expected {balance_before - transfer_value - transfer_fee}, got {balance_after}"
 
     print("✅ Passed test_transfer")

--- a/tests/e2e_tests/utils/chain_interactions.py
+++ b/tests/e2e_tests/utils/chain_interactions.py
@@ -110,30 +110,6 @@ def register_subnet(substrate: "SubstrateInterface", wallet: "Wallet") -> bool:
     return response.is_success
 
 
-def register_neuron(
-    substrate: "SubstrateInterface", wallet: "Wallet", netuid: int
-) -> bool:
-    """
-    Registers a neuron on a subnet. Mimics subnet register command.
-    """
-    neuron_register_call = substrate.compose_call(
-        call_module="SubtensorModule",
-        call_function="burned_register",
-        call_params={
-            "netuid": netuid,
-            "hotkey": wallet.hotkey.ss58_address,
-        },
-    )
-    extrinsic = substrate.create_signed_extrinsic(
-        call=neuron_register_call, keypair=wallet.coldkey
-    )
-    response = substrate.submit_extrinsic(
-        extrinsic, wait_for_finalization=True, wait_for_inclusion=True
-    )
-    response.process_events()
-    return response.is_success
-
-
 async def wait_epoch(subtensor: "Subtensor", netuid: int = 1):
     """
     Waits for the next epoch to start on a specific subnet.


### PR DESCRIPTION
- Increases coverage of subtensor methods
- Revamps transfer tests
- Replaces raw chain calls with subtensor calls
- Replaces logging with print for better output in e2e test machines
- Pt 1 of the push to increase coverage 