### PR TITLE
Update `ensure_connected` for websockets

### DIFF
--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -216,7 +216,7 @@ class Subtensor:
         """Establishes a connection to the Substrate node using configured parameters."""
         try:
             # Set up params.
-            if not self.websocket:
+            if self.websocket is None or self.websocket.close_code is not None:
                 self.websocket = ws_client.connect(
                     self.chain_endpoint,
                     open_timeout=self._connection_timeout,

--- a/bittensor/utils/networking.py
+++ b/bittensor/utils/networking.py
@@ -10,7 +10,7 @@ from typing import Optional
 import netaddr
 import requests
 from retry import retry
-from websockets.exceptions import ConnectionClosed, ConnectionClosedError
+from websockets.exceptions import ConnectionClosed
 
 from bittensor.utils.btlogging import logging
 
@@ -193,7 +193,7 @@ def ensure_connected(func):
 
         try:
             return func(self, *args, **kwargs)
-        except (ConnectionClosed, ConnectionClosedError):
+        except ConnectionClosed:
             logging.console.warning(
                 "WebSocket connection closed. Attempting to reconnect 5 times..."
             )

--- a/bittensor/utils/networking.py
+++ b/bittensor/utils/networking.py
@@ -10,7 +10,7 @@ from typing import Optional
 import netaddr
 import requests
 from retry import retry
-from websocket import WebSocketConnectionClosedException
+from websockets.exceptions import ConnectionClosed, ConnectionClosedError
 
 from bittensor.utils.btlogging import logging
 
@@ -193,7 +193,7 @@ def ensure_connected(func):
 
         try:
             return func(self, *args, **kwargs)
-        except WebSocketConnectionClosedException:
+        except (ConnectionClosed, ConnectionClosedError):
             logging.console.warning(
                 "WebSocket connection closed. Attempting to reconnect 5 times..."
             )

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -126,7 +126,7 @@ def get_mock_neuron_by_uid(uid: int, **kwargs) -> NeuronInfo:
 
 class FakeWebsocket(ClientConnection):
     close_code = None
-    
+
     def __init__(self, *args, seed, **kwargs):
         protocol = ClientProtocol(parse_uri("ws://127.0.0.1:9945"))
         super().__init__(socket=None, protocol=protocol, **kwargs)

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -125,6 +125,8 @@ def get_mock_neuron_by_uid(uid: int, **kwargs) -> NeuronInfo:
 
 
 class FakeWebsocket(ClientConnection):
+    close_code = None
+    
     def __init__(self, *args, seed, **kwargs):
         protocol = ClientProtocol(parse_uri("ws://127.0.0.1:9945"))
         super().__init__(socket=None, protocol=protocol, **kwargs)


### PR DESCRIPTION
The exception catch for `ensure_connected` is no longer relevant since we no longer use `websocket`. This updates it for `websockets`.