### PR TITLE
Refactor AsyncSubtensor aenter logic

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -173,8 +173,8 @@ class AsyncSubtensor(SubtensorMixin):
             f"[magenta]Connecting to Substrate:[/magenta] [blue]{self}[/blue][magenta]...[/magenta]"
         )
         try:
-            async with self.substrate:
-                return self
+            await self.substrate.initialize()
+            return self
         except TimeoutError:
             logging.error(
                 f"[red]Error[/red]: Timeout occurred connecting to substrate."

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -144,7 +144,7 @@ async def test_async_subtensor_aenter_connection_refused_error(
     # Preps
     fake_async_substrate = mocker.AsyncMock(
         autospec=async_subtensor.AsyncSubstrateInterface,
-        __aenter__=mocker.AsyncMock(side_effect=error),
+        initialize=mocker.AsyncMock(side_effect=error),
     )
     mocker.patch.object(
         async_subtensor, "AsyncSubstrateInterface", return_value=fake_async_substrate
@@ -157,7 +157,7 @@ async def test_async_subtensor_aenter_connection_refused_error(
             pass
 
     # Asserts
-    fake_async_substrate.__aenter__.assert_called_once()
+    fake_async_substrate.initialize.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -157,7 +157,7 @@ async def test_async_subtensor_aenter_connection_refused_error(
             pass
 
     # Asserts
-    fake_async_substrate.initialize.assert_called_once()
+    fake_async_substrate.initialize.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -128,9 +128,8 @@ async def test_async_subtensor_magic_methods(mocker):
         pass
 
     # Asserts
-    fake_async_substrate.__aenter__.assert_called_once()
-    fake_async_substrate.__aexit__.assert_called_once()
-    fake_async_substrate.close.assert_awaited_once()
+    fake_async_substrate.initialize.assert_called_once()
+    fake_async_substrate.close.assert_called_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Refactored the logic of `__aenter__` for `AsyncSubtensor` so that it doesn't close the websocket immediately. 