### PR TITLE
Changes the logging level for unexpected header keys to trace

### DIFF
--- a/bittensor/core/synapse.py
+++ b/bittensor/core/synapse.py
@@ -808,7 +808,8 @@ class Synapse(BaseModel):
                     logging.error(f"Error while parsing 'input_obj' header {key}: {e}")
                     continue
             else:
-                logging.warning(f"Unexpected header key encountered: {key}")
+                # setting this to warning fills up logs unnecessarily
+                logging.trace(f"Unexpected header key encountered: {key}")
 
         # Assign the remaining known headers directly
         inputs_dict["timeout"] = headers.get("timeout", None)


### PR DESCRIPTION
It was recently changed to warning, but we've received complaints that this fills up logs.