### PR TITLE
Alpha str formatting

### DIFF
--- a/bittensor/utils/balance.py
+++ b/bittensor/utils/balance.py
@@ -53,8 +53,13 @@ class Balance:
         return self.tao
 
     def __str__(self):
-        """Returns the Balance object as a string in the format "symbolvalue", where the value is in tao."""
-        return f"{self.unit}{float(self.tao):,.9f}"
+        """
+        Returns the Balance object as a string in the format "symbolvalue", where the value is in tao.
+        """
+        if self.unit == units[0]:
+            return f"{self.unit}{float(self.tao):,.9f}"
+        else:
+            return f"\u200e{float(self.tao):,.9f}{self.unit}\u200e"
 
     def __rich__(self):
         int_tao, fract_tao = format(float(self.tao), "f").split(".")


### PR DESCRIPTION
Ensures that alpha symbols are always rendered to the right of the value, by adding the unicode embedding for left-to-right formatting to the `__str__` of Balance.