### PR TITLE
Add method for fetching all Neuron Certificates on a Netuid

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1504,6 +1504,7 @@ class AsyncSubtensor(SubtensorMixin):
         query_certificates = await self.query_map(
             module="SubtensorModule",
             name="NeuronCertificates",
+            params=[netuid],
             block=block,
             block_hash=block_hash,
             reuse_block=reuse_block,

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1479,6 +1479,40 @@ class AsyncSubtensor(SubtensorMixin):
             return None
         return None
 
+    async def get_all_neuron_certificates(
+        self,
+        netuid: int,
+        block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        reuse_block: bool = False,
+    ) -> dict[str, Certificate]:
+        """
+        Retrieves the TLS certificates for neurons within a specified subnet (netuid) of the Bittensor network.
+
+        Arguments:
+            netuid: The unique identifier of the subnet.
+            block: The blockchain block number for the query.
+            block_hash: The hash of the block to retrieve the parameter from. Do not specify if using block or
+                reuse_block.
+            reuse_block: Whether to use the last-used block. Do not set if using block_hash or block.
+
+        Returns:
+            {ss58: Certificate} for the key/Certificate pairs on the subnet
+
+        This function is used for certificate discovery for setting up mutual tls communication between neurons.
+        """
+        query_certificates = await self.query_map(
+            module="SubtensorModule",
+            name="NeuronCertificates",
+            block=block,
+            block_hash=block_hash,
+            reuse_block=reuse_block,
+        )
+        output = {}
+        async for key, item in query_certificates:
+            output[decode_account_id(key)] = Certificate(item.value)
+        return output
+
     async def get_neuron_for_pubkey_and_subnet(
         self,
         hotkey_ss58: str,

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1123,6 +1123,31 @@ class Subtensor(SubtensorMixin):
             return None
         return None
 
+    def get_all_neuron_certificates(
+        self, netuid: int, block: Optional[int] = None
+    ) -> dict[str, Certificate]:
+        """
+        Retrieves the TLS certificates for neurons within a specified subnet (netuid) of the Bittensor network.
+
+        Arguments:
+            netuid: The unique identifier of the subnet.
+            block: The blockchain block number for the query.
+
+        Returns:
+            {ss58: Certificate} for the key/Certificate pairs on the subnet
+
+        This function is used for certificate discovery for setting up mutual tls communication between neurons.
+        """
+        query_certificates = self.query_map(
+            module="SubtensorModule",
+            name="NeuronCertificates",
+            block=block,
+        )
+        output = {}
+        for key, item in query_certificates:
+            output[decode_account_id(key)] = Certificate(item.value)
+        return output
+
     def get_neuron_for_pubkey_and_subnet(
         self, hotkey_ss58: str, netuid: int, block: Optional[int] = None
     ) -> Optional["NeuronInfo"]:

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1141,6 +1141,7 @@ class Subtensor(SubtensorMixin):
         query_certificates = self.query_map(
             module="SubtensorModule",
             name="NeuronCertificates",
+            params=[netuid],
             block=block,
         )
         output = {}

--- a/tests/e2e_tests/test_neuron_certificate.py
+++ b/tests/e2e_tests/test_neuron_certificate.py
@@ -47,5 +47,8 @@ async def test_neuron_certificate(subtensor, alice_wallet):
         )
         == encoded_certificate
     )
+    all_certs_query = subtensor.get_all_neuron_certificates(netuid=netuid)
+    assert alice_wallet.hotkey.ss58_address in all_certs_query.keys()
+    assert all_certs_query[alice_wallet.hotkey.ss58_address] == encoded_certificate
 
     logging.info("✅ Passed test_neuron_certificate")

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -2676,3 +2676,18 @@ async def test_set_subnet_identity(mocker, subtensor):
         wait_for_inclusion=False,
     )
     assert result == mocked_extrinsic.return_value
+
+
+@pytest.mark.asyncio
+async def test_get_all_neuron_certificates(mocker, subtensor):
+    fake_netuid = 12
+    mocked_query_map_subtensor = mocker.AsyncMock()
+    mocker.patch.object(subtensor.substrate, "query_map", mocked_query_map_subtensor)
+    await subtensor.get_all_neuron_certificates(fake_netuid)
+    mocked_query_map_subtensor.assert_called_once_with(
+        module="SubtensorModule",
+        storage_function="NeuronCertificates",
+        params=[fake_netuid],
+        block_hash=None,
+        reuse_block_hash=False,
+    )

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -2684,7 +2684,7 @@ async def test_get_all_neuron_certificates(mocker, subtensor):
     mocked_query_map_subtensor = mocker.AsyncMock()
     mocker.patch.object(subtensor.substrate, "query_map", mocked_query_map_subtensor)
     await subtensor.get_all_neuron_certificates(fake_netuid)
-    mocked_query_map_subtensor.assert_called_once_with(
+    mocked_query_map_subtensor.assert_awaited_once_with(
         module="SubtensorModule",
         storage_function="NeuronCertificates",
         params=[fake_netuid],

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -3084,3 +3084,16 @@ def test_set_subnet_identity(mocker, subtensor):
         wait_for_inclusion=False,
     )
     assert result == mocked_extrinsic.return_value
+
+
+def test_get_all_neuron_certificates(mocker, subtensor):
+    fake_netuid = 12
+    mocked_query_map_subtensor = mocker.MagicMock()
+    mocker.patch.object(subtensor.substrate, "query_map", mocked_query_map_subtensor)
+    subtensor.get_all_neuron_certificates(fake_netuid)
+    mocked_query_map_subtensor.assert_called_once_with(
+        module="SubtensorModule",
+        storage_function="NeuronCertificates",
+        params=[fake_netuid],
+        block_hash=None,
+    )


### PR DESCRIPTION
Adds methods for retrieving all neuron certificates on a netuid (`get_all_neuron_certificates`) to `Subtensor` and `AsyncSubtensor`