### PR TITLE
Various improvements and fixes

### DIFF
--- a/bittensor/core/axon.py
+++ b/bittensor/core/axon.py
@@ -594,7 +594,7 @@ class Axon:
         """
         parser = argparse.ArgumentParser()
         Axon.add_args(parser)  # Add specific axon-related arguments
-        return Config(parser, args=[])
+        return Config(parser)
 
     @classmethod
     def help(cls):

--- a/bittensor/core/axon.py
+++ b/bittensor/core/axon.py
@@ -341,7 +341,7 @@ class Axon:
         self.config = config  # type: ignore
 
         # Get wallet or use default.
-        self.wallet = wallet or Wallet()
+        self.wallet = wallet or Wallet(config=self.config)
 
         # Build axon objects.
         self.uuid = str(uuid.uuid1())

--- a/bittensor/core/dendrite.py
+++ b/bittensor/core/dendrite.py
@@ -241,8 +241,8 @@ class DendriteMixin:
         """
         error_id = str(uuid.uuid4())
         error_type = exception.__class__.__name__
-        if isinstance(exception, aiohttp.ClientConnectorError):
-            logging.trace(f"{error_type}#{error_id}: {exception}")
+        if isinstance(exception, (aiohttp.ClientConnectorError, asyncio.TimeoutError)):
+            logging.debug(f"{error_type}#{error_id}: {exception}")
         else:
             logging.error(f"{error_type}#{error_id}: {exception}")
 

--- a/bittensor/core/dendrite.py
+++ b/bittensor/core/dendrite.py
@@ -241,7 +241,10 @@ class DendriteMixin:
         """
         error_id = str(uuid.uuid4())
         error_type = exception.__class__.__name__
-        logging.error(f"{error_type}#{error_id}: {exception}")
+        if isinstance(exception, aiohttp.ClientConnectorError):
+            logging.trace(f"{error_type}#{error_id}: {exception}")
+        else:
+            logging.error(f"{error_type}#{error_id}: {exception}")
 
     def process_error_message(
         self,

--- a/bittensor/core/settings.py
+++ b/bittensor/core/settings.py
@@ -277,6 +277,7 @@ DEFAULTS = munchify(
         "logging": {
             "debug": os.getenv("BT_LOGGING_DEBUG") or False,
             "trace": os.getenv("BT_LOGGING_TRACE") or False,
+            "info": os.getenv("BT_LOGGING_INFO") or False,
             "record_log": os.getenv("BT_LOGGING_RECORD_LOG") or False,
             "logging_dir": os.getenv("BT_LOGGING_LOGGING_DIR") or str(MINERS_DIR),
         },

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -267,7 +267,7 @@ class Subtensor:
         """
         parser = argparse.ArgumentParser()
         Subtensor.add_args(parser)
-        return Config(parser, args=[])
+        return Config(parser)
 
     @staticmethod
     def setup_config(network: Optional[str], config: "Config"):

--- a/bittensor/core/threadpool.py
+++ b/bittensor/core/threadpool.py
@@ -204,7 +204,7 @@ class PriorityThreadPoolExecutor(_base.Executor):
         """
         parser = argparse.ArgumentParser()
         PriorityThreadPoolExecutor.add_args(parser)
-        return Config(parser, args=[])
+        return Config(parser)
 
     @property
     def is_empty(self):

--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -371,7 +371,7 @@ class LoggingMachine(StateMachine, Logger):
 
     def after_enable_default(self):
         pass
-    
+
     # Warning
     def before_enable_warning(self):
         """Logs status before enable Warning."""
@@ -383,7 +383,7 @@ class LoggingMachine(StateMachine, Logger):
     def after_enable_warning(self):
         """Logs status after enable Warning."""
         self._logger.info("Warning enabled.")
-    
+
     # Info
     def before_enable_info(self):
         """Logs status before enable info."""
@@ -668,6 +668,10 @@ class LoggingMachine(StateMachine, Logger):
                 cfg.logging_dir = logging_dir
         else:
             cfg = LoggingConfig(
-                debug=debug, trace=trace, info=info, record_log=record_log, logging_dir=logging_dir
+                debug=debug,
+                trace=trace,
+                info=info,
+                record_log=record_log,
+                logging_dir=logging_dir,
             )
         self.set_config(cfg)

--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -643,7 +643,7 @@ class LoggingMachine(StateMachine, Logger):
         """
         parser = argparse.ArgumentParser()
         cls.add_args(parser)
