### PR TITLE
WS ensure_connected socket catch

### DIFF
--- a/bittensor/utils/networking.py
+++ b/bittensor/utils/networking.py
@@ -171,7 +171,7 @@ def ensure_connected(func):
         try:
             sock_opt = sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
             return sock is not None and sock_opt == 0
-        except OSError:
+        except (OSError, AttributeError):
             return False
 
     @retry(

--- a/bittensor/utils/networking.py
+++ b/bittensor/utils/networking.py
@@ -168,10 +168,11 @@ def ensure_connected(func):
     def is_connected(substrate) -> bool:
         """Check if the substrate connection is active."""
         sock = substrate.websocket.socket
-        return (
-            sock is not None
-            and sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR) == 0
-        )
+        try:
+            sock_opt = sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
+            return sock is not None and sock_opt == 0
+        except OSError:
+            return False
 
     @retry(
         exceptions=ConnectionRefusedError,


### PR DESCRIPTION
Catches OSError that can be caused if `socket.getsockopt` is called on a closed websocket(s) connection.