### PR TITLE
Fix spelling error in `networking.py`, `commit_reveal.py`, `async_commit_reveal.py`, and `test_commit_weights.py`

### DIFF
--- a/bittensor/core/extrinsics/async_commit_reveal.py
+++ b/bittensor/core/extrinsics/async_commit_reveal.py
@@ -143,7 +143,7 @@ async def commit_reveal_v3_extrinsic(
             return False, message
 
         logging.success(
-            f"[green]Finalized![/green] Weights commited with reveal round [blue]{reveal_round}[/blue]."
+            f"[green]Finalized![/green] Weights committed with reveal round [blue]{reveal_round}[/blue]."
         )
         return True, f"reveal_round:{reveal_round}"
 

--- a/bittensor/core/extrinsics/commit_reveal.py
+++ b/bittensor/core/extrinsics/commit_reveal.py
@@ -145,7 +145,7 @@ def commit_reveal_v3_extrinsic(
 
         if success is True:
             logging.success(
-                f"[green]Finalized![/green] Weights commited with reveal round [blue]{reveal_round}[/blue]."
+                f"[green]Finalized![/green] Weights committed with reveal round [blue]{reveal_round}[/blue]."
             )
             return True, f"reveal_round:{reveal_round}"
         else:

--- a/bittensor/utils/networking.py
+++ b/bittensor/utils/networking.py
@@ -34,7 +34,7 @@ def int_to_ip(int_val: int) -> str:
 def ip_to_int(str_val: str) -> int:
     """Maps an ip-string to a unique integer.
     arg:
-        str_val (:tyep:`str`, `required):
+        str_val (:type:`str`, `required):
             The string representation of an ip. Of form *.*.*.* for ipv4 or *::*:*:*:* for ipv6
 
     Returns:
@@ -51,7 +51,7 @@ def ip_to_int(str_val: str) -> int:
 def ip_version(str_val: str) -> int:
     """Returns the ip version (IPV4 or IPV6).
     arg:
-        str_val (:tyep:`str`, `required):
+        str_val (:type:`str`, `required):
             The string representation of an ip. Of form *.*.*.* for ipv4 or *::*:*:*:* for ipv6
 
     Returns:

--- a/tests/e2e_tests/test_commit_weights.py
+++ b/tests/e2e_tests/test_commit_weights.py
@@ -179,7 +179,7 @@ async def test_commit_and_reveal_weights_legacy(local_chain):
 @pytest.mark.asyncio
 async def test_commit_weights_uses_next_nonce(local_chain):
     """
-    Tests that commiting weights doesn't re-use a nonce in the transaction pool.
+    Tests that committing weights doesn't re-use a nonce in the transaction pool.
 
     Steps:
         1. Register a subnet through Alice


### PR DESCRIPTION
- **`async_commit_reveal.py` & `commit_reveal.py`**
  - Fixed typo in log message:  
    - `Weights commited` → `Weights committed`.

- **`networking.py`**
  - Fixed incorrect docstring type annotation:  
    - `:tyep:` → `:type:`.

- **`test_commit_weights.py`**
  - Fixed typo in a test docstring:  
    - `commiting` → `committing`.
