### PR TITLE
Adds a factory function to create an initialised AsyncSubtensor object.

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -17,9 +17,18 @@
 
 import warnings
 
-from .core.settings import __version__, version_split, DEFAULTS
+from .core.settings import __version__, version_split, DEFAULTS, DEFAULT_NETWORK
+from .core.async_subtensor import AsyncSubtensor
 from .utils.btlogging import logging
 from .utils.deprecated import *
+
+
+async def async_subtensor(network: str = DEFAULT_NETWORK) -> AsyncSubtensor:
+    """
+    Creates an initialised AsyncSubtensor object.
+    """
+    async with AsyncSubtensor(network=network) as subtensor_:
+        return subtensor_
 
 
 def __getattr__(name):


### PR DESCRIPTION
Factory function for creating an already-initialised `AsyncSubtensor` object. Meaning you can do

```python
import bittensor as bt
subtensor = await bt.async_subtensor()
await subtensor.get_subnets(...
```

rather than the traditional

```python
from bittensor.core.async_subtensor import AsyncSubtensor
subtensor = AsyncSubtensor()
async with subtensor:
    await subtensor.get_subnets(...
```