### PR TITLE
Fix submit_extrinsic timeout

### DIFF
--- a/bittensor/core/extrinsics/utils.py
+++ b/bittensor/core/extrinsics/utils.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from substrateinterface import SubstrateInterface, ExtrinsicReceipt
     from scalecodec.types import GenericExtrinsic
 
-EXTRINSIC_SUBMISSION_TIMEOUT = os.getenv("EXTRINSIC_SUBMISSION_TIMEOUT", 200)
+EXTRINSIC_SUBMISSION_TIMEOUT = int(os.getenv("EXTRINSIC_SUBMISSION_TIMEOUT", 200))
 
 
 def submit_extrinsic(

--- a/bittensor/core/extrinsics/utils.py
+++ b/bittensor/core/extrinsics/utils.py
@@ -15,11 +15,14 @@ if TYPE_CHECKING:
     from scalecodec.types import GenericExtrinsic
 
 try:
-    EXTRINSIC_SUBMISSION_TIMEOUT = int(os.getenv("EXTRINSIC_SUBMISSION_TIMEOUT", 200))
+    EXTRINSIC_SUBMISSION_TIMEOUT = float(os.getenv("EXTRINSIC_SUBMISSION_TIMEOUT", 200))
 except ValueError:
     raise ValueError(
-        "EXTRINSIC_SUBMISSION_TIMEOUT environment variable must be an integer."
+        "EXTRINSIC_SUBMISSION_TIMEOUT environment variable must be a float."
     )
+
+if EXTRINSIC_SUBMISSION_TIMEOUT < 0:
+    raise ValueError("EXTRINSIC_SUBMISSION_TIMEOUT cannot be negative.")
 
 
 def submit_extrinsic(

--- a/bittensor/core/extrinsics/utils.py
+++ b/bittensor/core/extrinsics/utils.py
@@ -14,7 +14,12 @@ if TYPE_CHECKING:
     from substrateinterface import SubstrateInterface, ExtrinsicReceipt
     from scalecodec.types import GenericExtrinsic
 
-EXTRINSIC_SUBMISSION_TIMEOUT = int(os.getenv("EXTRINSIC_SUBMISSION_TIMEOUT", 200))
+try:
+    EXTRINSIC_SUBMISSION_TIMEOUT = int(os.getenv("EXTRINSIC_SUBMISSION_TIMEOUT", 200))
+except ValueError:
+    raise ValueError(
+        "EXTRINSIC_SUBMISSION_TIMEOUT environment variable must be an integer."
+    )
 
 
 def submit_extrinsic(

--- a/bittensor/utils/networking.py
+++ b/bittensor/utils/networking.py
@@ -163,6 +163,8 @@ def get_formatted_ws_endpoint_url(endpoint_url: Optional[str]) -> Optional[str]:
 def ensure_connected(func):
     """Decorator ensuring the function executes with an active substrate connection."""
 
+    # TODO we need to rethink the logic in this
+
     def is_connected(substrate) -> bool:
         """Check if the substrate connection is active."""
         sock = substrate.websocket.socket

--- a/tests/unit_tests/extrinsics/test_utils.py
+++ b/tests/unit_tests/extrinsics/test_utils.py
@@ -1,6 +1,6 @@
 import time
 from unittest.mock import MagicMock, patch
-
+import importlib
 import pytest
 from substrateinterface.base import (
     SubstrateInterface,
@@ -9,6 +9,11 @@ from substrateinterface.base import (
 )
 
 from bittensor.core.extrinsics import utils
+
+
+@pytest.fixture
+def set_extrinsics_timeout_env(monkeypatch):
+    monkeypatch.setenv("EXTRINSIC_SUBMISSION_TIMEOUT", "3")
 
 
 def test_submit_extrinsic_timeout():
@@ -27,6 +32,30 @@ def test_submit_extrinsic_timeout():
 
 
 def test_submit_extrinsic_success():
+    mock_substrate = MagicMock(autospec=SubstrateInterface)
+    mock_substrate.submit_extrinsic.return_value = True
+    mock_extrinsic = MagicMock(autospec=GenericExtrinsic)
+    result = utils.submit_extrinsic(mock_substrate, mock_extrinsic, True, True)
+    assert result is True
+
+
+def test_submit_extrinsic_timeout_env(set_extrinsics_timeout_env):
+    importlib.reload(utils)
+    timeout = utils.EXTRINSIC_SUBMISSION_TIMEOUT
+
+    def wait(extrinsic, wait_for_inclusion, wait_for_finalization):
+        time.sleep(timeout + 1)
+        return True
+
+    mock_substrate = MagicMock(autospec=SubstrateInterface)
+    mock_substrate.submit_extrinsic = wait
+    mock_extrinsic = MagicMock(autospec=GenericExtrinsic)
+    with pytest.raises(SubstrateRequestException):
+        utils.submit_extrinsic(mock_substrate, mock_extrinsic, True, True)
+
+
+def test_submit_extrinsic_success_env(set_extrinsics_timeout_env):
+    importlib.reload(utils)
     mock_substrate = MagicMock(autospec=SubstrateInterface)
     mock_substrate.submit_extrinsic.return_value = True
     mock_extrinsic = MagicMock(autospec=GenericExtrinsic)

--- a/tests/unit_tests/extrinsics/test_utils.py
+++ b/tests/unit_tests/extrinsics/test_utils.py
@@ -104,3 +104,9 @@ def test_import_timeout_env_parse(monkeypatch):
     with pytest.raises(ValueError) as e:
         importlib.reload(utils)
     assert "cannot be negative" in str(e.value)
+
+    # default (not checking exact value, just that it's a value)
+    monkeypatch.delenv("EXTRINSIC_SUBMISSION_TIMEOUT")
+    importlib.reload(utils)
+    assert isinstance(utils.EXTRINSIC_SUBMISSION_TIMEOUT, float) # has a default value
+    assert utils.EXTRINSIC_SUBMISSION_TIMEOUT > 0 # is positive

--- a/tests/unit_tests/extrinsics/test_utils.py
+++ b/tests/unit_tests/extrinsics/test_utils.py
@@ -13,14 +13,14 @@ from bittensor.core.extrinsics import utils
 
 @pytest.fixture
 def set_extrinsics_timeout_env(monkeypatch):
-    monkeypatch.setenv("EXTRINSIC_SUBMISSION_TIMEOUT", "3")
+    monkeypatch.setenv("EXTRINSIC_SUBMISSION_TIMEOUT", "1")
 
 
 def test_submit_extrinsic_timeout():
-    timeout = 3
+    timeout = 1
 
     def wait(extrinsic, wait_for_inclusion, wait_for_finalization):
-        time.sleep(timeout + 1)
+        time.sleep(timeout + 0.01)
         return True
 
     mock_substrate = MagicMock(autospec=SubstrateInterface)
@@ -61,3 +61,46 @@ def test_submit_extrinsic_success_env(set_extrinsics_timeout_env):
     mock_extrinsic = MagicMock(autospec=GenericExtrinsic)
     result = utils.submit_extrinsic(mock_substrate, mock_extrinsic, True, True)
     assert result is True
+
+
+def test_submit_extrinsic_timeout_env_float(monkeypatch):
+    monkeypatch.setenv("EXTRINSIC_SUBMISSION_TIMEOUT", "1.45")  # use float
+
+    importlib.reload(utils)
+    timeout = utils.EXTRINSIC_SUBMISSION_TIMEOUT
+
+    assert timeout == 1.45  # parsed correctly
+
+    def wait(extrinsic, wait_for_inclusion, wait_for_finalization):
+        time.sleep(timeout + 0.3)  # sleep longer by float
+        return True
+
+    mock_substrate = MagicMock(autospec=SubstrateInterface)
+    mock_substrate.submit_extrinsic = wait
+    mock_extrinsic = MagicMock(autospec=GenericExtrinsic)
+    with pytest.raises(SubstrateRequestException):
+        utils.submit_extrinsic(mock_substrate, mock_extrinsic, True, True)
+
+
+def test_import_timeout_env_parse(monkeypatch):
+    # int
+    monkeypatch.setenv("EXTRINSIC_SUBMISSION_TIMEOUT", "1")
+    importlib.reload(utils)
+    assert utils.EXTRINSIC_SUBMISSION_TIMEOUT == 1  # parsed correctly
+
+    # float
+    monkeypatch.setenv("EXTRINSIC_SUBMISSION_TIMEOUT", "1.45")  # use float
+    importlib.reload(utils)
+    assert utils.EXTRINSIC_SUBMISSION_TIMEOUT == 1.45  # parsed correctly
+
+    # invalid
+    monkeypatch.setenv("EXTRINSIC_SUBMISSION_TIMEOUT", "not_an_int")
+    with pytest.raises(ValueError) as e:
+        importlib.reload(utils)
+    assert "must be a float" in str(e.value)
+
+    # negative
+    monkeypatch.setenv("EXTRINSIC_SUBMISSION_TIMEOUT", "-1")
+    with pytest.raises(ValueError) as e:
+        importlib.reload(utils)
+    assert "cannot be negative" in str(e.value)

--- a/tests/unit_tests/extrinsics/test_utils.py
+++ b/tests/unit_tests/extrinsics/test_utils.py
@@ -1,0 +1,34 @@
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from substrateinterface.base import (
+    SubstrateInterface,
+    GenericExtrinsic,
+    SubstrateRequestException,
+)
+
+from bittensor.core.extrinsics import utils
+
+
+def test_submit_extrinsic_timeout():
+    timeout = 3
+
+    def wait(extrinsic, wait_for_inclusion, wait_for_finalization):
+        time.sleep(timeout + 1)
+        return True
+
+    mock_substrate = MagicMock(autospec=SubstrateInterface)
+    mock_substrate.submit_extrinsic = wait
+    mock_extrinsic = MagicMock(autospec=GenericExtrinsic)
+    with patch.object(utils, "EXTRINSIC_SUBMISSION_TIMEOUT", timeout):
+        with pytest.raises(SubstrateRequestException):
+            utils.submit_extrinsic(mock_substrate, mock_extrinsic, True, True)
+
+
+def test_submit_extrinsic_success():
+    mock_substrate = MagicMock(autospec=SubstrateInterface)
+    mock_substrate.submit_extrinsic.return_value = True
+    mock_extrinsic = MagicMock(autospec=GenericExtrinsic)
+    result = utils.submit_extrinsic(mock_substrate, mock_extrinsic, True, True)
+    assert result is True

--- a/tests/unit_tests/extrinsics/test_utils.py
+++ b/tests/unit_tests/extrinsics/test_utils.py
@@ -42,6 +42,7 @@ def test_submit_extrinsic_success():
 def test_submit_extrinsic_timeout_env(set_extrinsics_timeout_env):
     importlib.reload(utils)
     timeout = utils.EXTRINSIC_SUBMISSION_TIMEOUT
+    assert timeout < 5  # should be less than 5 seconds as taken from test env var
 
     def wait(extrinsic, wait_for_inclusion, wait_for_finalization):
         time.sleep(timeout + 1)

--- a/tests/unit_tests/extrinsics/test_utils.py
+++ b/tests/unit_tests/extrinsics/test_utils.py
@@ -109,5 +109,5 @@ def test_import_timeout_env_parse(monkeypatch):
     # default (not checking exact value, just that it's a value)
     monkeypatch.delenv("EXTRINSIC_SUBMISSION_TIMEOUT")
     importlib.reload(utils)
-    assert isinstance(utils.EXTRINSIC_SUBMISSION_TIMEOUT, float) # has a default value
-    assert utils.EXTRINSIC_SUBMISSION_TIMEOUT > 0 # is positive
+    assert isinstance(utils.EXTRINSIC_SUBMISSION_TIMEOUT, float)  # has a default value
+    assert utils.EXTRINSIC_SUBMISSION_TIMEOUT > 0  # is positive


### PR DESCRIPTION
`submit_extrinsic` is broken, because exceptions in threads cannot be caught. This fixes that issue, and adds a unit test. Also adds a TODO because I don't think our reconnection logic is solid.