### PR TITLE
Use apt-get instead of apt for scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ LABEL bittensor.image.authors="bittensor.com" \
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Update the base image
-RUN apt update && apt upgrade -y
+RUN apt-get update && apt-get upgrade -y
 # Install bittensor
 ## Install dependencies
-RUN apt install -y curl sudo nano git htop netcat-openbsd wget unzip tmux apt-utils cmake build-essential
+RUN apt-get install -y curl sudo nano git htop netcat-openbsd wget unzip tmux apt-utils cmake build-essential
 ## Upgrade pip
 RUN pip3 install --upgrade pip
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -175,9 +175,9 @@ mac_install_bittensor() {
 OS="$(uname)"
 if [[ "$OS" == "Linux" ]]; then
 
-    which -s apt
+    which -s apt-get
     if [[ $? == 0 ]] ; then
-        abort "This linux based install requires apt. To run with other distros (centos, arch, etc), you will need to manually install the requirements"
+        abort "This linux based install requires apt-get. To run with other distros (centos, arch, etc), you will need to manually install the requirements"
     fi
     echo """
     


### PR DESCRIPTION
This PR changes the Dockerfile and the install script to only use `apt-get` instead of `apt`.

`apt` is meant to be used interactively, so this use is better suited to `apt-get`