### PR TITLE
Remove metadata retrieval of custom errors from format_error_message

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1184,11 +1184,9 @@ class AsyncSubtensor:
             if await response.is_success:
                 return True, ""
             else:
-                return False, format_error_message(
-                    await response.error_message, substrate=self.substrate
-                )
+                return False, format_error_message(await response.error_message)
         except SubstrateRequestException as e:
-            return False, format_error_message(e, substrate=self.substrate)
+            return False, format_error_message(e)
 
     async def get_children(self, hotkey: str, netuid: int) -> tuple[bool, list, str]:
         """
@@ -1218,7 +1216,7 @@ class AsyncSubtensor:
             else:
                 return True, [], ""
         except SubstrateRequestException as e:
-            return False, [], format_error_message(e, self.substrate)
+            return False, [], format_error_message(e)
 
     async def get_subnet_hyperparameters(
         self, netuid: int, block_hash: Optional[str] = None, reuse_block: bool = False

--- a/bittensor/core/extrinsics/async_registration.py
+++ b/bittensor/core/extrinsics/async_registration.py
@@ -85,9 +85,7 @@ async def _do_pow_register(
     # process if registration successful, try again if pow is still valid
     await response.process_events()
     if not await response.is_success:
-        return False, format_error_message(
-            error_message=await response.error_message, substrate=subtensor.substrate
-        )
+        return False, format_error_message(error_message=await response.error_message)
     # Successful registration
     else:
         return True, None

--- a/bittensor/core/extrinsics/async_root.py
+++ b/bittensor/core/extrinsics/async_root.py
@@ -171,9 +171,7 @@ async def _do_set_root_weights(
     if await response.is_success:
         return True, "Successfully set weights."
     else:
-        return False, format_error_message(
-            await response.error_message, substrate=subtensor.substrate
-        )
+        return False, format_error_message(await response.error_message)
 
 
 async def set_root_weights_extrinsic(
@@ -263,6 +261,6 @@ async def set_root_weights_extrinsic(
             return False
 
     except SubstrateRequestException as e:
-        fmt_err = format_error_message(e, subtensor.substrate)
+        fmt_err = format_error_message(e)
         logging.error(f":cross_mark: [red]Failed error:[/red] {fmt_err}")
         return False

--- a/bittensor/core/extrinsics/async_transfer.py
+++ b/bittensor/core/extrinsics/async_transfer.py
@@ -64,9 +64,7 @@ async def _do_transfer(
         return (
             False,
             "",
-            format_error_message(
-                await response.error_message, substrate=subtensor.substrate
-            ),
+            format_error_message(await response.error_message),
         )
 
 

--- a/bittensor/core/extrinsics/async_weights.py
+++ b/bittensor/core/extrinsics/async_weights.py
@@ -77,9 +77,7 @@ async def _do_set_weights(
     if await response.is_success:
         return True, "Successfully set weights."
     else:
-        return False, format_error_message(
-            response.error_message, substrate=subtensor.substrate
-        )
+        return False, format_error_message(response.error_message)
 
 
 async def set_weights_extrinsic(
@@ -206,9 +204,7 @@ async def _do_commit_weights(
     if await response.is_success:
         return True, None
     else:
-        return False, format_error_message(
-            response.error_message, substrate=subtensor.substrate
-        )
+        return False, format_error_message(response.error_message)
 
 
 async def commit_weights_extrinsic(

--- a/bittensor/core/extrinsics/commit_weights.py
+++ b/bittensor/core/extrinsics/commit_weights.py
@@ -127,9 +127,7 @@ def commit_weights_extrinsic(
         logging.info(success_message)
         return True, success_message
     else:
-        error_message = format_error_message(
-            error_message, substrate=subtensor.substrate
-        )
+        error_message = format_error_message(error_message)
         logging.error(f"Failed to commit weights: {error_message}")
         return False, error_message
 
@@ -249,8 +247,6 @@ def reveal_weights_extrinsic(
         logging.info(success_message)
         return True, success_message
     else:
-        error_message = format_error_message(
-            error_message, substrate=subtensor.substrate
-        )
+        error_message = format_error_message(error_message)
         logging.error(f"Failed to reveal weights: {error_message}")
         return False, error_message

--- a/bittensor/core/extrinsics/registration.py
+++ b/bittensor/core/extrinsics/registration.py
@@ -79,9 +79,7 @@ def _do_pow_register(
     # process if registration successful, try again if pow is still valid
     response.process_events()
     if not response.is_success:
-        return False, format_error_message(
-            response.error_message, substrate=self.substrate
-        )
+        return False, format_error_message(response.error_message)
     # Successful registration
     else:
         return True, None
@@ -310,9 +308,7 @@ def _do_burned_register(
     # process if registration successful, try again if pow is still valid
     response.process_events()
     if not response.is_success:
-        return False, format_error_message(
-            response.error_message, substrate=self.substrate
-        )
+        return False, format_error_message(response.error_message)
     # Successful registration
     else:
         return True, None

--- a/bittensor/core/extrinsics/root.py
+++ b/bittensor/core/extrinsics/root.py
@@ -46,9 +46,7 @@ def _do_root_register(
     # process if registration successful, try again if pow is still valid
     response.process_events()
     if not response.is_success:
-        return False, format_error_message(
-            response.error_message, substrate=self.substrate
-        )
+        return False, format_error_message(response.error_message)
     # Successful registration
     else:
         return True, None

--- a/bittensor/core/extrinsics/serving.py
+++ b/bittensor/core/extrinsics/serving.py
@@ -181,9 +181,7 @@ def serve_extrinsic(
             )
             return True
         else:
-            logging.error(
-                f"Failed: {format_error_message(error_message, substrate=subtensor.substrate)}"
-            )
+            logging.error(f"Failed: {format_error_message(error_message)}")
             return False
     else:
         return True
@@ -301,9 +299,7 @@ def publish_metadata(
         if response.is_success:
             return True
         else:
-            raise MetadataError(
-                format_error_message(response.error_message, substrate=self.substrate)
-            )
+            raise MetadataError(format_error_message(response.error_message))
 
 
 # Community uses this function directly

--- a/bittensor/core/extrinsics/set_weights.py
+++ b/bittensor/core/extrinsics/set_weights.py
@@ -96,9 +96,7 @@ def do_set_weights(
     if response.is_success:
         return True, "Successfully set weights."
     else:
-        return False, format_error_message(
-            response.error_message, substrate=self.substrate
-        )
+        return False, format_error_message(response.error_message)
 
 
 # Community uses this extrinsic directly and via `subtensor.set_weights`

--- a/bittensor/core/extrinsics/staking.py
+++ b/bittensor/core/extrinsics/staking.py
@@ -59,9 +59,7 @@ def _do_stake(
     if response.is_success:
         return True
     else:
-        raise StakeError(
-            format_error_message(response.error_message, substrate=self.substrate)
-        )
+        raise StakeError(format_error_message(response.error_message))
 
 
 def _check_threshold_amount(

--- a/bittensor/core/extrinsics/transfer.py
+++ b/bittensor/core/extrinsics/transfer.py
@@ -185,7 +185,7 @@ def transfer_extrinsic(
             )
     else:
         logging.error(
-            f":cross_mark: [red]Failed[/red]: {format_error_message(error_message, substrate=subtensor.substrate)}"
+            f":cross_mark: [red]Failed[/red]: {format_error_message(error_message)}"
         )
 
     if success:

--- a/bittensor/core/extrinsics/unstaking.py
+++ b/bittensor/core/extrinsics/unstaking.py
@@ -58,9 +58,7 @@ def _do_unstake(
     if response.is_success:
         return True
     else:
-        raise StakeError(
-            format_error_message(response.error_message, substrate=self.substrate)
-        )
+        raise StakeError(format_error_message(response.error_message))
 
 
 def _check_threshold_amount(subtensor: "Subtensor", stake_balance: "Balance") -> bool:

--- a/bittensor/core/extrinsics/utils.py
+++ b/bittensor/core/extrinsics/utils.py
@@ -65,9 +65,7 @@ def submit_extrinsic(
                 wait_for_finalization=wait_for_finalization,
             )
         except SubstrateRequestException as e:
-            logging.error(
-                format_error_message(e.args[0], substrate=subtensor.substrate)
-            )
+            logging.error(format_error_message(e.args[0]))
             # Re-raise the exception for retrying of the extrinsic call. If we remove the retry logic,
             # the raise will need to be removed.
             raise

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -152,17 +152,13 @@ def get_hash(content, encoding="utf-8"):
     return sha3.hexdigest()
 
 
-def format_error_message(
-    error_message: Union[dict, Exception],
-    substrate: Union["AsyncSubstrateInterface", "SubstrateInterface"],
-) -> str:
+def format_error_message(error_message: Union[dict, Exception]) -> str:
     """
     Formats an error message from the Subtensor error information for use in extrinsics.
 
     Args:
         error_message: A dictionary containing the error information from Subtensor, or a SubstrateRequestException
                        containing dictionary literal args.
