### PR TITLE
Fix E2E test_dendrite by making sure Alice is Top validator in Subnet

### DIFF
--- a/tests/e2e_tests/test_dendrite.py
+++ b/tests/e2e_tests/test_dendrite.py
@@ -34,6 +34,13 @@ async def test_dendrite(local_chain, subtensor, templates, alice_wallet, bob_wal
     # Verify subnet <netuid> created successfully
     assert subtensor.subnet_exists(netuid), "Subnet wasn't created successfully"
 
+    # Make sure Alice is Top Validator
+    assert subtensor.add_stake(
+        alice_wallet,
+        netuid=netuid,
+        amount=Balance.from_tao(1),
+    )
+
     # update max_allowed_validators so only one neuron can get validator_permit
     assert sudo_set_admin_utils(
         local_chain,


### PR DESCRIPTION
Related to the way Subtensor [sorts and selects TopK](https://github.com/opentensor/subtensor/blob/main/pallets/subtensor/src/epoch/math.rs#L243-L245) neurons by stake: if more than one neuron has the same stake value (including zero), the neuron with the higher UID is selected.