### PR TITLE
BittensorConsole class

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -132,10 +132,10 @@ class AsyncSubtensor:
                     self.network = "custom"
             else:
                 logging.info(
-                    f"Network not specified or not valid. Using default chain endpoint: <blue>{NETWORK_MAP[DEFAULTS.subtensor.network]}</blue>."
+                    f"Network not specified or not valid. Using default chain endpoint: [blue]{NETWORK_MAP[DEFAULTS.subtensor.network]}[/blue]."
                 )
                 logging.info(
-                    "You can set this for commands with the <blue>--network</blue> flag, or by setting this in the config."
+                    "You can set this for commands with the [blue]--network[/blue] flag, or by setting this in the config."
                 )
                 self.chain_endpoint = NETWORK_MAP[DEFAULTS.subtensor.network]
                 self.network = DEFAULTS.subtensor.network
@@ -152,19 +152,19 @@ class AsyncSubtensor:
 
     async def __aenter__(self):
         logging.info(
-            f"<magenta>Connecting to Substrate:</magenta> <blue>{self}</blue><magenta>...</magenta>"
+            f"[magenta]Connecting to Substrate:[/magenta] [blue]{self}[/blue][magenta]...[/magenta]"
         )
         try:
             async with self.substrate:
                 return self
         except TimeoutException:
             logging.error(
-                f"<red>Error</red>: Timeout occurred connecting to substrate. Verify your chain and network settings: {self}"
+                f"[red]Error[/red]: Timeout occurred connecting to substrate. Verify your chain and network settings: {self}"
             )
             raise ConnectionError
         except (ConnectionRefusedError, ssl.SSLError) as error:
             logging.error(
-                f"<red>Error</red>: Connection refused when connecting to substrate. "
+                f"[red]Error[/red]: Connection refused when connecting to substrate. "
                 f"Verify your chain and network settings: {self}. Error: {error}"
             )
             raise ConnectionError
@@ -533,7 +533,7 @@ class AsyncSubtensor:
                 )
             except Exception as e:
                 logging.error(
-                    f":cross_mark: <red>Failed to get payment info: </red>{e}"
+                    f":cross_mark: [red]Failed to get payment info: [/red]{e}"
                 )
                 payment_info = {"partialFee": int(2e7)}  # assume  0.02 Tao
 
@@ -1408,7 +1408,7 @@ class AsyncSubtensor:
             `True` if registration was successful, otherwise `False`.
         """
         logging.info(
-            f"Registering on netuid <blue>0</blue> on network: <blue>{self.network}</blue>"
+            f"Registering on netuid [blue]0[/blue] on network: [blue]{self.network}[/blue]"
         )
 
         # Check current recycle amount
@@ -1431,7 +1431,7 @@ class AsyncSubtensor:
         # Check balance is sufficient
         if balance < current_recycle:
             logging.error(
-                f"<red>Insufficient balance {balance} to register neuron. Current recycle is {current_recycle} TAO</red>."
+                f"[red]Insufficient balance {balance} to register neuron. Current recycle is {current_recycle} TAO[/red]."
             )
             return False
 
@@ -1509,7 +1509,7 @@ class AsyncSubtensor:
         ) > await self.weights_rate_limit(netuid):
             try:
                 logging.info(
-                    f"Setting weights for subnet #<blue>{netuid}</blue>. Attempt <blue>{retries + 1} of {max_retries}</blue>."
+                    f"Setting weights for subnet #[blue]{netuid}[/blue]. Attempt [blue]{retries + 1} of {max_retries}[/blue]."
                 )
                 success, message = await set_weights_extrinsic(
                     subtensor=self,
@@ -1547,7 +1547,7 @@ class AsyncSubtensor:
         """
         netuids_ = np.array(netuids, dtype=np.int64)
         weights_ = np.array(weights, dtype=np.float32)
