### PR TITLE
Exit `set_weights` on success

### DIFF
--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1720,6 +1720,7 @@ class Subtensor:
         while (
             self.blocks_since_last_update(netuid, uid) > self.weights_rate_limit(netuid)  # type: ignore
             and retries < max_retries
+            and success is False
         ):
             try:
                 logging.info(


### PR DESCRIPTION
Previously `Subtensor.set_weights` did not exit on success — only exiting when `max_retries` is hit or blocks are reached.