### PR TITLE
CI: Upgrade rust compiler for E2E tests

### DIFF
--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -52,7 +52,7 @@ jobs:
       max-parallel: 8  # Set the maximum number of parallel jobs
       matrix:
         rust-branch:
-          - nightly-2024-03-05
+          - stable
         rust-target:
           - x86_64-unknown-linux-gnu
         os:


### PR DESCRIPTION
> *** Building substrate binary...
> error: failed to parse manifest at /home/runner/work/bittensor/bittensor/subtensor/Cargo.toml
> Caused by:
> feature edition2024 is required
> The package requires the Cargo feature called edition2024, but that feature is not stabilized in this version of Cargo (1.84.1 (66221abde 2024-11-19)).
> Consider trying a newer version of Cargo (this may require the nightly release).
> See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.