### PR TITLE
Fixes logging when passing multiple objects

### DIFF
--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -50,9 +50,13 @@ from bittensor.utils.btlogging.console import BittensorConsole
 
 def _concat_message(msg="", prefix="", suffix=""):
     """Concatenates a message with optional prefix and suffix."""
-    empty_pref_suf = [None, ""]
-    msg = f"{f'{prefix} - ' if prefix not in empty_pref_suf else ''}{msg}{f' - {suffix}' if suffix not in empty_pref_suf else ''}"
-    return msg
+    message_parts = [
+        str(component).strip()
+        for component in [prefix, msg, suffix]
+        if component is not None and str(component).strip()
+    ]
+    formatted_message = " - ".join(message_parts)
+    return formatted_message
 
 
 class LoggingConfig(NamedTuple):


### PR DESCRIPTION
When passing multiple objects, the logger breaks in the current implementation due to the check in the current `_concat_message`. 

```python
Traceback (most recent call last):
  File "/Users/ibraheem/Desktop/bittensor sdk/bittensor/bittensor/core/test.py", line 23, in <module>
    logging.debug("Raw weights", raw_weights)
  File "/Users/ibraheem/Desktop/bittensor sdk/bittensor/bittensor/utils/btlogging/loggingmachine.py", line 454, in debug
    msg = _concat_message(msg, prefix, suffix)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ibraheem/Desktop/bittensor sdk/bittensor/bittensor/utils/btlogging/loggingmachine.py", line 54, in _concat_message
    msg = f"{f'{prefix} - ' if prefix not in empty_pref_suf else ''}{msg}{f' - {suffix}' if suffix not in empty_pref_suf else ''}"
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

This PR fixes that that and achieves the same outcome

To reproduce the issue:

```python
import numpy as np
from bittensor.utils.btlogging import logging

raw_weights = np.array([0, 0, 0, 0])

logging.warning("Raw weights", raw_weights)
```