### PR TITLE
Tests for subtensor methods related with `stake` and `unstake` extrinsics

### DIFF
--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -2106,7 +2106,6 @@ class Subtensor:
             amounts (list[Union[Balance, float]]): Corresponding amounts of TAO to stake for each hotkey.
             wait_for_inclusion (bool): Waits for the transaction to be included in a block.
             wait_for_finalization (bool): Waits for the transaction to be finalized on the blockchain.
-            prompt (bool): If ``True``, prompts for user confirmation before proceeding.
 
         Returns:
             bool: ``True`` if the staking is successful for all specified neurons, False otherwise.
@@ -2114,12 +2113,12 @@ class Subtensor:
         This function is essential for managing stakes across multiple neurons, reflecting the dynamic and collaborative nature of the Bittensor network.
         """
         return add_stake_multiple_extrinsic(
-            self,
-            wallet,
-            hotkey_ss58s,
-            amounts,
-            wait_for_inclusion,
-            wait_for_finalization,
+            subtensor=self,
+            wallet=wallet,
+            hotkey_ss58s=hotkey_ss58s,
+            amounts=amounts,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
         )
 
     def unstake(

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -2145,12 +2145,12 @@ class Subtensor:
         This function supports flexible stake management, allowing neurons to adjust their network participation and potential reward accruals.
         """
         return unstake_extrinsic(
-            self,
-            wallet,
-            hotkey_ss58,
-            amount,
-            wait_for_inclusion,
-            wait_for_finalization,
+            subtensor=self,
+            wallet=wallet,
+            hotkey_ss58=hotkey_ss58,
+            amount=amount,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
         )
 
     def unstake_multiple(

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -2177,10 +2177,10 @@ class Subtensor:
         This function allows for strategic reallocation or withdrawal of stakes, aligning with the dynamic stake management aspect of the Bittensor network.
         """
         return unstake_multiple_extrinsic(
-            self,
-            wallet,
-            hotkey_ss58s,
-            amounts,
-            wait_for_inclusion,
-            wait_for_finalization,
+            subtensor=self,
+            wallet=wallet,
+            hotkey_ss58s=hotkey_ss58s,
+            amounts=amounts,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
         )

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2599,3 +2599,68 @@ def test_get_delegates_latest_block(mocker, subtensor):
     )
     mock_list_from_vec_u8.assert_called_once_with(fake_json_body["result"])
     assert result == ["delegate1", "delegate2"]
+
+
+def test_is_hotkey_delegate_true(mocker, subtensor):
+    """Test when hotkey is a delegate."""
+    # Mock data
+    fake_hotkey_ss58 = "hotkey_1"
+    fake_block = 123
+    fake_delegates = [
+        mocker.Mock(hotkey_ss58="hotkey_1"),
+        mocker.Mock(hotkey_ss58="hotkey_2"),
+    ]
+
+    # Mocks
+    mock_get_delegates = mocker.patch.object(
+        subtensor, "get_delegates", return_value=fake_delegates
+    )
+
+    # Call
+    result = subtensor.is_hotkey_delegate(fake_hotkey_ss58, block=fake_block)
+
+    # Assertions
+    mock_get_delegates.assert_called_once_with(block=fake_block)
+    assert result is True
+
+
+def test_is_hotkey_delegate_false(mocker, subtensor):
+    """Test when hotkey is not a delegate."""
+    # Mock data
+    fake_hotkey_ss58 = "hotkey_3"
+    fake_block = 123
+    fake_delegates = [
+        mocker.Mock(hotkey_ss58="hotkey_1"),
+        mocker.Mock(hotkey_ss58="hotkey_2"),
+    ]
+
+    # Mocks
+    mock_get_delegates = mocker.patch.object(
+        subtensor, "get_delegates", return_value=fake_delegates
+    )
+
+    # Call
+    result = subtensor.is_hotkey_delegate(fake_hotkey_ss58, block=fake_block)
+
+    # Assertions
+    mock_get_delegates.assert_called_once_with(block=fake_block)
+    assert result is False
+
+
+def test_is_hotkey_delegate_empty_list(mocker, subtensor):
+    """Test when delegate list is empty."""
+    # Mock data
+    fake_hotkey_ss58 = "hotkey_1"
+    fake_block = 123
+
+    # Mocks
+    mock_get_delegates = mocker.patch.object(
+        subtensor, "get_delegates", return_value=[]
+    )
+
+    # Call
+    result = subtensor.is_hotkey_delegate(fake_hotkey_ss58, block=fake_block)
+
+    # Assertions
+    mock_get_delegates.assert_called_once_with(block=fake_block)
+    assert result is False

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2193,3 +2193,110 @@ def test_get_stake_for_coldkey_and_hotkey(subtensor, mocker, fake_value_result):
     else:
         spy_balance_from_rao.assert_not_called()
     assert result == fake_value_result
+
+
+def test_get_hotkey_owner_success(mocker, subtensor):
+    """Test when hotkey exists and owner is found."""
+    # Mock data
+    fake_hotkey_ss58 = "fake_hotkey"
+    fake_coldkey_ss58 = "fake_coldkey"
+    fake_block = 123
+
+    # Mocks
+    mock_query_subtensor = mocker.patch.object(
+        subtensor,
+        "query_subtensor",
+        return_value=mocker.Mock(value=fake_coldkey_ss58),
+    )
+    mock_does_hotkey_exist = mocker.patch.object(
+        subtensor, "does_hotkey_exist", return_value=True
+    )
+
+    # Call
+    result = subtensor.get_hotkey_owner(fake_hotkey_ss58, block=fake_block)
+
+    # Assertions
+    mock_query_subtensor.assert_called_once_with(
+        "Owner", fake_block, [fake_hotkey_ss58]
+    )
+    mock_does_hotkey_exist.assert_called_once_with(fake_hotkey_ss58, fake_block)
+    assert result == fake_coldkey_ss58
+
+
+def test_get_hotkey_owner_no_value(mocker, subtensor):
+    """Test when query_subtensor returns no value."""
+    # Mock data
+    fake_hotkey_ss58 = "fake_hotkey"
+    fake_block = 123
+
+    # Mocks
+    mock_query_subtensor = mocker.patch.object(
+        subtensor,
+        "query_subtensor",
+        return_value=None,
+    )
+    mock_does_hotkey_exist = mocker.patch.object(
+        subtensor, "does_hotkey_exist", return_value=True
+    )
+
+    # Call
+    result = subtensor.get_hotkey_owner(fake_hotkey_ss58, block=fake_block)
+
+    # Assertions
+    mock_query_subtensor.assert_called_once_with(
+        "Owner", fake_block, [fake_hotkey_ss58]
+    )
+    mock_does_hotkey_exist.assert_not_called()
+    assert result is None
+
+
+def test_get_hotkey_owner_does_not_exist(mocker, subtensor):
+    """Test when hotkey does not exist."""
+    # Mock data
+    fake_hotkey_ss58 = "fake_hotkey"
+    fake_block = 123
+
+    # Mocks
+    mock_query_subtensor = mocker.patch.object(
+        subtensor,
+        "query_subtensor",
+        return_value=mocker.Mock(value="fake_coldkey"),
+    )
+    mock_does_hotkey_exist = mocker.patch.object(
+        subtensor, "does_hotkey_exist", return_value=False
+    )
+
+    # Call
+    result = subtensor.get_hotkey_owner(fake_hotkey_ss58, block=fake_block)
+
+    # Assertions
+    mock_query_subtensor.assert_called_once_with(
+        "Owner", fake_block, [fake_hotkey_ss58]
+    )
+    mock_does_hotkey_exist.assert_called_once_with(fake_hotkey_ss58, fake_block)
+    assert result is None
+
+
+def test_get_hotkey_owner_latest_block(mocker, subtensor):
+    """Test when no block is provided (latest block)."""
+    # Mock data
+    fake_hotkey_ss58 = "fake_hotkey"
+    fake_coldkey_ss58 = "fake_coldkey"
+
+    # Mocks
+    mock_query_subtensor = mocker.patch.object(
+        subtensor,
+        "query_subtensor",
+        return_value=mocker.Mock(value=fake_coldkey_ss58),
+    )
+    mock_does_hotkey_exist = mocker.patch.object(
+        subtensor, "does_hotkey_exist", return_value=True
+    )
+
+    # Call
+    result = subtensor.get_hotkey_owner(fake_hotkey_ss58)
+
+    # Assertions
+    mock_query_subtensor.assert_called_once_with("Owner", None, [fake_hotkey_ss58])
+    mock_does_hotkey_exist.assert_called_once_with(fake_hotkey_ss58, None)
+    assert result == fake_coldkey_ss58

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2728,3 +2728,34 @@ def test_add_stake_multiple_success(mocker, subtensor):
         wait_for_finalization=False,
     )
     assert result == mock_add_stake_multiple_extrinsic.return_value
+
+
+def test_unstake_success(mocker, subtensor):
+    """Test unstake operation is successful."""
+    # Mock data
+    fake_wallet = mocker.Mock()
+    fake_hotkey_ss58 = "hotkey_1"
+    fake_amount = 10.0
+
+    # Mock `unstake_extrinsic`
+    mock_unstake_extrinsic = mocker.patch.object(subtensor_module, "unstake_extrinsic")
+
+    # Call
+    result = subtensor.unstake(
+        wallet=fake_wallet,
+        hotkey_ss58=fake_hotkey_ss58,
+        amount=fake_amount,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+    )
+
+    # Assertions
+    mock_unstake_extrinsic.assert_called_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58=fake_hotkey_ss58,
+        amount=fake_amount,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+    )
+    assert result == mock_unstake_extrinsic.return_value

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2732,12 +2732,11 @@ def test_add_stake_multiple_success(mocker, subtensor):
 
 def test_unstake_success(mocker, subtensor):
     """Test unstake operation is successful."""
-    # Mock data
+    # Preps
     fake_wallet = mocker.Mock()
     fake_hotkey_ss58 = "hotkey_1"
     fake_amount = 10.0
 
-    # Mock `unstake_extrinsic`
     mock_unstake_extrinsic = mocker.patch.object(subtensor_module, "unstake_extrinsic")
 
     # Call
@@ -2759,3 +2758,35 @@ def test_unstake_success(mocker, subtensor):
         wait_for_finalization=False,
     )
     assert result == mock_unstake_extrinsic.return_value
+
+
+def test_unstake_multiple_success(mocker, subtensor):
+    """Test unstake_multiple succeeds for all hotkeys."""
+    # Preps
+    fake_wallet = mocker.Mock()
+    fake_hotkeys = ["hotkey_1", "hotkey_2"]
+    fake_amounts = [10.0, 20.0]
+
+    mock_unstake_multiple_extrinsic = mocker.patch(
+        "bittensor.core.subtensor.unstake_multiple_extrinsic", return_value=True
+    )
+
+    # Call
+    result = subtensor.unstake_multiple(
+        wallet=fake_wallet,
+        hotkey_ss58s=fake_hotkeys,
+        amounts=fake_amounts,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+    )
+
+    # Assertions
+    mock_unstake_multiple_extrinsic.assert_called_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58s=fake_hotkeys,
+        amounts=fake_amounts,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+    )
+    assert result == mock_unstake_multiple_extrinsic.return_value

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2195,6 +2195,98 @@ def test_get_stake_for_coldkey_and_hotkey(subtensor, mocker, fake_value_result):
     assert result == fake_value_result
 
 
+def test_does_hotkey_exist_true(mocker, subtensor):
+    """Test when the hotkey exists."""
+    # Mock data
+    fake_hotkey_ss58 = "fake_hotkey"
+    fake_owner = "valid_owner"
+    fake_block = 123
+
+    # Mocks
+    mock_query_subtensor = mocker.patch.object(
+        subtensor,
+        "query_subtensor",
+        return_value=mocker.Mock(value=fake_owner),
+    )
+
+    # Call
+    result = subtensor.does_hotkey_exist(fake_hotkey_ss58, block=fake_block)
+
+    # Assertions
+    mock_query_subtensor.assert_called_once_with(
+        "Owner", fake_block, [fake_hotkey_ss58]
+    )
+    assert result is True
+
+
+def test_does_hotkey_exist_no_value(mocker, subtensor):
+    """Test when query_subtensor returns no value."""
+    # Mock data
+    fake_hotkey_ss58 = "fake_hotkey"
+    fake_block = 123
+
+    # Mocks
+    mock_query_subtensor = mocker.patch.object(
+        subtensor,
+        "query_subtensor",
+        return_value=None,
+    )
+
+    # Call
+    result = subtensor.does_hotkey_exist(fake_hotkey_ss58, block=fake_block)
+
+    # Assertions
+    mock_query_subtensor.assert_called_once_with(
+        "Owner", fake_block, [fake_hotkey_ss58]
+    )
+    assert result is False
+
+
+def test_does_hotkey_exist_special_id(mocker, subtensor):
+    """Test when query_subtensor returns the special invalid owner identifier."""
+    # Mock data
+    fake_hotkey_ss58 = "fake_hotkey"
+    fake_owner = "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM"
+    fake_block = 123
+
+    # Mocks
+    mock_query_subtensor = mocker.patch.object(
+        subtensor,
+        "query_subtensor",
+        return_value=mocker.Mock(value=fake_owner),
+    )
+
+    # Call
+    result = subtensor.does_hotkey_exist(fake_hotkey_ss58, block=fake_block)
+
+    # Assertions
+    mock_query_subtensor.assert_called_once_with(
+        "Owner", fake_block, [fake_hotkey_ss58]
+    )
+    assert result is False
+
+
+def test_does_hotkey_exist_latest_block(mocker, subtensor):
+    """Test when no block is provided (latest block)."""
+    # Mock data
+    fake_hotkey_ss58 = "fake_hotkey"
+    fake_owner = "valid_owner"
+
+    # Mocks
+    mock_query_subtensor = mocker.patch.object(
+        subtensor,
+        "query_subtensor",
+        return_value=mocker.Mock(value=fake_owner),
+    )
+
+    # Call
+    result = subtensor.does_hotkey_exist(fake_hotkey_ss58)
+
+    # Assertions
+    mock_query_subtensor.assert_called_once_with("Owner", None, [fake_hotkey_ss58])
+    assert result is True
+
+
 def test_get_hotkey_owner_success(mocker, subtensor):
     """Test when hotkey exists and owner is found."""
     # Mock data

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2664,3 +2664,36 @@ def test_is_hotkey_delegate_empty_list(mocker, subtensor):
     # Assertions
     mock_get_delegates.assert_called_once_with(block=fake_block)
     assert result is False
+
+
+def test_add_stake_success(mocker, subtensor):
+    """Test add_stake returns True on successful staking."""
+    # Mock data
+    fake_wallet = mocker.Mock()
+    fake_hotkey_ss58 = "fake_hotkey"
+    fake_amount = 10.0
+
+    # Mock `add_stake_extrinsic`
+    mock_add_stake_extrinsic = mocker.patch(
+        "bittensor.core.subtensor.add_stake_extrinsic"
+    )
+
+    # Call
+    result = subtensor.add_stake(
+        wallet=fake_wallet,
+        hotkey_ss58=fake_hotkey_ss58,
+        amount=fake_amount,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+    )
+
+    # Assertions
+    mock_add_stake_extrinsic.assert_called_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58=fake_hotkey_ss58,
+        amount=fake_amount,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+    )
+    assert result is mock_add_stake_extrinsic.return_value

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2668,14 +2668,13 @@ def test_is_hotkey_delegate_empty_list(mocker, subtensor):
 
 def test_add_stake_success(mocker, subtensor):
     """Test add_stake returns True on successful staking."""
-    # Mock data
+    # Prep
     fake_wallet = mocker.Mock()
     fake_hotkey_ss58 = "fake_hotkey"
     fake_amount = 10.0
 
-    # Mock `add_stake_extrinsic`
-    mock_add_stake_extrinsic = mocker.patch(
-        "bittensor.core.subtensor.add_stake_extrinsic"
+    mock_add_stake_extrinsic = mocker.patch.object(
+        subtensor_module, "add_stake_extrinsic"
     )
 
     # Call
@@ -2696,4 +2695,36 @@ def test_add_stake_success(mocker, subtensor):
         wait_for_inclusion=True,
         wait_for_finalization=False,
     )
-    assert result is mock_add_stake_extrinsic.return_value
+    assert result == mock_add_stake_extrinsic.return_value
+
+
+def test_add_stake_multiple_success(mocker, subtensor):
+    """Test add_stake_multiple successfully stakes for all hotkeys."""
+    # Prep
+    fake_wallet = mocker.Mock()
+    fake_hotkey_ss58 = ["fake_hotkey"]
+    fake_amount = [10.0]
+
+    mock_add_stake_multiple_extrinsic = mocker.patch.object(
+        subtensor_module, "add_stake_multiple_extrinsic"
+    )
+
+    # Call
+    result = subtensor.add_stake_multiple(
+        wallet=fake_wallet,
+        hotkey_ss58s=fake_hotkey_ss58,
+        amounts=fake_amount,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+    )
+
+    # Assertions
+    mock_add_stake_multiple_extrinsic.assert_called_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58s=fake_hotkey_ss58,
+        amounts=fake_amount,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+    )
+    assert result == mock_add_stake_multiple_extrinsic.return_value

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2457,3 +2457,44 @@ def test_get_minimum_required_stake_invalid_result(mocker, subtensor):
     )
     mock_balance_from_rao.assert_called_once_with(fake_invalid_stake)
     assert result == mock_balance_from_rao.return_value
+
+
+def test_tx_rate_limit_success(mocker, subtensor):
+    """Test when tx_rate_limit is successfully retrieved."""
+    # Mock data
+    fake_rate_limit = 100
+    fake_block = 123
+
+    # Mocks
+    mock_query_subtensor = mocker.patch.object(
+        subtensor,
+        "query_subtensor",
+        return_value=mocker.Mock(value=fake_rate_limit),
+    )
+
+    # Call
+    result = subtensor.tx_rate_limit(block=fake_block)
+
+    # Assertions
+    mock_query_subtensor.assert_called_once_with("TxRateLimit", fake_block)
+    assert result == fake_rate_limit
+
+
+def test_tx_rate_limit_no_value(mocker, subtensor):
+    """Test when query_subtensor returns None."""
+    # Mock data
+    fake_block = 123
+
+    # Mocks
+    mock_query_subtensor = mocker.patch.object(
+        subtensor,
+        "query_subtensor",
+        return_value=None,
+    )
+
+    # Call
+    result = subtensor.tx_rate_limit(block=fake_block)
+
+    # Assertions
+    mock_query_subtensor.assert_called_once_with("TxRateLimit", fake_block)
+    assert result is None


### PR DESCRIPTION
DO NOT MERGE UNTIL https://github.com/opentensor/bittensor/pull/2456 merged and this PR rebased to `staging`