### PR TITLE
fix(2188): don't allow uvicorn to reconfigure event_loop_policy

### DIFF
--- a/bittensor/core/axon.py
+++ b/bittensor/core/axon.py
@@ -377,7 +377,11 @@ class Axon:
         self.app = FastAPI()
         log_level = "trace" if logging.__trace_on__ else "critical"
         self.fast_config = uvicorn.Config(
-            self.app, host="0.0.0.0", port=self.config.axon.port, log_level=log_level
+            self.app,
+            host="0.0.0.0",
+            log_level=log_level,
+            loop="none",
+            port=self.config.axon.port,
         )
         self.fast_server = FastAPIThreadedServer(config=self.fast_config)
         self.router = APIRouter()


### PR DESCRIPTION
### Bug

https://github.com/opentensor/bittensor/issues/2188

### Description of the Change

Pass `loop="none"` to actually not allow uvicorn to set up event loop policy and use our default (at the moment asyncio patched with nest_asyncio)

### Alternate Designs

Patching `uvicorn` (with `uvloop`) to be `nest_asyncio` compatible.

### Possible Drawbacks

None

### Verification Process

Running unittests & launching Axon (with and without `uvloop` package installed) to see accepting incoming requests.

### Release Notes

- Configure uvicorn to reuse process' event loop policy