### PR TITLE
Use `.value` in e2e test

### DIFF
--- a/tests/e2e_tests/test_set_weights.py
+++ b/tests/e2e_tests/test_set_weights.py
@@ -128,7 +128,7 @@ async def test_set_weights_uses_next_nonce(local_chain, subtensor, alice_wallet)
             module="SubtensorModule",
             name="Weights",
             params=[netuid, 0],  # Alice should be the only UID
-        )
+        ).value
 
         assert weights is not None, f"Weights not found for subnet {netuid}"
         assert weights == list(


### PR DESCRIPTION
We miss using `.value` on a `ScaleObj` in the e2e tests.