### PR TITLE
Use websockets for Subtensor

### DIFF
--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -148,7 +148,7 @@ class Subtensor:
             _mock (bool): If set to ``True``, uses a mocked connection for testing purposes. Default is ``False``.
             log_verbose (bool): Whether to enable verbose logging. If set to ``True``, detailed log information about the connection and network operations will be provided. Default is ``True``.
             connection_timeout (int): The maximum time in seconds to keep the connection alive. Default is ``600``.
-            websocket: websockets sync (threading) client object connected to the network.
+            websocket (websockets.sync.client.ClientConnection): websockets sync (threading) client object connected to the network.
 
         This initialization sets up the connection to the specified Bittensor network, allowing for various blockchain operations such as neuron registration, stake management, and setting weights.
         """

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -5,7 +5,6 @@ Bittensor blockchain, facilitating a range of operations essential for the decen
 
 import argparse
 import copy
-import socket
 import ssl
 from typing import Union, Optional, TypedDict, Any
 
@@ -18,6 +17,7 @@ from scalecodec.exceptions import RemainingScaleBytesNotEmptyException
 from scalecodec.type_registry import load_type_registry_preset
 from scalecodec.types import ScaleType
 from substrateinterface.base import QueryMapResult, SubstrateInterface
+from websockets.sync import client as ws_client
 
 from bittensor.core import settings
 from bittensor.core.axon import Axon
@@ -132,6 +132,7 @@ class Subtensor:
         _mock: bool = False,
         log_verbose: bool = False,
         connection_timeout: int = 600,
+        websocket: Optional[ws_client.ClientConnection] = None,
     ) -> None:
         """
         Initializes a Subtensor interface for interacting with the Bittensor blockchain.
@@ -147,6 +148,7 @@ class Subtensor:
             _mock (bool): If set to ``True``, uses a mocked connection for testing purposes. Default is ``False``.
             log_verbose (bool): Whether to enable verbose logging. If set to ``True``, detailed log information about the connection and network operations will be provided. Default is ``True``.
             connection_timeout (int): The maximum time in seconds to keep the connection alive. Default is ``600``.
