### PR TITLE
fix: increase stacklevel in LoggingMachine log calls

### DIFF
--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -443,10 +443,18 @@ class LoggingMachine(StateMachine, Logger):
         """
         return self.current_state_value == "Trace"
 
-    def trace(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
+    def trace(
+        self,
+        msg="",
+        prefix="",
+        suffix="",
+        *args,
+        stacklevel=2 if sys.version_info >= (3, 11) else 1, # logger.trace is not an internal method
+        **kwargs,
+    ):
         """Wraps trace message with prefix and suffix."""
         msg = _concat_message(msg, prefix, suffix)
-        self._logger.trace(msg, *args, **kwargs, stacklevel=stacklevel + 2)
+        self._logger.trace(msg, *args, **kwargs, stacklevel=stacklevel + 1)
 
     def debug(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps debug message with prefix and suffix."""
@@ -458,10 +466,18 @@ class LoggingMachine(StateMachine, Logger):
         msg = _concat_message(msg, prefix, suffix)
         self._logger.info(msg, *args, **kwargs, stacklevel=stacklevel + 1)
 
-    def success(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
+    def success(
+        self,
+        msg="",
+        prefix="",
+        suffix="",
+        *args,
+        stacklevel=2 if sys.version_info >= (3, 11) else 1, # logger.success is not an internal method
+        **kwargs,
+    ):
         """Wraps success message with prefix and suffix."""
         msg = _concat_message(msg, prefix, suffix)
-        self._logger.success(msg, *args, **kwargs, stacklevel=stacklevel + 2)
+        self._logger.success(msg, *args, **kwargs, stacklevel=stacklevel + 1)
 
     def warning(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps warning message with prefix and suffix."""

--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -443,45 +443,45 @@ class LoggingMachine(StateMachine, Logger):
         """
         return self.current_state_value == "Trace"
 
-    def trace(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def trace(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps trace message with prefix and suffix."""
         msg = _concat_message(msg, prefix, suffix)
-        self._logger.trace(msg, *args, **kwargs)
+        self._logger.trace(msg, *args, **kwargs, stacklevel=stacklevel + 2)
 
-    def debug(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def debug(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps debug message with prefix and suffix."""
         msg = _concat_message(msg, prefix, suffix)
-        self._logger.debug(msg, *args, **kwargs)
+        self._logger.debug(msg, *args, **kwargs, stacklevel=stacklevel + 1)
 
-    def info(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def info(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps info message with prefix and suffix."""
         msg = _concat_message(msg, prefix, suffix)
-        self._logger.info(msg, *args, **kwargs)
+        self._logger.info(msg, *args, **kwargs, stacklevel=stacklevel + 1)
 
-    def success(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def success(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps success message with prefix and suffix."""
         msg = _concat_message(msg, prefix, suffix)
-        self._logger.success(msg, *args, **kwargs)
+        self._logger.success(msg, *args, **kwargs, stacklevel=stacklevel + 2)
 
-    def warning(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def warning(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps warning message with prefix and suffix."""
         msg = _concat_message(msg, prefix, suffix)
-        self._logger.warning(msg, *args, **kwargs)
+        self._logger.warning(msg, *args, **kwargs, stacklevel=stacklevel + 1)
 
-    def error(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def error(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps error message with prefix and suffix."""
         msg = _concat_message(msg, prefix, suffix)
-        self._logger.error(msg, *args, **kwargs)
+        self._logger.error(msg, *args, **kwargs, stacklevel=stacklevel + 1)
 
-    def critical(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def critical(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps critical message with prefix and suffix."""
         msg = _concat_message(msg, prefix, suffix)
-        self._logger.critical(msg, *args, **kwargs)
+        self._logger.critical(msg, *args, **kwargs, stacklevel=stacklevel + 1)
 
-    def exception(self, msg="", prefix="", suffix="", *args, **kwargs):
+    def exception(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps exception message with prefix and suffix."""
         msg = _concat_message(msg, prefix, suffix)
-        self._logger.exception(msg, *args, **kwargs)
+        self._logger.exception(msg, *args, **kwargs, stacklevel=stacklevel + 1)
 
     def on(self):
         """Enable default state."""

--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -48,10 +48,7 @@ from .helpers import all_loggers
 from bittensor.utils.btlogging.console import BittensorConsole
 
 # https://github.com/python/cpython/issues/97941
-if sys.version_info >= (3, 11):
-    CUSTOM_LOGGER_METHOD_STACKLEVEL = 2
-else:
-    CUSTOM_LOGGER_METHOD_STACKLEVEL = 1
+CUSTOM_LOGGER_METHOD_STACK_LEVEL = 2 if sys.version_info >= (3, 11) else 1
 
 
 def _concat_message(msg="", prefix="", suffix=""):

--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -449,7 +449,9 @@ class LoggingMachine(StateMachine, Logger):
         prefix="",
         suffix="",
         *args,
-        stacklevel=2 if sys.version_info >= (3, 11) else 1, # logger.trace is not an internal method
+        stacklevel=2  # logger.trace is not an internal method
+        if sys.version_info >= (3, 11)
+        else 1,
         **kwargs,
     ):
         """Wraps trace message with prefix and suffix."""
@@ -472,7 +474,9 @@ class LoggingMachine(StateMachine, Logger):
         prefix="",
         suffix="",
         *args,
-        stacklevel=2 if sys.version_info >= (3, 11) else 1, # logger.success is not an internal method
+        stacklevel=2  # logger.success is not an internal method
+        if sys.version_info >= (3, 11)
+        else 1,
         **kwargs,
     ):
         """Wraps success message with prefix and suffix."""

--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -47,6 +47,12 @@ from .format import BtFileFormatter, BtStreamFormatter
 from .helpers import all_loggers
 from bittensor.utils.btlogging.console import BittensorConsole
 
+# https://github.com/python/cpython/issues/97941
+if sys.version_info >= (3, 11):
+    CUSTOM_LOGGER_METHOD_STACKLEVEL = 2
+else:
+    CUSTOM_LOGGER_METHOD_STACKLEVEL = 1
+
 
 def _concat_message(msg="", prefix="", suffix=""):
     """Concatenates a message with optional prefix and suffix."""
@@ -447,20 +453,15 @@ class LoggingMachine(StateMachine, Logger):
         """
         return self.current_state_value == "Trace"
 
-    def trace(
-        self,
-        msg="",
-        prefix="",
-        suffix="",
-        *args,
-        stacklevel=2  # logger.trace is not an internal method
-        if sys.version_info >= (3, 11)
-        else 1,
-        **kwargs,
-    ):
+    def trace(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps trace message with prefix and suffix."""
         msg = _concat_message(msg, prefix, suffix)
-        self._logger.trace(msg, *args, **kwargs, stacklevel=stacklevel + 1)
+        self._logger.trace(
+            msg,
+            *args,
+            **kwargs,
+            stacklevel=stacklevel + CUSTOM_LOGGER_METHOD_STACKLEVEL,
+        )
 
     def debug(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps debug message with prefix and suffix."""
@@ -472,20 +473,15 @@ class LoggingMachine(StateMachine, Logger):
         msg = _concat_message(msg, prefix, suffix)
         self._logger.info(msg, *args, **kwargs, stacklevel=stacklevel + 1)
 
-    def success(
-        self,
-        msg="",
-        prefix="",
-        suffix="",
-        *args,
-        stacklevel=2  # logger.success is not an internal method
-        if sys.version_info >= (3, 11)
-        else 1,
-        **kwargs,
-    ):
+    def success(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps success message with prefix and suffix."""
         msg = _concat_message(msg, prefix, suffix)
-        self._logger.success(msg, *args, **kwargs, stacklevel=stacklevel + 1)
+        self._logger.success(
+            msg,
+            *args,
+            **kwargs,
+            stacklevel=stacklevel + CUSTOM_LOGGER_METHOD_STACKLEVEL,
+        )
 
     def warning(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):
         """Wraps warning message with prefix and suffix."""

--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -477,7 +477,7 @@ class LoggingMachine(StateMachine, Logger):
             msg,
             *args,
             **kwargs,
-            stacklevel=stacklevel + CUSTOM_LOGGER_METHOD_STACKLEVEL,
+            stacklevel=stacklevel + CUSTOM_LOGGER_METHOD_STACK_LEVEL,
         )
 
     def warning(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):

--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -457,7 +457,7 @@ class LoggingMachine(StateMachine, Logger):
             msg,
             *args,
             **kwargs,
-            stacklevel=stacklevel + CUSTOM_LOGGER_METHOD_STACKLEVEL,
+            stacklevel=stacklevel + CUSTOM_LOGGER_METHOD_STACK_LEVEL,
         )
 
     def debug(self, msg="", prefix="", suffix="", *args, stacklevel=1, **kwargs):

--- a/tests/unit_tests/test_logging.py
+++ b/tests/unit_tests/test_logging.py
@@ -176,6 +176,19 @@ def test_all_log_levels_output(logging_machine, caplog):
     assert "Test error" in caplog.text
     assert "Test critical" in caplog.text
 
+    records = [(r.module, r.getMessage()) for r in caplog.records]
+
+    assert records == [
+        ("loggingmachine", "Trace enabled."),
+        ("test_logging", "Test trace"),
+        ("test_logging", "Test debug"),
+        ("test_logging", "Test info"),
+        ("test_logging", "Test success"),
+        ("test_logging", "Test warning"),
+        ("test_logging", "Test error"),
+        ("test_logging", "Test critical"),
+    ]
+
 
 @pytest.mark.parametrize(
     "msg, prefix, suffix, expected_result",


### PR DESCRIPTION
<!--

### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.

-->

### Bug

Fixes https://github.com/opentensor/bittensor/issues/2449

### Description of the Change

"loggingmachine.py" is printed in logs because LoggingMachine does not unstack it's internal calls to wrapped logger

### Alternate Designs

Adding LoggerAdapter

### Possible Drawbacks

None

### Verification Process

Ran unittests.
Checked logs are formatted correctly.

### Release Notes

- Fixed caller's module filename in logs