### PR TITLE
Update unit tests websocket

### DIFF
--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -256,6 +256,11 @@ def subtensor(mocker):
     mocker.patch.object(
         subtensor_module, "SubstrateInterface", return_value=fake_substrate
     )
+    fake_websocket = mocker.MagicMock()
+    fake_websocket.client.connect.return_value = 0
+    mocker.patch.object(
+        subtensor_module, "ws_client", return_value=fake_websocket
+    )
     return Subtensor()
 
 

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -258,9 +258,7 @@ def subtensor(mocker):
     )
     fake_websocket = mocker.MagicMock()
     fake_websocket.client.connect.return_value = 0
-    mocker.patch.object(
-        subtensor_module, "ws_client", return_value=fake_websocket
-    )
+    mocker.patch.object(subtensor_module, "ws_client", return_value=fake_websocket)
     return Subtensor()
 
 


### PR DESCRIPTION
Updates unit tests to use the mocked websocket that is now used for subtensor instantiation.