-        return Config(parser, args=[])
+        return Config(parser)
 
     def __call__(
         self,

--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -66,6 +66,7 @@ class LoggingConfig(NamedTuple):
 
     debug: bool
     trace: bool
+    info: bool
     record_log: bool
     logging_dir: str
 
@@ -78,6 +79,7 @@ class LoggingMachine(StateMachine, Logger):
     Trace = State()
     Disabled = State()
     Warning = State()
+    Info = State()
 
     enable_default = (
         Debug.to(Default)
@@ -85,6 +87,7 @@ class LoggingMachine(StateMachine, Logger):
         | Disabled.to(Default)
         | Default.to(Default)
         | Warning.to(Default)
+        | Info.to(Default)
     )
 
     enable_console = (
@@ -93,9 +96,17 @@ class LoggingMachine(StateMachine, Logger):
         | Disabled.to(Debug)
         | Debug.to(Debug)
         | Warning.to(Debug)
+        | Info.to(Debug)
     )
 
-    enable_info = enable_default
+    enable_info = (
+        Default.to(Info)
+        | Debug.to(Info)
+        | Trace.to(Info)
+        | Disabled.to(Info)
+        | Warning.to(Info)
+        | Info.to(Info)
+    )
 
     enable_trace = (
         Default.to(Trace)
@@ -103,6 +114,7 @@ class LoggingMachine(StateMachine, Logger):
         | Disabled.to(Trace)
         | Trace.to(Trace)
         | Warning.to(Trace)
+        | Info.to(Trace)
     )
 
     enable_debug = (
@@ -111,6 +123,7 @@ class LoggingMachine(StateMachine, Logger):
         | Disabled.to(Debug)
         | Debug.to(Debug)
         | Warning.to(Debug)
+        | Info.to(Debug)
     )
 
     enable_warning = (
@@ -119,6 +132,7 @@ class LoggingMachine(StateMachine, Logger):
         | Disabled.to(Warning)
         | Debug.to(Warning)
         | Warning.to(Warning)
+        | Info.to(Warning)
     )
 
     disable_trace = Trace.to(Default)
@@ -127,11 +141,14 @@ class LoggingMachine(StateMachine, Logger):
 
     disable_warning = Warning.to(Default)
 
+    disable_info = Info.to(Default)
+
     disable_logging = (
         Trace.to(Disabled)
         | Debug.to(Disabled)
         | Default.to(Disabled)
         | Disabled.to(Disabled)
+        | Info.to(Disabled)
     )
 
     def __init__(self, config: "Config", name: str = BITTENSOR_LOGGER_NAME):
@@ -169,6 +186,8 @@ class LoggingMachine(StateMachine, Logger):
             self.enable_trace()
         elif config.debug:
             self.enable_debug()
+        elif config.info:
+            self.enable_info()
         else:
             self.enable_default()
 
@@ -222,6 +241,8 @@ class LoggingMachine(StateMachine, Logger):
             self.enable_trace()
         elif self._config.debug:
             self.enable_debug()
+        elif self._config.info:
+            self.enable_info()
 
     def _create_and_start_listener(self, handlers):
         """
@@ -341,17 +362,8 @@ class LoggingMachine(StateMachine, Logger):
     # Default Logging
     def before_enable_default(self):
         """Logs status before enable Default."""
-        self._logger.info("Enabling default logging.")
+        self._logger.info("Enabling default logging (Warning level)")
         self._logger.setLevel(stdlogging.WARNING)
-        for logger in all_loggers():
-            if logger.name in self._primary_loggers:
-                continue
-            logger.setLevel(stdlogging.CRITICAL)
-
-    def before_enable_info(self):
-        """Logs status before enable Default."""
-        self._logger.info("Enabling default logging.")
-        self._logger.setLevel(stdlogging.INFO)
         for logger in all_loggers():
             if logger.name in self._primary_loggers:
                 continue
@@ -359,7 +371,8 @@ class LoggingMachine(StateMachine, Logger):
 
     def after_enable_default(self):
         pass
-
+    
+    # Warning
     def before_enable_warning(self):
         """Logs status before enable Warning."""
         self._logger.info("Enabling warning.")
@@ -370,6 +383,20 @@ class LoggingMachine(StateMachine, Logger):
     def after_enable_warning(self):
         """Logs status after enable Warning."""
         self._logger.info("Warning enabled.")
+    
+    # Info
+    def before_enable_info(self):
+        """Logs status before enable info."""
+        self._logger.info("Enabling info logging.")
+        self._logger.setLevel(stdlogging.INFO)
+        for logger in all_loggers():
+            if logger.name in self._primary_loggers:
+                continue
+            logger.setLevel(stdlogging.INFO)
+
+    def after_enable_info(self):
+        """Logs status after enable info."""
+        self._logger.info("Info enabled.")
 
     # Trace
     def before_enable_trace(self):
@@ -525,6 +552,14 @@ class LoggingMachine(StateMachine, Logger):
             if self.current_state_value == "Trace":
                 self.disable_trace()
 
+    def set_info(self, on: bool = True):
+        """Sets Info state."""
+        if on and not self.current_state_value == "Info":
+            self.enable_info()
+        elif not on:
+            if self.current_state_value == "Info":
+                self.disable_info()
+
     def set_warning(self, on: bool = True):
         """Sets Warning state."""
         if on and not self.current_state_value == "Warning":
@@ -543,12 +578,6 @@ class LoggingMachine(StateMachine, Logger):
         if not self.current_state_value == "Console":
             self.enable_console()
 
-    # as an option to be more obvious. `bittensor.logging.set_info()` is the same `bittensor.logging.set_default()`
-    def set_info(self):
-        """Sets Default state."""
-        if not self.current_state_value == "Default":
-            self.enable_info()
-
     def get_level(self) -> int:
         """Returns Logging level."""
         return self._logger.level
@@ -565,6 +594,7 @@ class LoggingMachine(StateMachine, Logger):
         prefix_str = "" if prefix is None else prefix + "."
         try:
             default_logging_debug = os.getenv("BT_LOGGING_DEBUG") or False
+            default_logging_info = os.getenv("BT_LOGGING_INFO") or False
             default_logging_trace = os.getenv("BT_LOGGING_TRACE") or False
             default_logging_record_log = os.getenv("BT_LOGGING_RECORD_LOG") or False
             default_logging_logging_dir = os.getenv(
@@ -581,6 +611,12 @@ class LoggingMachine(StateMachine, Logger):
                 action="store_true",
                 help="""Turn on bittensor trace level information""",
                 default=default_logging_trace,
+            )
+            parser.add_argument(
+                "--" + prefix_str + "logging.info",
+                action="store_true",
+                help="""Turn on bittensor info level information""",
+                default=default_logging_info,
             )
             parser.add_argument(
                 "--" + prefix_str + "logging.record_log",
@@ -614,12 +650,15 @@ class LoggingMachine(StateMachine, Logger):
         config: "Config" = None,
         debug: bool = None,
         trace: bool = None,
+        info: bool = None,
         record_log: bool = None,
         logging_dir: str = None,
     ):
         if config is not None:
             cfg = self._extract_logging_config(config)
-            if debug is not None:
+            if info is not None:
+                cfg.info = info
+            elif debug is not None:
                 cfg.debug = debug
             elif trace is not None:
                 cfg.trace = trace
@@ -629,6 +668,6 @@ class LoggingMachine(StateMachine, Logger):
                 cfg.logging_dir = logging_dir
         else:
             cfg = LoggingConfig(
-                debug=debug, trace=trace, record_log=record_log, logging_dir=logging_dir
+                debug=debug, trace=trace, info=info, record_log=record_log, logging_dir=logging_dir
             )
         self.set_config(cfg)

--- a/bittensor/utils/deprecated.py
+++ b/bittensor/utils/deprecated.py
@@ -180,6 +180,7 @@ def warning(on: bool = True):
     """
     logging.set_warning(on)
 
+
 def info(on: bool = True):
     """
     Enables or disables info logging.

--- a/bittensor/utils/deprecated.py
+++ b/bittensor/utils/deprecated.py
@@ -176,6 +176,14 @@ def warning(on: bool = True):
     """
     Enables or disables warning logging.
     Args:
-        on (bool): If True, enables warning logging. If False, disables warning logging and sets default (INFO) level.
+        on (bool): If True, enables warning logging. If False, disables warning logging and sets default (WARNING) level.
     """
     logging.set_warning(on)
+
+def info(on: bool = True):
+    """
+    Enables or disables info logging.
+    Args:
+        on (bool): If True, enables info logging. If False, disables info logging and sets default (WARNING) level.
+    """
+    logging.set_info(on)

--- a/tests/unit_tests/test_logging.py
+++ b/tests/unit_tests/test_logging.py
@@ -38,7 +38,7 @@ def mock_config(tmp_path):
     log_file_path = log_dir / DEFAULT_LOG_FILE_NAME
 
     mock_config = LoggingConfig(
-        debug=False, trace=False, record_log=True, logging_dir=str(log_dir)
+        debug=False, trace=False, info=False, record_log=True, logging_dir=str(log_dir)
     )
 
     yield mock_config, log_file_path
@@ -140,7 +140,7 @@ def test_enable_file_logging_with_new_config(tmp_path):
     log_file_path = log_dir / DEFAULT_LOG_FILE_NAME
 
     # check no file handler is created
-    config = LoggingConfig(debug=False, trace=False, record_log=True, logging_dir=None)
+    config = LoggingConfig(debug=False, trace=False, info=False, record_log=True, logging_dir=None)
     lm = LoggingMachine(config)
     assert not any(
         isinstance(handler, stdlogging.FileHandler) for handler in lm._handlers
@@ -148,7 +148,7 @@ def test_enable_file_logging_with_new_config(tmp_path):
 
     # check file handler now exists
     new_config = LoggingConfig(
-        debug=False, trace=False, record_log=True, logging_dir=str(log_dir)
+        debug=False, trace=False, info=False, record_log=True, logging_dir=str(log_dir)
     )
     lm.set_config(new_config)
     assert any(isinstance(handler, stdlogging.FileHandler) for handler in lm._handlers)

--- a/tests/unit_tests/test_logging.py
+++ b/tests/unit_tests/test_logging.py
@@ -140,7 +140,9 @@ def test_enable_file_logging_with_new_config(tmp_path):
     log_file_path = log_dir / DEFAULT_LOG_FILE_NAME
 
     # check no file handler is created
-    config = LoggingConfig(debug=False, trace=False, info=False, record_log=True, logging_dir=None)
+    config = LoggingConfig(
+        debug=False, trace=False, info=False, record_log=True, logging_dir=None
+    )
     lm = LoggingMachine(config)
     assert not any(
         isinstance(handler, stdlogging.FileHandler) for handler in lm._handlers


### PR DESCRIPTION
- Adds `--logging.info` level so it can be set. Previously we forgot to add this level when default was changed from into to warning. 
- Allows wallet to be created through configs in the axon if they are provided instead of always creating a default wallet. If no config is passed, a default wallet is created. 
- Changes verbosity level of `ClientConnectorError` and `TimeoutError` in the dendrite to debug (as it was in earlier versions to reduce spam) 
- Fixes behaviour of config initialization for axon, subtensor, logging and threadpool. 