-        logging.info(f"Setting weights in network: <blue>{self.network}</blue>")
+        logging.info(f"Setting weights in network: [blue]{self.network}[/blue]")
         # Run the set weights operation.
         return await set_root_weights_extrinsic(
             subtensor=self,

--- a/bittensor/core/extrinsics/async_registration.py
+++ b/bittensor/core/extrinsics/async_registration.py
@@ -224,13 +224,13 @@ async def register_extrinsic(
                     # Look error here
                     # https://github.com/opentensor/subtensor/blob/development/pallets/subtensor/src/errors.rs
 
-                        if "HotKeyAlreadyRegisteredInSubNet" in err_msg:
-                            logging.info(
-                                f":white_heavy_check_mark: [green]Already Registered on subnet:[/green] [blue]{netuid}[/blue]."
-                            )
-                            return True
-                        logging.error(f":cross_mark: [red]Failed[/red]: {err_msg}")
-                        await asyncio.sleep(0.5)
+                    if "HotKeyAlreadyRegisteredInSubNet" in err_msg:
+                        logging.info(
+                            f":white_heavy_check_mark: [green]Already Registered on subnet:[/green] [blue]{netuid}[/blue]."
+                        )
+                        return True
+                    logging.error(f":cross_mark: [red]Failed[/red]: {err_msg}")
+                    await asyncio.sleep(0.5)
 
                 # Successful registration, final check for neuron and pubkey
                 if success:

--- a/bittensor/core/extrinsics/async_registration.py
+++ b/bittensor/core/extrinsics/async_registration.py
@@ -74,12 +74,12 @@ async def register_extrinsic(
     logging.debug("Checking subnet status")
     if not await subtensor.subnet_exists(netuid):
         logging.error(
-            f":cross_mark: <red>Failed error:</red> subnet <blue>{netuid}</blue> does not exist."
+            f":cross_mark: [red]Failed error:[/red] subnet [blue]{netuid}[/blue] does not exist."
         )
         return False
 
     logging.info(
-        f":satellite: <magenta>Checking Account on subnet</magenta> <blue>{netuid}</blue> <magenta>...</magenta>"
+        f":satellite: [magenta]Checking Account on subnet[/magenta] [blue]{netuid}[/blue] [magenta]...[/magenta]"
     )
     neuron = await subtensor.get_neuron_for_pubkey_and_subnet(
         hotkey_ss58=wallet.hotkey.ss58_address,
@@ -87,7 +87,7 @@ async def register_extrinsic(
     )
     if not neuron.is_null:
         logging.debug(
-            f"Wallet <green>{wallet}</green> is already registered on subnet <blue>{neuron.netuid}</blue> with uid<blue>{neuron.uid}</blue>."
+            f"Wallet [green]{wallet}[/green] is already registered on subnet [blue]{neuron.netuid}[/blue] with uid[blue]{neuron.uid}[/blue]."
         )
         return True
 
@@ -100,7 +100,7 @@ async def register_extrinsic(
     pow_result: Optional["POWSolution"]
     while True:
         logging.info(
-            f":satellite: <magenta>Registering...</magenta> <blue>({attempts}/{max_allowed_attempts})</blue>"
+            f":satellite: [magenta]Registering...[/magenta] [blue]({attempts}/{max_allowed_attempts})[/blue]"
         )
         # Solve latest POW.
         if cuda:
@@ -138,13 +138,13 @@ async def register_extrinsic(
             )
             if is_registered:
                 logging.error(
-                    f":white_heavy_check_mark: <green>Already registered on netuid:</green> <blue>{netuid}</blue>"
+                    f":white_heavy_check_mark: [green]Already registered on netuid:[/green] [blue]{netuid}[/blue]"
                 )
                 return True
 
         # pow successful, proceed to submit pow to chain for registration
         else:
-            logging.info(":satellite: <magenta>Submitting POW...</magenta>")
+            logging.info(":satellite: [magenta]Submitting POW...[/magenta]")
             # check if pow result is still valid
             while not await pow_result.is_stale_async(subtensor=subtensor):
                 call = await subtensor.substrate.compose_call(
@@ -185,10 +185,10 @@ async def register_extrinsic(
 
                         if "HotKeyAlreadyRegisteredInSubNet" in err_msg:
                             logging.info(
-                                f":white_heavy_check_mark: <green>Already Registered on subnet:</green> <blue>{netuid}</blue>."
+                                f":white_heavy_check_mark: [green]Already Registered on subnet:[/green] [blue]{netuid}[/blue]."
                             )
                             return True
-                        logging.error(f":cross_mark: <red>Failed</red>: {err_msg}")
+                        logging.error(f":cross_mark: [red]Failed[/red]: {err_msg}")
                         await asyncio.sleep(0.5)
 
                 # Successful registration, final check for neuron and pubkey
@@ -199,18 +199,18 @@ async def register_extrinsic(
                     )
                     if is_registered:
                         logging.success(
-                            ":white_heavy_check_mark: <green>Registered</green>"
+                            ":white_heavy_check_mark: [green]Registered[/green]"
                         )
                         return True
                     else:
                         # neuron not found, try again
                         logging.error(
-                            ":cross_mark: <red>Unknown error. Neuron not found.</red>"
+                            ":cross_mark: [red]Unknown error. Neuron not found.[/red]"
                         )
                         continue
             else:
                 # Exited loop because pow is no longer valid.
-                logging.error("<red>POW is stale.</red>")
+                logging.error("[red]POW is stale.[/red]")
                 # Try again.
                 continue
 
@@ -218,11 +218,11 @@ async def register_extrinsic(
             # Failed registration, retry pow
             attempts += 1
             logging.error(
-                f":satellite: <magenta>Failed registration, retrying pow ...</magenta> <blue>({attempts}/{max_allowed_attempts})</blue>"
+                f":satellite: [magenta]Failed registration, retrying pow ...[/magenta] [blue]({attempts}/{max_allowed_attempts})[/blue]"
             )
         else:
             # Failed to register after max attempts.
-            logging.error("<red>No more attempts.</red>")
+            logging.error("[red]No more attempts.[/red]")
             return False
 
 
@@ -331,7 +331,7 @@ async def run_faucet_extrinsic(
             await response.process_events()
             if not await response.is_success:
                 logging.error(
-                    f":cross_mark: <red>Failed</red>: {format_error_message(error_message=await response.error_message, substrate=subtensor.substrate)}"
+                    f":cross_mark: [red]Failed[/red]: {format_error_message(error_message=await response.error_message, substrate=subtensor.substrate)}"
                 )
                 if attempts == max_allowed_attempts:
                     raise MaxAttemptsException
@@ -345,7 +345,7 @@ async def run_faucet_extrinsic(
                     wallet.coldkeypub.ss58_address
                 )
                 logging.info(
-                    f"Balance: <blue>{old_balance[wallet.coldkeypub.ss58_address]}</blue> :arrow_right: <green>{new_balance[wallet.coldkeypub.ss58_address]}</green>"
+                    f"Balance: [blue]{old_balance[wallet.coldkeypub.ss58_address]}[/blue] :arrow_right: [green]{new_balance[wallet.coldkeypub.ss58_address]}[/green]"
                 )
                 old_balance = new_balance
 

--- a/bittensor/core/extrinsics/async_root.py
+++ b/bittensor/core/extrinsics/async_root.py
@@ -67,18 +67,18 @@ async def root_register_extrinsic(
         return False
 
     logging.debug(
-        f"Checking if hotkey (<blue>{wallet.hotkey_str}</blue>) is registered on root."
+        f"Checking if hotkey ([blue]{wallet.hotkey_str}[/blue]) is registered on root."
     )
     is_registered = await subtensor.is_hotkey_registered(
         netuid=netuid, hotkey_ss58=wallet.hotkey.ss58_address
     )
     if is_registered:
         logging.error(
-            ":white_heavy_check_mark: <green>Already registered on root network.</green>"
+            ":white_heavy_check_mark: [green]Already registered on root network.[/green]"
         )
         return True
 
-    logging.info(":satellite: <magenta>Registering to root network...</magenta>")
+    logging.info(":satellite: [magenta]Registering to root network...[/magenta]")
     call = await subtensor.substrate.compose_call(
         call_module="SubtensorModule",
         call_function="root_register",
@@ -92,7 +92,7 @@ async def root_register_extrinsic(
     )
 
     if not success:
-        logging.error(f":cross_mark: <red>Failed error:</red> {err_msg}")
+        logging.error(f":cross_mark: [red]Failed error:[/red] {err_msg}")
         time.sleep(0.5)
         return False
 
@@ -105,12 +105,12 @@ async def root_register_extrinsic(
         )
         if uid is not None:
             logging.info(
-                f":white_heavy_check_mark: <green>Registered with UID</green> <blue>{uid}</blue>."
+                f":white_heavy_check_mark: [green]Registered with UID[/green] [blue]{uid}[/blue]."
             )
             return True
         else:
             # neuron not found, try again
-            logging.error(":cross_mark: <red>Unknown error. Neuron not found.</red>")
+            logging.error(":cross_mark: [red]Unknown error. Neuron not found.[/red]")
             return False
 
 
@@ -234,11 +234,11 @@ async def set_root_weights_extrinsic(
     logging.info("Normalizing weights")
     formatted_weights = normalize_max_weight(x=weights, limit=max_weight_limit)
     logging.info(
-        f"Raw weights -> Normalized weights: <blue>{weights}</blue> -> <green>{formatted_weights}</green>"
+        f"Raw weights -> Normalized weights: [blue]{weights}[/blue] -> [green]{formatted_weights}[/green]"
     )
 
     try:
-        logging.info(":satellite: <magenta>Setting root weights...<magenta>")
+        logging.info(":satellite: [magenta]Setting root weights...[magenta]")
         weight_uids, weight_vals = convert_weights_and_uids_for_emit(netuids, weights)
 
         success, error_message = await _do_set_root_weights(
@@ -255,14 +255,14 @@ async def set_root_weights_extrinsic(
             return True
 
         if success is True:
-            logging.info(":white_heavy_check_mark: <green>Finalized</green>")
+            logging.info(":white_heavy_check_mark: [green]Finalized[/green]")
             return True
         else:
             fmt_err = error_message
-            logging.error(f":cross_mark: <red>Failed error:</red> {fmt_err}")
+            logging.error(f":cross_mark: [red]Failed error:[/red] {fmt_err}")
             return False
 
     except SubstrateRequestException as e:
         fmt_err = format_error_message(e, subtensor.substrate)
-        logging.error(f":cross_mark: <red>Failed error:</red> {fmt_err}")
+        logging.error(f":cross_mark: [red]Failed error:[/red] {fmt_err}")
         return False

--- a/bittensor/core/extrinsics/async_transfer.py
+++ b/bittensor/core/extrinsics/async_transfer.py
@@ -98,7 +98,7 @@ async def transfer_extrinsic(
     # Validate destination address.
     if not is_valid_bittensor_address_or_public_key(destination):
         logging.error(
-            f":cross_mark: <red>Invalid destination SS58 address</red>: {destination}"
+            f":cross_mark: [red]Invalid destination SS58 address[/red]: {destination}"
         )
         return False
     logging.info(f"Initiating transfer on network: {subtensor.network}")
@@ -109,7 +109,7 @@ async def transfer_extrinsic(
 
     # Check balance.
     logging.info(
-        f":satellite: <magenta>Checking balance and fees on chain </magenta> <blue>{subtensor.network}</blue>"
+        f":satellite: [magenta]Checking balance and fees on chain [/magenta] [blue]{subtensor.network}[/blue]"
     )
     # check existential deposit and fee
     logging.debug("Fetching existential and fee")
@@ -135,13 +135,13 @@ async def transfer_extrinsic(
             return False
 
     if account_balance < (amount + fee + existential_deposit):
-        logging.error(":cross_mark: <red>Not enough balance</red>")
-        logging.error(f"\t\tBalance:\t<blue>{account_balance}</blue>")
-        logging.error(f"\t\tAmount:\t<blue>{amount}</blue>")
-        logging.error(f"\t\tFor fee:\t<blue>{fee}</blue>")
+        logging.error(":cross_mark: [red]Not enough balance[/red]")
+        logging.error(f"\t\tBalance:\t[blue]{account_balance}[/blue]")
+        logging.error(f"\t\tAmount:\t[blue]{amount}[/blue]")
+        logging.error(f"\t\tFor fee:\t[blue]{fee}[/blue]")
         return False
 
-    logging.info(":satellite: <magenta>Transferring...</magenta")
+    logging.info(":satellite: [magenta]Transferring...</magenta")
     success, block_hash, err_msg = await _do_transfer(
         subtensor=subtensor,
         wallet=wallet,
@@ -152,8 +152,8 @@ async def transfer_extrinsic(
     )
 
     if success:
-        logging.success(":white_heavy_check_mark: [green]Finalized</green>")
-        logging.info(f"[green]Block Hash:</green> <blue>{block_hash}</blue>")
+        logging.success(":white_heavy_check_mark: [green]Finalized[/green]")
+        logging.info(f"[green]Block Hash:[/green] [blue]{block_hash}[/blue]")
 
         if subtensor.network == "finney":
             logging.debug("Fetching explorer URLs")
@@ -162,18 +162,18 @@ async def transfer_extrinsic(
             )
             if explorer_urls != {} and explorer_urls:
                 logging.info(
-                    f"[green]Opentensor Explorer Link: {explorer_urls.get('opentensor')}</green>"
+                    f"[green]Opentensor Explorer Link: {explorer_urls.get('opentensor')}[/green]"
                 )
                 logging.info(
-                    f"[green]Taostats Explorer Link: {explorer_urls.get('taostats')}</green>"
+                    f"[green]Taostats Explorer Link: {explorer_urls.get('taostats')}[/green]"
                 )
 
-        logging.info(":satellite: <magenta>Checking Balance...<magenta>")
+        logging.info(":satellite: [magenta]Checking Balance...[magenta]")
         new_balance = await subtensor.get_balance(wallet.coldkeypub.ss58_address)
         logging.info(
-            f"Balance: [blue]{account_balance}</blue> :arrow_right: [green]{new_balance[wallet.coldkeypub.ss58_address]}</green>"
+            f"Balance: [blue]{account_balance}[/blue] :arrow_right: [green]{new_balance[wallet.coldkeypub.ss58_address]}[/green]"
         )
         return True
     else:
-        logging.error(f":cross_mark: <red>Failed</red>: {err_msg}")
+        logging.error(f":cross_mark: [red]Failed[/red]: {err_msg}")
         return False

--- a/bittensor/core/extrinsics/async_weights.py
+++ b/bittensor/core/extrinsics/async_weights.py
@@ -125,7 +125,7 @@ async def set_weights_extrinsic(
     )
 
     logging.info(
-        ":satellite: <magenta>Setting weights on </magenta><blue>{subtensor.network}</blue> <magenta>...</magenta>"
+        ":satellite: [magenta]Setting weights on [/magenta][blue]{subtensor.network}[/blue] [magenta]...[/magenta]"
     )
     try:
         success, error_message = await _do_set_weights(
@@ -144,14 +144,14 @@ async def set_weights_extrinsic(
 
         if success is True:
             message = "Successfully set weights and Finalized."
-            logging.success(f":white_heavy_check_mark: <green>{message}</green>")
+            logging.success(f":white_heavy_check_mark: [green]{message}[/green]")
             return True, message
         else:
-            logging.error(f"<red>Failed</red> set weights. Error: {error_message}")
+            logging.error(f"[red]Failed[/red] set weights. Error: {error_message}")
             return False, error_message
 
     except Exception as error:
-        logging.error(f":cross_mark: <red>Failed</red> set weights. Error: {error}")
+        logging.error(f":cross_mark: [red]Failed[/red] set weights. Error: {error}")
         return False, str(error)
 
 

--- a/bittensor/core/extrinsics/registration.py
+++ b/bittensor/core/extrinsics/registration.py
@@ -127,24 +127,24 @@ def register_extrinsic(
     """
     if not subtensor.subnet_exists(netuid):
         logging.error(
-            f":cross_mark: <red>Failed: </red> Subnet <blue>{netuid}</blue> does not exist."
+            f":cross_mark: [red]Failed: [/red] Subnet [blue]{netuid}[/blue] does not exist."
         )
         return False
 
     logging.info(
-        f":satellite: <magenta>Checking Account on subnet</magenta> <blue>{netuid}</blue><magenta>...</magenta>"
+        f":satellite: [magenta]Checking Account on subnet[/magenta] [blue]{netuid}[/blue][magenta]...[/magenta]"
     )
     neuron = subtensor.get_neuron_for_pubkey_and_subnet(
         wallet.hotkey.ss58_address, netuid=netuid
     )
     if not neuron.is_null:
         logging.debug(
-            f"Wallet <green>{wallet}</green> is already registered on <blue>{neuron.netuid}</blue> with <blue>{neuron.uid}</blue>."
+            f"Wallet [green]{wallet}[/green] is already registered on [blue]{neuron.netuid}[/blue] with [blue]{neuron.uid}[/blue]."
         )
         return True
 
     logging.debug(
-        f"Registration hotkey: <blue>{wallet.hotkey.ss58_address}</blue>, <green>Public</green> coldkey: <blue>{wallet.coldkey.ss58_address}</blue> in the network: <blue>{subtensor.network}</blue>."
+        f"Registration hotkey: [blue]{wallet.hotkey.ss58_address}[/blue], [green]Public[/green] coldkey: [blue]{wallet.coldkey.ss58_address}[/blue] in the network: [blue]{subtensor.network}[/blue]."
     )
 
     if not torch:
@@ -155,7 +155,7 @@ def register_extrinsic(
     attempts = 1
     while True:
         logging.info(
-            f":satellite: <magenta>Registering...</magenta> <blue>({attempts}/{max_allowed_attempts})</blue>"
+            f":satellite: [magenta]Registering...[/magenta] [blue]({attempts}/{max_allowed_attempts})[/blue]"
         )
         # Solve latest POW.
         if cuda:
@@ -193,13 +193,13 @@ def register_extrinsic(
             )
             if is_registered:
                 logging.info(
-                    f":white_heavy_check_mark: <green>Already registered on netuid:</green> <blue>{netuid}</blue>."
+                    f":white_heavy_check_mark: [green]Already registered on netuid:[/green] [blue]{netuid}[/blue]."
                 )
                 return True
 
         # pow successful, proceed to submit pow to chain for registration
         else:
-            logging.info(":satellite: <magenta>Submitting POW...</magenta>")
+            logging.info(":satellite: [magenta]Submitting POW...[/magenta]")
             # check if pow result is still valid
             while not pow_result.is_stale(subtensor=subtensor):
                 result: tuple[bool, Optional[str]] = _do_pow_register(
@@ -217,34 +217,34 @@ def register_extrinsic(
                     # https://github.com/opentensor/subtensor/blob/development/pallets/subtensor/src/errors.rs
                     if "HotKeyAlreadyRegisteredInSubNet" in err_msg:
                         logging.info(
-                            f":white_heavy_check_mark: <green>Already Registered on subnet </green><blue>{netuid}</blue>."
+                            f":white_heavy_check_mark: [green]Already Registered on subnet [/green][blue]{netuid}[/blue]."
                         )
                         return True
 
-                    logging.error(f":cross_mark: <red>Failed:</red> {err_msg}")
+                    logging.error(f":cross_mark: [red]Failed:[/red] {err_msg}")
                     time.sleep(0.5)
 
                 # Successful registration, final check for neuron and pubkey
                 else:
-                    logging.info(":satellite: <magenta>Checking Balance...</magenta>")
+                    logging.info(":satellite: [magenta]Checking Balance...[/magenta]")
                     is_registered = subtensor.is_hotkey_registered(
                         hotkey_ss58=wallet.hotkey.ss58_address,
                         netuid=netuid,
                     )
                     if is_registered:
                         logging.info(
-                            ":white_heavy_check_mark: <green>Registered</green>"
+                            ":white_heavy_check_mark: [green]Registered[/green]"
                         )
                         return True
                     else:
                         # neuron not found, try again
                         logging.error(
-                            ":cross_mark: <red>Unknown error. Neuron not found.</red>"
+                            ":cross_mark: [red]Unknown error. Neuron not found.[/red]"
                         )
                         continue
             else:
                 # Exited loop because pow is no longer valid.
-                logging.error("<red>POW is stale.</red>")
+                logging.error("[red]POW is stale.[/red]")
                 # Try again.
                 continue
 
@@ -252,11 +252,11 @@ def register_extrinsic(
             # Failed registration, retry pow
             attempts += 1
             logging.info(
-                f":satellite: <magenta>Failed registration, retrying pow ...</magenta> <blue>({attempts}/{max_allowed_attempts})</blue>"
+                f":satellite: [magenta]Failed registration, retrying pow ...[/magenta] [blue]({attempts}/{max_allowed_attempts})[/blue]"
             )
         else:
             # Failed to register after max attempts.
-            logging.error("<red>No more attempts.</red>")
+            logging.error("[red]No more attempts.[/red]")
             return False
 
 
@@ -339,7 +339,7 @@ def burned_register_extrinsic(
     """
     if not subtensor.subnet_exists(netuid):
         logging.error(
-            f":cross_mark: <red>Failed error:</red> subnet <blue>{netuid}</blue> does not exist."
+            f":cross_mark: [red]Failed error:[/red] subnet [blue]{netuid}[/blue] does not exist."
         )
         return False
 
@@ -348,7 +348,7 @@ def burned_register_extrinsic(
         return False
 
     logging.info(
-        f":satellite: <magenta>Checking Account on subnet</magenta> <blue>{netuid}</blue><magenta> ...</magenta>"
+        f":satellite: [magenta]Checking Account on subnet[/magenta] [blue]{netuid}[/blue][magenta] ...[/magenta]"
     )
     neuron = subtensor.get_neuron_for_pubkey_and_subnet(
         wallet.hotkey.ss58_address, netuid=netuid
@@ -357,14 +357,14 @@ def burned_register_extrinsic(
     old_balance = subtensor.get_balance(wallet.coldkeypub.ss58_address)
 
     if not neuron.is_null:
-        logging.info(":white_heavy_check_mark: <green>Already Registered</green>")
-        logging.info(f"\t\tuid: <blue>{neuron.uid}</blue>")
-        logging.info(f"\t\tnetuid: <blue>{neuron.netuid}</blue>")
-        logging.info(f"\t\thotkey: <blue>{neuron.hotkey}</blue>")
-        logging.info(f"\t\tcoldkey: <blue>{neuron.coldkey}</blue>")
+        logging.info(":white_heavy_check_mark: [green]Already Registered[/green]")
+        logging.info(f"\t\tuid: [blue]{neuron.uid}[/blue]")
+        logging.info(f"\t\tnetuid: [blue]{neuron.netuid}[/blue]")
+        logging.info(f"\t\thotkey: [blue]{neuron.hotkey}[/blue]")
+        logging.info(f"\t\tcoldkey: [blue]{neuron.coldkey}[/blue]")
         return True
 
-    logging.info(":satellite: <magenta>Recycling TAO for Registration...</magenta>")
+    logging.info(":satellite: [magenta]Recycling TAO for Registration...[/magenta]")
 
     recycle_amount = subtensor.recycle(netuid=netuid)
     logging.info(f"Recycling {recycle_amount} to register on subnet:{netuid}")
@@ -378,25 +378,25 @@ def burned_register_extrinsic(
     )
 
     if not success:
-        logging.error(f":cross_mark: <red>Failed error:</red> {err_msg}")
+        logging.error(f":cross_mark: [red]Failed error:[/red] {err_msg}")
         time.sleep(0.5)
         return False
     # Successful registration, final check for neuron and pubkey
     else:
-        logging.info(":satellite: <magenta>Checking Balance...</magenta>")
+        logging.info(":satellite: [magenta]Checking Balance...[/magenta]")
         block = subtensor.get_current_block()
         new_balance = subtensor.get_balance(wallet.coldkeypub.ss58_address, block=block)
 
         logging.info(
-            f"Balance: <blue>{old_balance}</blue> :arrow_right: <green>{new_balance}</green>"
+            f"Balance: [blue]{old_balance}[/blue] :arrow_right: [green]{new_balance}[/green]"
         )
         is_registered = subtensor.is_hotkey_registered(
             netuid=netuid, hotkey_ss58=wallet.hotkey.ss58_address
         )
         if is_registered:
-            logging.info(":white_heavy_check_mark: <green>Registered</green>")
+            logging.info(":white_heavy_check_mark: [green]Registered[/green]")
             return True
         else:
             # neuron not found, try again
-            logging.error(":cross_mark: <red>Unknown error. Neuron not found.</red>")
+            logging.error(":cross_mark: [red]Unknown error. Neuron not found.[/red]")
             return False

--- a/bittensor/core/extrinsics/root.py
+++ b/bittensor/core/extrinsics/root.py
@@ -79,11 +79,11 @@ def root_register_extrinsic(
     )
     if is_registered:
         logging.info(
-            ":white_heavy_check_mark: <green>Already registered on root network.</green>"
+            ":white_heavy_check_mark: [green]Already registered on root network.[/green]"
         )
         return True
 
-    logging.info(":satellite: <magenta>Registering to root network...</magenta>")
+    logging.info(":satellite: [magenta]Registering to root network...[/magenta]")
     success, err_msg = _do_root_register(
         wallet=wallet,
         wait_for_inclusion=wait_for_inclusion,
@@ -91,7 +91,7 @@ def root_register_extrinsic(
     )
 
     if not success:
-        logging.error(f":cross_mark: <red>Failed</red>: {err_msg}")
+        logging.error(f":cross_mark: [red]Failed[/red]: {err_msg}")
         time.sleep(0.5)
 
     # Successful registration, final check for neuron and pubkey
@@ -100,11 +100,11 @@ def root_register_extrinsic(
             netuid=0, hotkey_ss58=wallet.hotkey.ss58_address
         )
         if is_registered:
-            logging.success(":white_heavy_check_mark: <green>Registered</green>")
+            logging.success(":white_heavy_check_mark: [green]Registered[/green]")
             return True
         else:
             # neuron not found, try again
-            logging.error(":cross_mark: <red>Unknown error. Neuron not found.</red>")
+            logging.error(":cross_mark: [red]Unknown error. Neuron not found.[/red]")
 
 
 @ensure_connected
@@ -224,11 +224,11 @@ def set_root_weights_extrinsic(
         x=weights, limit=max_weight_limit
     )
     logging.info(
-        f"Raw Weights -> Normalized weights: <blue>{weights}</blue> -> <green>{formatted_weights}</green>"
+        f"Raw Weights -> Normalized weights: [blue]{weights}[/blue] -> [green]{formatted_weights}[/green]"
     )
 
     logging.info(
-        f":satellite: <magenta>Setting root weights on</magenta> <blue>{subtensor.network}</blue> <magenta>...</magenta>"
+        f":satellite: [magenta]Setting root weights on[/magenta] [blue]{subtensor.network}[/blue] [magenta]...[/magenta]"
     )
     try:
         weight_uids, weight_vals = weight_utils.convert_weights_and_uids_for_emit(
@@ -248,15 +248,15 @@ def set_root_weights_extrinsic(
             return True
 
         if success is True:
-            logging.info(":white_heavy_check_mark: <green>Finalized</green>")
+            logging.info(":white_heavy_check_mark: [green]Finalized[/green]")
             logging.success(f"Set weights {str(success)}")
             return True
         else:
             logging.error(
-                f":cross_mark: <red>Failed </red> set weights. {str(error_message)}"
+                f":cross_mark: [red]Failed [/red] set weights. {str(error_message)}"
             )
             return False
 
     except Exception as e:
-        logging.error(f":cross_mark: <red>Failed </red> set weights. {str(e)}")
+        logging.error(f":cross_mark: [red]Failed [/red] set weights. {str(e)}")
         return False

--- a/bittensor/core/extrinsics/serving.py
+++ b/bittensor/core/extrinsics/serving.py
@@ -205,7 +205,7 @@ def serve_axon_extrinsic(
         try:
             external_ip = net.get_external_ip()
             logging.success(
-                f":white_heavy_check_mark: <green>Found external ip:</green> <blue>{external_ip}</blue>"
+                f":white_heavy_check_mark: [green]Found external ip:[/green] [blue]{external_ip}[/blue]"
             )
         except Exception as e:
             raise RuntimeError(

--- a/bittensor/core/extrinsics/set_weights.py
+++ b/bittensor/core/extrinsics/set_weights.py
@@ -145,7 +145,7 @@ def set_weights_extrinsic(
     )
 
     logging.info(
-        f":satellite: <magenta>Setting weights on </magenta><blue>{subtensor.network}<blue> <magenta>...</magenta>"
+        f":satellite: [magenta]Setting weights on [/magenta][blue]{subtensor.network}[blue] [magenta]...[/magenta]"
     )
     logging.debug(f"Weights: {[float(v / 65535) for v in weight_vals]}")
 
@@ -165,13 +165,13 @@ def set_weights_extrinsic(
             return True, "Not waiting for finalization or inclusion."
 
         if success is True:
-            logging.success(f"<green>Finalized!</green> Set weights: {str(success)}")
+            logging.success(f"[green]Finalized![/green] Set weights: {str(success)}")
             return True, "Successfully set weights and Finalized."
         else:
             logging.error(error_message)
             return False, error_message
 
     except Exception as e:
-        logging.error(f":cross_mark: <red>Failed.</red>: Error: {e}")
+        logging.error(f":cross_mark: [red]Failed.[/red]: Error: {e}")
         logging.debug(str(e))
         return False, str(e)

--- a/bittensor/core/extrinsics/transfer.py
+++ b/bittensor/core/extrinsics/transfer.py
@@ -114,7 +114,7 @@ def transfer_extrinsic(
     """
     # Validate destination address.
     if not is_valid_bittensor_address_or_public_key(dest):
-        logging.error(f"<red>Invalid destination address: {dest}</red>")
+        logging.error(f"[red]Invalid destination address: {dest}[/red]")
         return False
 
     if isinstance(dest, bytes):
@@ -132,12 +132,12 @@ def transfer_extrinsic(
         transfer_balance = amount
 
     # Check balance.
-    logging.info(":satellite: <magenta>Checking Balance...</magenta>")
+    logging.info(":satellite: [magenta]Checking Balance...[/magenta]")
     account_balance = subtensor.get_balance(wallet.coldkey.ss58_address)
     # check existential deposit.
     existential_deposit = subtensor.get_existential_deposit()
 
-    logging.info(":satellite: <magenta>Transferring...</magenta>")
+    logging.info(":satellite: [magenta]Transferring...[/magenta]")
     fee = subtensor.get_transfer_fee(
         wallet=wallet, dest=dest, value=transfer_balance.rao
     )
@@ -148,17 +148,17 @@ def transfer_extrinsic(
 
     # Check if we have enough balance.
     if account_balance < (transfer_balance + fee + existential_deposit):
-        logging.error(":cross_mark: <red>Not enough balance</red>:")
-        logging.info(f"\t\tBalance: \t<blue>{account_balance}</blue>")
-        logging.info(f"\t\tAmount: \t<blue>{transfer_balance}</blue>")
-        logging.info(f"\t\tFor fee: \t<blue>{fee}</blue>")
+        logging.error(":cross_mark: [red]Not enough balance[/red]:")
+        logging.info(f"\t\tBalance: \t[blue]{account_balance}[/blue]")
+        logging.info(f"\t\tAmount: \t[blue]{transfer_balance}[/blue]")
+        logging.info(f"\t\tFor fee: \t[blue]{fee}[/blue]")
         return False
 
-    logging.info(":satellite: <magenta>Transferring...</magenta>")
-    logging.info(f"\tAmount: <blue>{transfer_balance}</blue>")
-    logging.info(f"\tfrom: <blue>{wallet.name}:{wallet.coldkey.ss58_address}</blue>")
-    logging.info(f"\tTo: <blue>{dest}</blue>")
-    logging.info(f"\tFor fee: <blue>{fee}</blue>")
+    logging.info(":satellite: [magenta]Transferring...[/magenta]")
+    logging.info(f"\tAmount: [blue]{transfer_balance}[/blue]")
+    logging.info(f"\tfrom: [blue]{wallet.name}:{wallet.coldkey.ss58_address}[/blue]")
+    logging.info(f"\tTo: [blue]{dest}[/blue]")
+    logging.info(f"\tFor fee: [blue]{fee}[/blue]")
 
     success, block_hash, error_message = do_transfer(
         self=subtensor,
@@ -170,29 +170,29 @@ def transfer_extrinsic(
     )
 
     if success:
-        logging.success(":white_heavy_check_mark: <green>Finalized</green>")
-        logging.info(f"<green>Block Hash:</green> <blue>{block_hash}</blue>")
+        logging.success(":white_heavy_check_mark: [green]Finalized[/green]")
+        logging.info(f"[green]Block Hash:[/green] [blue]{block_hash}[/blue]")
 
         explorer_urls = get_explorer_url_for_network(
             subtensor.network, block_hash, NETWORK_EXPLORER_MAP
         )
         if explorer_urls != {} and explorer_urls:
             logging.info(
-                f"<green>Opentensor Explorer Link: {explorer_urls.get('opentensor')}</green>"
+                f"[green]Opentensor Explorer Link: {explorer_urls.get('opentensor')}[/green]"
             )
             logging.info(
-                f"<green>Taostats Explorer Link: {explorer_urls.get('taostats')}</green>"
+                f"[green]Taostats Explorer Link: {explorer_urls.get('taostats')}[/green]"
             )
     else:
         logging.error(
-            f":cross_mark: <red>Failed</red>: {format_error_message(error_message, substrate=subtensor.substrate)}"
+            f":cross_mark: [red]Failed[/red]: {format_error_message(error_message, substrate=subtensor.substrate)}"
         )
 
     if success:
-        logging.info(":satellite: <magenta>Checking Balance...</magenta>")
+        logging.info(":satellite: [magenta]Checking Balance...[/magenta]")
         new_balance = subtensor.get_balance(wallet.coldkey.ss58_address)
         logging.success(
-            f"Balance: <blue>{account_balance}</blue> :arrow_right: <green>{new_balance}</green>"
+            f"Balance: [blue]{account_balance}[/blue] :arrow_right: [green]{new_balance}[/green]"
         )
         return True
 

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1655,7 +1655,7 @@ class Subtensor:
                     call=call, keypair=wallet.coldkeypub
                 )
             except Exception as e:
-                logging.error(f"<red>Failed to get payment info.</red> {e}")
+                logging.error(f"[red]Failed to get payment info.[/red] {e}")
                 payment_info = {"partialFee": int(2e7)}  # assume  0.02 Tao
 
             fee = Balance.from_rao(payment_info["partialFee"])

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -216,7 +216,7 @@ def format_error_message(
                         err_description = err_docs[0] if err_docs else err_description
                     except (AttributeError, IndexError):
                         logging.error(
-                            "<red>Substrate pallets data unavailable. This is usually caused by an uninitialized substrate.</red>"
+                            "[red]Substrate pallets data unavailable. This is usually caused by an uninitialized substrate.[/red]"
                         )
             else:
                 err_description = err_data

--- a/bittensor/utils/balance.py
+++ b/bittensor/utils/balance.py
@@ -72,13 +72,13 @@ class Balance:
 
     def __rich__(self):
         int_tao, fract_tao = format(float(self.tao), "f").split(".")
-        return f"<green>{self.unit}{int_tao}.{fract_tao}</green>"
+        return f"[green]{self.unit}{int_tao}.{fract_tao}[/green]"
 
     def __str_rao__(self):
         return f"{self.rao_unit}{int(self.rao)}"
 
     def __rich_rao__(self):
-        return f"<green>{self.rao_unit}{int(self.rao)}</green>"
+        return f"[green]{self.rao_unit}{int(self.rao)}[/green]"
 
     def __repr__(self):
         return self.__str__()

--- a/bittensor/utils/btlogging/console.py
+++ b/bittensor/utils/btlogging/console.py
@@ -1,0 +1,72 @@
+"""
+BittensorConsole class gives the ability to log messages to the terminal without changing Bittensor logging level.
+
+Example:
+    from bittensor import logging
+
+    # will be logged
+    logging.console.info("info message")
+    logging.console.error("error message")
+    logging.console.success("success message")
+    logging.console.warning("warning message")
+    logging.console.critical("critical message")
+
+    # will not be logged
+    logging.info("test info")
+"""
+
+from typing import Callable, TYPE_CHECKING
+from functools import wraps
+from .helpers import all_loggers
+
+if TYPE_CHECKING:
+    from .loggingmachine import LoggingMachine
+
+
+def _print_wrapper(func: "Callable"):
+    @wraps(func)
+    def wrapper(self: "BittensorConsole", *args, **kwargs):
+        """A wrapper function to temporarily set the logger level to debug."""
+        old_logger_level = self.logger.get_level()
+        self.logger.set_console()
+        func(self, *args, **kwargs)
+
+        for logger in all_loggers():
+            logger.setLevel(old_logger_level)
+
+    return wrapper
+
+
+class BittensorConsole:
+    def __init__(self, logger: "LoggingMachine"):
+        self.logger = logger
+
+    @_print_wrapper
+    def debug(self, message: str):
+        """Logs a DEBUG message to the console."""
+        self.logger.debug(message)
+
+    @_print_wrapper
+    def info(self, message: str):
+        """Logs a INFO message to the console."""
+        self.logger.info(message)
+
+    @_print_wrapper
+    def success(self, message: str):
+        """Logs a SUCCESS message to the console."""
+        self.logger.success(message)
+
+    @_print_wrapper
+    def warning(self, message: str):
+        """Logs a WARNING message to the console."""
+        self.logger.warning(message)
+
+    @_print_wrapper
+    def error(self, message: str):
+        """Logs a ERROR message to the console."""
+        self.logger.error(message)
+
+    @_print_wrapper
+    def critical(self, message: str):
+        """Logs a CRITICAL message to the console."""
+        self.logger.critical(message)

--- a/bittensor/utils/btlogging/format.py
+++ b/bittensor/utils/btlogging/format.py
@@ -68,6 +68,8 @@ color_map: dict[str, str] = {
     "</green>": Style.RESET_ALL,
     "<magenta>": Fore.MAGENTA,
     "</magenta>": Style.RESET_ALL,
+    "<yellow>": Fore.YELLOW,
+    "</yellow>": Style.RESET_ALL,
 }
 
 
@@ -91,7 +93,6 @@ LOG_FORMATS: dict[int, str] = {
 LOG_TRACE_FORMATS: dict[int, str] = {
     level: f"{Fore.BLUE}%(asctime)s{Fore.RESET}"
     f" | {Style.BRIGHT}{color}%(levelname)s{Fore.RESET}{Back.RESET}{Style.RESET_ALL}"
-    f" | %(name)s:%(filename)s:%(lineno)s"
     f" | %(message)s"
     for level, color in log_level_color_prefix.items()
 }
@@ -99,13 +100,13 @@ LOG_TRACE_FORMATS: dict[int, str] = {
 DEFAULT_LOG_FORMAT: str = (
     f"{Fore.BLUE}%(asctime)s{Fore.RESET} | "
     f"{Style.BRIGHT}{Fore.WHITE}%(levelname)s{Style.RESET_ALL} | "
-    f"%(name)s:%(filename)s:%(lineno)s | %(message)s"
+    f"%(message)s"
 )
 
 DEFAULT_TRACE_FORMAT: str = (
     f"{Fore.BLUE}%(asctime)s{Fore.RESET} | "
     f"{Style.BRIGHT}{Fore.WHITE}%(levelname)s{Style.RESET_ALL} | "
-    f"%(name)s:%(filename)s:%(lineno)s | %(message)s"
+    f"%(message)s"
 )
 
 
@@ -222,5 +223,5 @@ class BtFileFormatter(logging.Formatter):
         Returns:
             formated record (str): The formatted log record.
         """
-        record.levelname = f"{record.levelname:^16}"
+        record.levelname = f"{record.levelname:^10}"
         return super().format(record)

--- a/bittensor/utils/btlogging/format.py
+++ b/bittensor/utils/btlogging/format.py
@@ -70,6 +70,8 @@ color_map: dict[str, str] = {
     "[/magenta]": Style.RESET_ALL,
     "[yellow]": Fore.YELLOW,
     "[/yellow]": Style.RESET_ALL,
+    "[orange]": Fore.YELLOW,
+    "[/orange]": Style.RESET_ALL,
 }
 
 

--- a/bittensor/utils/btlogging/format.py
+++ b/bittensor/utils/btlogging/format.py
@@ -95,6 +95,7 @@ LOG_FORMATS: dict[int, str] = {
 LOG_TRACE_FORMATS: dict[int, str] = {
     level: f"{Fore.BLUE}%(asctime)s{Fore.RESET}"
     f" | {Style.BRIGHT}{color}%(levelname)s{Fore.RESET}{Back.RESET}{Style.RESET_ALL}"
+    f" | %(name)s:%(filename)s:%(lineno)s"
     f" | %(message)s"
     for level, color in log_level_color_prefix.items()
 }
@@ -102,13 +103,13 @@ LOG_TRACE_FORMATS: dict[int, str] = {
 DEFAULT_LOG_FORMAT: str = (
     f"{Fore.BLUE}%(asctime)s{Fore.RESET} | "
     f"{Style.BRIGHT}{Fore.WHITE}%(levelname)s{Style.RESET_ALL} | "
-    f"%(message)s"
+    f"%(name)s:%(filename)s:%(lineno)s | %(message)s"
 )
 
 DEFAULT_TRACE_FORMAT: str = (
     f"{Fore.BLUE}%(asctime)s{Fore.RESET} | "
     f"{Style.BRIGHT}{Fore.WHITE}%(levelname)s{Style.RESET_ALL} | "
-    f"%(message)s"
+    f"%(name)s:%(filename)s:%(lineno)s | %(message)s"
 )
 
 

--- a/bittensor/utils/btlogging/format.py
+++ b/bittensor/utils/btlogging/format.py
@@ -60,16 +60,16 @@ emoji_map: dict[str, str] = {
 
 
 color_map: dict[str, str] = {
-    "<red>": Fore.RED,
-    "</red>": Style.RESET_ALL,
-    "<blue>": Fore.BLUE,
-    "</blue>": Style.RESET_ALL,
-    "<green>": Fore.GREEN,
-    "</green>": Style.RESET_ALL,
-    "<magenta>": Fore.MAGENTA,
-    "</magenta>": Style.RESET_ALL,
-    "<yellow>": Fore.YELLOW,
-    "</yellow>": Style.RESET_ALL,
+    "[red]": Fore.RED,
+    "[/red]": Style.RESET_ALL,
+    "[blue]": Fore.BLUE,
+    "[/blue]": Style.RESET_ALL,
+    "[green]": Fore.GREEN,
+    "[/green]": Style.RESET_ALL,
+    "[magenta]": Fore.MAGENTA,
+    "[/magenta]": Style.RESET_ALL,
+    "[yellow]": Fore.YELLOW,
+    "[/yellow]": Style.RESET_ALL,
 }
 
 

--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -45,6 +45,7 @@ from .defines import (
 )
 from .format import BtFileFormatter, BtStreamFormatter
 from .helpers import all_loggers
+from bittensor.utils.btlogging.console import BittensorConsole
 
 
 def _concat_message(msg="", prefix="", suffix=""):
@@ -78,6 +79,14 @@ class LoggingMachine(StateMachine, Logger):
         | Disabled.to(Default)
         | Default.to(Default)
         | Warning.to(Default)
+    )
+
+    enable_console = (
+        Default.to(Debug)
+        | Trace.to(Debug)
+        | Disabled.to(Debug)
+        | Debug.to(Debug)
+        | Warning.to(Debug)
     )
 
     enable_info = enable_default
@@ -146,6 +155,7 @@ class LoggingMachine(StateMachine, Logger):
         self._logger = self._initialize_bt_logger(name)
         self.disable_third_party_loggers()
         self._enable_initial_state(self._config)
+        self.console = BittensorConsole(self)
 
     def _enable_initial_state(self, config):
         """Set correct state action on initializing"""
@@ -384,6 +394,12 @@ class LoggingMachine(StateMachine, Logger):
         for logger in all_loggers():
             logger.setLevel(stdlogging.DEBUG)
 
+    def before_enable_console(self):
+        """Logs status before enable Console."""
+        self._stream_formatter.set_trace(True)
+        for logger in all_loggers():
+            logger.setLevel(stdlogging.DEBUG)
+
     def after_enable_debug(self):
         """Logs status after enable Debug."""
         self._logger.info("Debug enabled.")
@@ -504,6 +520,11 @@ class LoggingMachine(StateMachine, Logger):
         """Sets Default state."""
         if not self.current_state_value == "Default":
             self.enable_default()
+
+    def set_console(self):
+        """Sets Console state."""
+        if not self.current_state_value == "Console":
+            self.enable_console()
 
     # as an option to be more obvious. `bittensor.logging.set_info()` is the same `bittensor.logging.set_default()`
     def set_info(self):


### PR DESCRIPTION
blogging gets a new `console` field. It appears immediately during `LoggingMachine` instance is initialization.
`BittensorConsole` methods allow you to output messages to the terminal/console without changing the logging level of the main logging (btlogging).

Usage example:
```python
from bittensor import logging

# will be logged
logging.console.info("info message")
logging.console.error("error message")
logging.console.success("success message")
logging.console.warning("warning message")
 logging.console.critical("critical message")

# will not be logged
logging.info("test info")
```