-        substrate: The initialised SubstrateInterface object to use.
 
     Returns:
         str: A formatted error message string.
@@ -204,22 +200,8 @@ def format_error_message(
             err_data = error_message.get("data", "")
 
             # subtensor custom error marker
-            if err_data.startswith("Custom error:") and substrate:
-                if substrate.metadata:
-                    try:
-                        pallet = substrate.metadata.get_metadata_pallet(
-                            "SubtensorModule"
-                        )
-                        error_index = int(err_data.split("Custom error:")[-1])
-
-                        error_dict = pallet.errors[error_index].value
-                        err_type = error_dict.get("message", err_type)
-                        err_docs = error_dict.get("docs", [])
-                        err_description = err_docs[0] if err_docs else err_description
-                    except (AttributeError, IndexError):
-                        logging.error(
-                            "[red]Substrate pallets data unavailable. This is usually caused by an uninitialized substrate.[/red]"
-                        )
+            if err_data.startswith("Custom error:"):
+                err_description = f"{err_data} | Please consult https://docs.bittensor.com/subtensor-nodes/subtensor-error-messages"
             else:
                 err_description = err_data
 

--- a/tests/unit_tests/extrinsics/test__init__.py
+++ b/tests/unit_tests/extrinsics/test__init__.py
@@ -1,10 +1,9 @@
 """Tests for bittensor/extrinsics/__ini__ module."""
 
 from bittensor.utils import format_error_message
-from tests.unit_tests.extrinsics.test_commit_weights import subtensor
 
 
-def test_format_error_message_with_right_error_message(mocker):
+def test_format_error_message_with_right_error_message():
     """Verify that error message from extrinsic response parses correctly."""
     # Prep
     fake_error_message = {
@@ -14,7 +13,7 @@ def test_format_error_message_with_right_error_message(mocker):
     }
 
     # Call
-    result = format_error_message(fake_error_message, substrate=mocker.MagicMock())
+    result = format_error_message(fake_error_message)
 
     # Assertions
 
@@ -23,13 +22,13 @@ def test_format_error_message_with_right_error_message(mocker):
     assert "Some error description." in result
 
 
-def test_format_error_message_with_empty_error_message(mocker):
+def test_format_error_message_with_empty_error_message():
     """Verify that empty error message from extrinsic response parses correctly."""
     # Prep
     fake_error_message = {}
 
     # Call
-    result = format_error_message(fake_error_message, substrate=mocker.MagicMock())
+    result = format_error_message(fake_error_message)
 
     # Assertions
 
@@ -38,13 +37,13 @@ def test_format_error_message_with_empty_error_message(mocker):
     assert "Unknown Description" in result
 
 
-def test_format_error_message_with_wrong_type_error_message(mocker):
+def test_format_error_message_with_wrong_type_error_message():
     """Verify that error message from extrinsic response with wrong type parses correctly."""
     # Prep
     fake_error_message = None
 
     # Call
-    result = format_error_message(fake_error_message, substrate=mocker.MagicMock())
+    result = format_error_message(fake_error_message)
 
     # Assertions
 
@@ -53,7 +52,7 @@ def test_format_error_message_with_wrong_type_error_message(mocker):
     assert "Unknown Description" in result
 
 
-def test_format_error_message_with_custom_error_message_with_index(mocker):
+def test_format_error_message_with_custom_error_message_with_index():
     """Tests error formatter if subtensor error is custom error with index."""
     # Preps
     fake_custom_error = {
@@ -68,28 +67,19 @@ def test_format_error_message_with_custom_error_message_with_index(mocker):
         "name": "SomeErrorName",
     }
 
-    fake_substrate = mocker.MagicMock()
-    fake_substrate.metadata.get_metadata_pallet().errors.__getitem__().value.get = (
-        mocker.Mock(
-            side_effect=[fake_custom_error["message"], fake_subtensor_error["docs"]]
-        )
-    )
-
-    mocker.patch(
-        "substrateinterface.base.SubstrateInterface", return_value=fake_substrate
-    )
-
     # Call
-    result = format_error_message(fake_custom_error, fake_substrate)
+    result = format_error_message(fake_custom_error)
 
     # Assertions
     assert (
         result
-        == f"Subtensor returned `SubstrateRequestException({fake_subtensor_error['name']})` error. This means: `Some description`."
+        == f"Subtensor returned `SubstrateRequestException({fake_subtensor_error['name']})` error. This means: "
+        f"`{fake_custom_error['data']} | Please consult "
+        f"https://docs.bittensor.com/subtensor-nodes/subtensor-error-messages`."
     )
 
 
-def test_format_error_message_with_custom_error_message_without_index(mocker):
+def test_format_error_message_with_custom_error_message_without_index():
     """Tests error formatter if subtensor error is custom error without index."""
     # Preps
     fake_custom_error = {
@@ -97,19 +87,13 @@ def test_format_error_message_with_custom_error_message_without_index(mocker):
         "message": "SomeErrorType",
         "data": "Custom error description",
     }
-    fake_substrate = mocker.MagicMock()
-    fake_substrate.metadata.get_metadata_pallet().errors.__getitem__().value.get.return_value = fake_custom_error[
-        "message"
-    ]
-    mocker.patch(
-        "substrateinterface.base.SubstrateInterface", return_value=fake_substrate
-    )
 
     # Call
-    result = format_error_message(fake_custom_error, fake_substrate)
+    result = format_error_message(fake_custom_error)
 
     # Assertions
     assert (
         result
-        == f"Subtensor returned `SubstrateRequestException({fake_custom_error['message']})` error. This means: `{fake_custom_error['data']}`."
+        == f"Subtensor returned `SubstrateRequestException({fake_custom_error['message']})` error. This means: "
+        f"`{fake_custom_error['data']}`."
     )

--- a/tests/unit_tests/extrinsics/test_async_registration.py
+++ b/tests/unit_tests/extrinsics/test_async_registration.py
@@ -128,9 +128,7 @@ async def test_do_pow_register_failure(subtensor, mocker):
         extrinsic=fake_extrinsic, wait_for_inclusion=True, wait_for_finalization=True
     )
 
