### PR TITLE
Remove torch from the weights calls

### DIFF
--- a/bittensor/core/extrinsics/async_weights.py
+++ b/bittensor/core/extrinsics/async_weights.py
@@ -9,11 +9,11 @@ import bittensor.utils.weight_utils as weight_utils
 from bittensor.core.settings import version_as_int
 from bittensor.utils import format_error_message
 from bittensor.utils.btlogging import logging
-from bittensor.utils.registration import torch, use_torch
 
 if TYPE_CHECKING:
     from bittensor_wallet import Wallet
     from bittensor.core.async_subtensor import AsyncSubtensor
+    from bittensor.utils.registration import torch
 
 
 async def _do_set_weights(
@@ -106,16 +106,10 @@ async def set_weights_extrinsic(
         success (bool): Flag is ``true`` if extrinsic was finalized or included in the block. If we did not wait for finalization / inclusion, the response is ``true``.
     """
     # First convert types.
-    if use_torch():
-        if isinstance(uids, list):
-            uids = torch.tensor(uids, dtype=torch.int64)
-        if isinstance(weights, list):
-            weights = torch.tensor(weights, dtype=torch.float32)
-    else:
-        if isinstance(uids, list):
-            uids = np.array(uids, dtype=np.int64)
-        if isinstance(weights, list):
-            weights = np.array(weights, dtype=np.float32)
+    if isinstance(uids, list):
+        uids = np.array(uids, dtype=np.int64)
+    if isinstance(weights, list):
+        weights = np.array(weights, dtype=np.float32)
 
     # Reformat and normalize.
     weight_uids, weight_vals = weight_utils.convert_weights_and_uids_for_emit(

--- a/bittensor/core/extrinsics/commit_reveal.py
+++ b/bittensor/core/extrinsics/commit_reveal.py
@@ -9,12 +9,12 @@ from bittensor.core.settings import version_as_int
 from bittensor.utils import format_error_message
 from bittensor.utils.btlogging import logging
 from bittensor.utils.networking import ensure_connected
-from bittensor.utils.registration import torch, use_torch
 from bittensor.utils.weight_utils import convert_weights_and_uids_for_emit
 
 if TYPE_CHECKING:
     from bittensor_wallet import Wallet
     from bittensor.core.subtensor import Subtensor
+    from bittensor.utils.registration import torch
 
 
 @ensure_connected
@@ -105,16 +105,10 @@ def commit_reveal_v3_extrinsic(
     """
     try:
         # Convert uids and weights
-        if use_torch():
-            if isinstance(uids, list):
-                uids = torch.tensor(uids, dtype=torch.int64)
-            if isinstance(weights, list):
-                weights = torch.tensor(weights, dtype=torch.float32)
-        else:
-            if isinstance(uids, list):
-                uids = np.array(uids, dtype=np.int64)
-            if isinstance(weights, list):
-                weights = np.array(weights, dtype=np.float32)
+        if isinstance(uids, list):
+            uids = np.array(uids, dtype=np.int64)
+        if isinstance(weights, list):
+            weights = np.array(weights, dtype=np.float32)
 
         # Reformat and normalize.
         uids, weights = convert_weights_and_uids_for_emit(uids, weights)

--- a/tests/unit_tests/extrinsics/test_async_weights.py
+++ b/tests/unit_tests/extrinsics/test_async_weights.py
@@ -279,42 +279,6 @@ async def test_set_weights_extrinsic_exception(subtensor, mocker):
 
 
 @pytest.mark.asyncio
-async def test_set_weights_extrinsic_if_use_torch(subtensor, mocker):
-    """Tests set_weights_extrinsic when use_torch is True."""
-    # Preps
-    fake_wallet = mocker.Mock(autospec=Wallet)
-    fake_netuid = 1
-    fake_uids = [1, 2, 3]
-    fake_weights = [0.1, 0.2, 0.7]
-
-    mocked_do_set_weights = mocker.patch.object(
-        async_weights, "_do_set_weights", return_value=(False, "Test error message")
-    )
-    mocked_convert_weights_and_uids_for_emit = mocker.patch.object(
-        async_weights.weight_utils,
-        "convert_weights_and_uids_for_emit",
-        return_value=(mocker.Mock(), mocker.Mock()),
-    )
-
-    # Call
-    result, message = await async_weights.set_weights_extrinsic(
-        subtensor=subtensor,
-        wallet=fake_wallet,
-        netuid=fake_netuid,
-        uids=fake_uids,
-        weights=fake_weights,
-        wait_for_inclusion=True,
-        wait_for_finalization=True,
-    )
-
-    # Asserts
-    mocked_do_set_weights.assert_called_once()
-    mocked_convert_weights_and_uids_for_emit.assert_called()
-    assert result is False
-    assert message == "Test error message"
-
-
-@pytest.mark.asyncio
 async def test_do_commit_weights_success(subtensor, mocker):
     """Tests _do_commit_weights when the commit is successful."""
     # Preps

--- a/tests/unit_tests/extrinsics/test_async_weights.py
+++ b/tests/unit_tests/extrinsics/test_async_weights.py
@@ -279,53 +279,6 @@ async def test_set_weights_extrinsic_exception(subtensor, mocker):
 
 
 @pytest.mark.asyncio
-async def test_set_weights_extrinsic_if_use_torch(subtensor, mocker):
-    """Tests set_weights_extrinsic when use_torch is True."""
-    # Preps
-    fake_wallet = mocker.Mock(autospec=Wallet)
-    fake_netuid = 1
-    fake_uids = [1, 2, 3]
-    fake_weights = [0.1, 0.2, 0.7]
-
-    mocked_use_torch = mocker.patch.object(
-        async_weights, "use_torch", return_value=True
-    )
-    mocked_torch_tensor = mocker.patch.object(
-        async_weights.torch, "tensor", return_value=mocker.Mock()
-    )
-
-    mocked_do_set_weights = mocker.patch.object(
-        async_weights, "_do_set_weights", return_value=(False, "Test error message")
-    )
-    mocked_convert_weights_and_uids_for_emit = mocker.patch.object(
-        async_weights.weight_utils,
-        "convert_weights_and_uids_for_emit",
-        return_value=(mocker.Mock(), mocker.Mock()),
-    )
-
-    # Call
-    result, message = await async_weights.set_weights_extrinsic(
-        subtensor=subtensor,
-        wallet=fake_wallet,
-        netuid=fake_netuid,
-        uids=fake_uids,
-        weights=fake_weights,
-        wait_for_inclusion=True,
-        wait_for_finalization=True,
-    )
-
-    # Asserts
-    mocked_do_set_weights.assert_called_once()
-    mocked_use_torch.assert_called_once()
-    mocked_convert_weights_and_uids_for_emit.assert_called()
-    mocked_torch_tensor.assert_called_with(
-        fake_weights, dtype=async_weights.torch.float32
-    )
-    assert result is False
-    assert message == "Test error message"
-
-
-@pytest.mark.asyncio
 async def test_do_commit_weights_success(subtensor, mocker):
     """Tests _do_commit_weights when the commit is successful."""
     # Preps

--- a/tests/unit_tests/extrinsics/test_async_weights.py
+++ b/tests/unit_tests/extrinsics/test_async_weights.py
@@ -279,6 +279,42 @@ async def test_set_weights_extrinsic_exception(subtensor, mocker):
 
 
 @pytest.mark.asyncio
+async def test_set_weights_extrinsic_if_use_torch(subtensor, mocker):
+    """Tests set_weights_extrinsic when use_torch is True."""
+    # Preps
+    fake_wallet = mocker.Mock(autospec=Wallet)
+    fake_netuid = 1
+    fake_uids = [1, 2, 3]
+    fake_weights = [0.1, 0.2, 0.7]
+
+    mocked_do_set_weights = mocker.patch.object(
+        async_weights, "_do_set_weights", return_value=(False, "Test error message")
+    )
+    mocked_convert_weights_and_uids_for_emit = mocker.patch.object(
+        async_weights.weight_utils,
+        "convert_weights_and_uids_for_emit",
+        return_value=(mocker.Mock(), mocker.Mock()),
+    )
+
+    # Call
+    result, message = await async_weights.set_weights_extrinsic(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=fake_netuid,
+        uids=fake_uids,
+        weights=fake_weights,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+    )
+
+    # Asserts
+    mocked_do_set_weights.assert_called_once()
+    mocked_convert_weights_and_uids_for_emit.assert_called()
+    assert result is False
+    assert message == "Test error message"
+
+
+@pytest.mark.asyncio
 async def test_do_commit_weights_success(subtensor, mocker):
     """Tests _do_commit_weights when the commit is successful."""
     # Preps

--- a/tests/unit_tests/extrinsics/test_commit_reveal.py
+++ b/tests/unit_tests/extrinsics/test_commit_reveal.py
@@ -150,81 +150,6 @@ def test_do_commit_reveal_v3_failure_due_to_error(mocker, subtensor):
     assert result == (False, "Formatted error")
 
 
-def test_commit_reveal_v3_extrinsic_success_with_torch(mocker, subtensor, hyperparams):
-    """Test successful commit-reveal with torch tensors."""
-    # Preps
-    fake_wallet = mocker.Mock(autospec=subtensor_module.Wallet)
-    fake_netuid = 1
-    fake_uids = torch.tensor([1, 2, 3], dtype=torch.int64)
-    fake_weights = torch.tensor([0.1, 0.2, 0.7], dtype=torch.float32)
-    fake_commit_for_reveal = b"mock_commit_for_reveal"
-    fake_reveal_round = 1
-
-    # Mocks
-    mocker.patch.object(commit_reveal, "use_torch", return_value=True)
-
-    mocked_uids = mocker.Mock()
-    mocked_weights = mocker.Mock()
-    mocked_convert_weights_and_uids_for_emit = mocker.patch.object(
-        commit_reveal,
-        "convert_weights_and_uids_for_emit",
-        return_value=(mocked_uids, mocked_weights),
-    )
-    mocked_get_subnet_reveal_period_epochs = mocker.patch.object(
-        subtensor, "get_subnet_reveal_period_epochs"
-    )
-    mocked_get_encrypted_commit = mocker.patch.object(
-        commit_reveal,
-        "get_encrypted_commit",
-        return_value=(fake_commit_for_reveal, fake_reveal_round),
-    )
-    mock_do_commit_reveal_v3 = mocker.patch.object(
-        commit_reveal, "_do_commit_reveal_v3", return_value=(True, "Success")
-    )
-    mock_block = mocker.patch.object(subtensor, "get_current_block", return_value=1)
-    mock_hyperparams = mocker.patch.object(
-        subtensor,
-        "get_subnet_hyperparameters",
-        return_value=hyperparams,
-    )
-
-    # Call
-    success, message = commit_reveal.commit_reveal_v3_extrinsic(
-        subtensor=subtensor,
-        wallet=fake_wallet,
-        netuid=fake_netuid,
-        uids=fake_uids,
-        weights=fake_weights,
-        wait_for_inclusion=True,
-        wait_for_finalization=True,
-    )
-
-    # Asserts
-    assert success is True
-    assert message == "reveal_round:1"
-    mocked_convert_weights_and_uids_for_emit.assert_called_once_with(
-        fake_uids, fake_weights
-    )
-    mocked_get_encrypted_commit.assert_called_once_with(
-        uids=mocked_uids,
-        weights=mocked_weights,
-        subnet_reveal_period_epochs=mock_hyperparams.return_value.commit_reveal_weights_interval,
-        version_key=commit_reveal.version_as_int,
-        tempo=mock_hyperparams.return_value.tempo,
-        netuid=fake_netuid,
-        current_block=mock_block.return_value,
-    )
-    mock_do_commit_reveal_v3.assert_called_once_with(
-        self=subtensor,
-        wallet=fake_wallet,
-        netuid=fake_netuid,
-        commit=fake_commit_for_reveal,
-        reveal_round=fake_reveal_round,
-        wait_for_inclusion=True,
-        wait_for_finalization=True,
-    )
-
-
 def test_commit_reveal_v3_extrinsic_success_with_numpy(mocker, subtensor, hyperparams):
     """Test successful commit-reveal with numpy arrays."""
     # Preps
@@ -233,7 +158,6 @@ def test_commit_reveal_v3_extrinsic_success_with_numpy(mocker, subtensor, hyperp
     fake_uids = np.array([1, 2, 3], dtype=np.int64)
     fake_weights = np.array([0.1, 0.2, 0.7], dtype=np.float32)
 
-    mocker.patch.object(commit_reveal, "use_torch", return_value=False)
     mock_convert = mocker.patch.object(
         commit_reveal,
         "convert_weights_and_uids_for_emit",
@@ -282,7 +206,6 @@ def test_commit_reveal_v3_extrinsic_response_false(mocker, subtensor, hyperparam
     fake_reveal_round = 1
 
     # Mocks
-    mocker.patch.object(commit_reveal, "use_torch", return_value=True)
     mocker.patch.object(
         commit_reveal,
         "convert_weights_and_uids_for_emit",


### PR DESCRIPTION
Remove torch from the weights calls, as the legacy torch support here serves no purpose.