### PR TITLE
Fix spelling errors

### DIFF
--- a/bittensor/core/extrinsics/commit_reveal.py
+++ b/bittensor/core/extrinsics/commit_reveal.py
@@ -145,7 +145,7 @@ def commit_reveal_v3_extrinsic(
 
         if success is True:
             logging.success(
-                f"[green]Finalized![/green] Weights commited with reveal round [blue]{reveal_round}[/blue]."
+                f"[green]Finalized![/green] Weights committed with reveal round [blue]{reveal_round}[/blue]."
             )
             return True, f"reveal_round:{reveal_round}"
         else:

--- a/bittensor/utils/networking.py
+++ b/bittensor/utils/networking.py
@@ -34,7 +34,7 @@ def int_to_ip(int_val: int) -> str:
 def ip_to_int(str_val: str) -> int:
     """Maps an ip-string to a unique integer.
     arg:
-        str_val (:tyep:`str`, `required):
+        str_val (:type:`str`, `required):
             The string representation of an ip. Of form *.*.*.* for ipv4 or *::*:*:*:* for ipv6
 
     Returns:
@@ -51,7 +51,7 @@ def ip_to_int(str_val: str) -> int:
 def ip_version(str_val: str) -> int:
     """Returns the ip version (IPV4 or IPV6).
     arg:
-        str_val (:tyep:`str`, `required):
+        str_val (:type:`str`, `required):
             The string representation of an ip. Of form *.*.*.* for ipv4 or *::*:*:*:* for ipv6
 
     Returns:


### PR DESCRIPTION
- Fixed spelling mistake: "commited" to "committed" in `commit_reveal.py`.
- Corrected the typo "tyep" to "type" in `networking.py`.
