### PR TITLE
Support fastblocks when setting root set weights in e2e tests

### DIFF
--- a/bittensor/core/extrinsics/root.py
+++ b/bittensor/core/extrinsics/root.py
@@ -118,6 +118,7 @@ def _do_set_root_weights(
     version_key: int = version_as_int,
     wait_for_inclusion: bool = False,
     wait_for_finalization: bool = False,
+    period: int = 5,
 ) -> tuple[bool, Optional[str]]:
     """
     Internal method to send a transaction to the Bittensor blockchain, setting weights for specified neurons on root. This method constructs and submits the transaction, handling retries and blockchain communication.
@@ -153,7 +154,7 @@ def _do_set_root_weights(
     extrinsic = self.substrate.create_signed_extrinsic(
         call=call,
         keypair=wallet.coldkey,
-        era={"period": 5},
+        era={"period": period},
     )
     response = self.substrate.submit_extrinsic(
         extrinsic,


### PR DESCRIPTION
This introduces a param period to root weights extrinsic which we can use to increase the total period the transaction is in pool. 
Testing to see if this fixes flaky behaviour when setting root weights