-    mocked_format_error_message.assert_called_once_with(
-        error_message=fake_err_message, substrate=subtensor.substrate
-    )
+    mocked_format_error_message.assert_called_once_with(error_message=fake_err_message)
     assert result_error_message == (False, mocked_format_error_message.return_value)
 
 

--- a/tests/unit_tests/extrinsics/test_async_transfer.py
+++ b/tests/unit_tests/extrinsics/test_async_transfer.py
@@ -125,9 +125,7 @@ async def test_do_transfer_failure(subtensor, mocker):
     )
     assert success is False
     assert block_hash == ""
-    mocked_format_error_message.assert_called_once_with(
-        "Fake error message", substrate=subtensor.substrate
-    )
+    mocked_format_error_message.assert_called_once_with("Fake error message")
     assert error_message == "Formatted error message"
 
 

--- a/tests/unit_tests/extrinsics/test_async_weights.py
+++ b/tests/unit_tests/extrinsics/test_async_weights.py
@@ -108,9 +108,7 @@ async def test_do_set_weights_failure(subtensor, mocker):
 
     # Asserts
     assert result is False
-    mocked_format_error_message.assert_called_once_with(
-        fake_response.error_message, substrate=subtensor.substrate
-    )
+    mocked_format_error_message.assert_called_once_with(fake_response.error_message)
     assert message == mocked_format_error_message.return_value
 
 
@@ -412,9 +410,7 @@ async def test_do_commit_weights_failure(subtensor, mocker):
 
     # Asserts
     assert result is False
-    mocked_format_error_message.assert_called_once_with(
-        fake_response.error_message, substrate=subtensor.substrate
-    )
+    mocked_format_error_message.assert_called_once_with(fake_response.error_message)
     assert message == "Formatted error"
 
 

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -1951,9 +1951,7 @@ async def test_get_children_substrate_request_exception(subtensor, mocker):
         storage_function="ChildKeys",
         params=[fake_hotkey, fake_netuid],
     )
-    mocked_format_error_message.assert_called_once_with(
-        fake_exception, subtensor.substrate
-    )
+    mocked_format_error_message.assert_called_once_with(fake_exception)
     assert result == (False, [], "Formatted error message")
 
 


### PR DESCRIPTION
Because it didn't actually pull the correct data.