### PR TITLE
Install btcli from install sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -164,7 +164,7 @@ mac_update_pip() {
 }
 
 mac_install_bittensor() {
-    ohai "Cloning bittensor@text_prompting into ~/.bittensor/bittensor"
+    ohai "Cloning bittensor into ~/.bittensor/bittensor"
     git clone https://github.com/opentensor/bittensor.git ~/.bittensor/bittensor/ 2> /dev/null || (cd ~/.bittensor/bittensor/ ; git fetch origin master ; git checkout master ; git pull --ff-only ; git reset --hard; git clean -xdf)
     ohai "Installing bittensor"
     $python -m pip install -e ~/.bittensor/bittensor/

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,6 +105,7 @@ linux_install_bittensor() {
     git clone https://github.com/opentensor/bittensor.git ~/.bittensor/bittensor/ 2> /dev/null || (cd ~/.bittensor/bittensor/ ; git fetch origin master ; git checkout master ; git pull --ff-only ; git reset --hard ; git clean -xdf)
     ohai "Installing bittensor"
     $python -m pip install -e ~/.bittensor/bittensor/
+    $python -m pip install -U bittensor-cli
     exit_on_error $? 
 }
 
@@ -167,6 +168,7 @@ mac_install_bittensor() {
     git clone https://github.com/opentensor/bittensor.git ~/.bittensor/bittensor/ 2> /dev/null || (cd ~/.bittensor/bittensor/ ; git fetch origin master ; git checkout master ; git pull --ff-only ; git reset --hard; git clean -xdf)
     ohai "Installing bittensor"
     $python -m pip install -e ~/.bittensor/bittensor/
+    $python -m pip install -U bittensor-cli
     exit_on_error $? 
     deactivate
 }


### PR DESCRIPTION
Adds back the functionality of installing btcli along with bittensor when using the `install.sh` script.