### PR TITLE
Fix e2e `conftest.py` for legacy runner

### DIFF
--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -77,7 +77,7 @@ def local_chain(request):
             logging.warning("Docker not found in the operating system!")
             logging.warning(docker_command)
             logging.warning("Tests are run in legacy mode.")
-        yield from legacy_runner(request)
+        yield from legacy_runner(params)
 
 
 def legacy_runner(params):
@@ -95,7 +95,6 @@ def legacy_runner(params):
 
     # Compile commands to send to process
     cmds = shlex.split(f"{script_path} {args}")
-
     with subprocess.Popen(
         cmds,
         start_new_session=True,


### PR DESCRIPTION
use arguments instead of whole request object