### PR TITLE
Dendrite `__del__` method fix

### DIFF
--- a/bittensor/core/dendrite.py
+++ b/bittensor/core/dendrite.py
@@ -877,7 +877,10 @@ class DendriteMixin:
             # ... some operations ...
             del dendrite  # This will implicitly invoke the __del__ method and close the session.
         """
-        self.close_session()
+        try:
+            self.close_session()
+        except RuntimeError:
+            pass
 
 
 # For back-compatibility with torch

--- a/bittensor/core/dendrite.py
+++ b/bittensor/core/dendrite.py
@@ -880,7 +880,11 @@ class DendriteMixin:
         try:
             self.close_session()
         except RuntimeError:
-            pass
+            if self._session:
+                logging.debug(
+                    "A Dendrite session was unable to be closed during garbage-collection of the Dendrite object. This "
+                    "usually indicates that you were not using the async context manager."
+                )
 
 
 # For back-compatibility with torch

--- a/tests/unit_tests/test_dendrite.py
+++ b/tests/unit_tests/test_dendrite.py
@@ -83,6 +83,17 @@ def test_close(setup_dendrite, setup_axon):
     assert setup_dendrite._session is None
 
 
+def test_garbage_collection(setup_dendrite):
+    del setup_dendrite  # should not raise an error
+
+
+@pytest.mark.asyncio
+async def test_async_garbage_collection(setup_dendrite, setup_axon):
+    async with setup_dendrite as dendrite:
+        assert (await dendrite.session) is not None
+    del setup_dendrite  # should not raise error
+
+
 @pytest.mark.asyncio
 async def test_aclose(setup_dendrite, setup_axon):
     axon = setup_axon


### PR DESCRIPTION
Adds a try:except catch for the `__del__` method, as `self.close_session()` only works if not run from within an already-running event loop.

It's already explained throughout the module to use async context managers. The problem arises when the object is attempt to be garbage-collected, and thus the `__del__` method is called.