### PR TITLE
Add `wait_for_block` method

### DIFF
--- a/bittensor/utils/async_substrate_interface.py
+++ b/bittensor/utils/async_substrate_interface.py
@@ -2794,13 +2794,21 @@ class AsyncSubstrateInterface:
                 up to you.
             task_return: True to immediately return the result of wait_for_block as an asyncio Task, False to wait
                 for the block to be reached, and return the result of the result handler.
+
+        Returns:
+            Either an asyncio.Task (which contains the running subscription, and whose `result()` will contain the
+                return of the result_handler), or the result itself, depending on `task_return` flag.
+                Note that if your result_handler returns `None`, this method will return `True`, otherwise
+                the return will be the result of your result_handler.
         """
 
         async def _handler(block_data: dict[str, Any]):
             required_number = block
             number = block_data["header"]["number"]
             if number >= required_number:
-                return await result_handler(block_data) or True
+                return (
+                    r if (r := await result_handler(block_data)) is not None else True
+                )
 
         args = inspect.getfullargspec(result_handler).args
         if len(args) != 1:

--- a/tests/unit_tests/utils/test_async_substrate_interface.py
+++ b/tests/unit_tests/utils/test_async_substrate_interface.py
@@ -1,0 +1,38 @@
+import pytest
+import asyncio
+from bittensor.utils import async_substrate_interface
+from typing import Any
+
+
+@pytest.mark.asyncio
+async def test_wait_for_block_invalid_result_handler():
+    chain_interface = async_substrate_interface.AsyncSubstrateInterface(
+        "dummy_endpoint"
+    )
+
+    with pytest.raises(ValueError):
+
+        async def dummy_handler(
+            block_data: dict[str, Any], extra_arg
+        ):  # extra argument
+            return block_data.get("header", {}).get("number", -1) == 2
+
+        await chain_interface.wait_for_block(
+            block=2, result_handler=dummy_handler, task_return=False
+        )
+
+
+@pytest.mark.asyncio
+async def test_wait_for_block_async_return():
+    chain_interface = async_substrate_interface.AsyncSubstrateInterface(
+        "dummy_endpoint"
+    )
+
+    async def dummy_handler(block_data: dict[str, Any]) -> bool:
+        return block_data.get("header", {}).get("number", -1) == 2
+
+    result = await chain_interface.wait_for_block(
+        block=2, result_handler=dummy_handler, task_return=True
+    )
+
+    assert isinstance(result, asyncio.Task)


### PR DESCRIPTION
Fixes the `AsyncSubstrateInterface._get_block_handler` method's `result_handler` and adds a `wait_for_block` method.