+            websocket: websockets sync (threading) client object connected to the network.
 
         This initialization sets up the connection to the specified Bittensor network, allowing for various blockchain operations such as neuron registration, stake management, and setting weights.
         """
@@ -183,6 +185,7 @@ class Subtensor:
         self.log_verbose = log_verbose
         self._connection_timeout = connection_timeout
         self.substrate: "SubstrateInterface" = None
+        self.websocket = websocket
         self._get_substrate()
 
     def __str__(self) -> str:
@@ -205,21 +208,22 @@ class Subtensor:
         """Establishes a connection to the Substrate node using configured parameters."""
         try:
             # Set up params.
+            if not self.websocket:
+                self.websocket = ws_client.connect(
+                    self.chain_endpoint,
+                    open_timeout=self._connection_timeout,
+                    max_size=2**32,
+                )
             self.substrate = SubstrateInterface(
                 ss58_format=settings.SS58_FORMAT,
                 use_remote_preset=True,
-                url=self.chain_endpoint,
                 type_registry=settings.TYPE_REGISTRY,
+                websocket=self.websocket,
             )
             if self.log_verbose:
                 logging.debug(
                     f"Connected to {self.network} network and {self.chain_endpoint}."
                 )
-
-            try:
-                self.substrate.websocket.settimeout(self._connection_timeout)
-            except (AttributeError, TypeError, socket.error, OSError) as e:
-                logging.warning(f"Error setting timeout: {e}")
 
         except (ConnectionRefusedError, ssl.SSLError) as error:
             logging.error(

--- a/bittensor/utils/async_substrate_interface.py
+++ b/bittensor/utils/async_substrate_interface.py
@@ -4,7 +4,7 @@ import random
 from collections import defaultdict
 from dataclasses import dataclass
 from hashlib import blake2b
-from typing import Optional, Any, Union, Callable, Awaitable, cast
+from typing import Optional, Any, Union, Callable, Awaitable, cast, TYPE_CHECKING
 
 from async_property import async_property
 from bittensor_wallet import Keypair
@@ -19,8 +19,11 @@ from substrateinterface.exceptions import (
     BlockNotFound,
 )
 from substrateinterface.storage import StorageKey
-from websockets.asyncio.client import ClientConnection, connect
+from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosed
+
+if TYPE_CHECKING:
+    from websockets.asyncio.client import ClientConnection
 
 ResultHandler = Callable[[dict, Any], Awaitable[tuple[dict, bool]]]
 

--- a/bittensor/utils/async_substrate_interface.py
+++ b/bittensor/utils/async_substrate_interface.py
@@ -693,7 +693,7 @@ class Websocket:
 
     async def _recv(self) -> None:
         try:
-            response = json.loads(await cast(ClientProtocol, self.ws).recv())
+            response = json.loads(await cast(ClientConnection, self.ws).recv())
             async with self._lock:
                 self._open_subscriptions -= 1
             if "id" in response:

--- a/bittensor/utils/async_substrate_interface.py
+++ b/bittensor/utils/async_substrate_interface.py
@@ -625,7 +625,7 @@ class Websocket:
         # TODO allow setting max concurrent connections and rpc subscriptions per connection
         # TODO reconnection logic
         self.ws_url = ws_url
-        self.ws: Optional[ClientConnection] = None
+        self.ws: Optional["ClientConnection"] = None
         self.id = 0
         self.max_subscriptions = max_subscriptions
         self.max_connections = max_connections

--- a/bittensor/utils/networking.py
+++ b/bittensor/utils/networking.py
@@ -165,7 +165,7 @@ def ensure_connected(func):
 
     def is_connected(substrate) -> bool:
         """Check if the substrate connection is active."""
-        sock = substrate.websocket.sock
+        sock = substrate.websocket.socket
         return (
             sock is not None
             and sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR) == 0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -23,5 +23,5 @@ python-Levenshtein
 scalecodec==1.2.11
 substrate-interface~=1.7.9
 uvicorn
-websockets>12.0
+websockets>=14.1
 bittensor-wallet>=2.1.0

--- a/tests/integration_tests/test_subtensor_integration.py
+++ b/tests/integration_tests/test_subtensor_integration.py
@@ -75,7 +75,7 @@ class TestSubtensor(unittest.TestCase):
         config1.subtensor.chain_endpoint = None
 
         # Mock network calls
-        with patch("substrateinterface.SubstrateInterface.connect_websocket"):
+        with patch("websockets.sync.client.connect"):
             with patch("substrateinterface.SubstrateInterface.reload_type_registry"):
                 print(bittensor.Subtensor, type(bittensor.Subtensor))
                 # Choose network arg over config

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2145,6 +2145,7 @@ def test_networks_during_connection(mocker):
     """Test networks during_connection."""
     # Preps
     subtensor_module.SubstrateInterface = mocker.Mock()
+    mocker.patch("websockets.sync.client.connect")
     # Call
     for network in list(settings.NETWORK_MAP.keys()) + ["undefined"]:
         sub = Subtensor(network)

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -1904,7 +1904,7 @@ def test_connect_with_substrate(mocker):
     """Ensure re-connection is non called when using an alive substrate."""
     # Prep
     fake_substrate = mocker.MagicMock()
-    fake_substrate.websocket.sock.getsockopt.return_value = 0
+    fake_substrate.websocket.socket.getsockopt.return_value = 0
     mocker.patch.object(
         subtensor_module, "SubstrateInterface", return_value=fake_substrate
     )


### PR DESCRIPTION
This changes the way Subtensor connects to the websocket server. Previously, the websocket was initialized from within SubstrateInterface. However, this was using the stdlib `websocket` package. The PyPI `websockets` package has significantly better stability, and results in no broken pipes in our testing.

Furthermore, because we're bumping the websockets requirement version to 14.1+, we're transitioning the async websockets client in AsyncSubstrate to use this updated client.