### PR TITLE
Add drand-commitments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ workflows:
       - build-and-test:
           matrix:
             parameters:
-              python-version: [ "3.9.13", "3.10.6", "3.11.4", "3.12.7", "3.13.1"]
+              python-version: [ "3.9.13", "3.10.6", "3.11.4", "3.12.7"]
           requires:
             - check-if-pr-is-draft
       - unit-tests-all-python-versions:
@@ -314,7 +314,7 @@ workflows:
       - lint-and-type-check:
           matrix:
             parameters:
-              python-version: [ "3.9.13", "3.10.6", "3.11.4", "3.12.7", "3.13.1" ]
+              python-version: [ "3.9.13", "3.10.6", "3.11.4", "3.12.7"]
           requires:
             - check-if-pr-is-draft
       #- coveralls:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
             python -m venv .venv
             . .venv/bin/activate
             python -m pip install --upgrade pip
-            upython -m pip install '.[dev]'
+            python -m pip install '.[dev]'
 
       - save_cache:
           name: Save cached venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,23 +94,13 @@ jobs:
             - v2-pypi-py<< parameters.python-version >>
 
       - run:
-          name: Install Rust toolchain
+          name: Setup Rust and Install Dependencies
           command: |
             curl https://sh.rustup.rs -sSf | sh -s -- -y
-            echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
-            source $BASH_ENV
+            export PATH="$HOME/.cargo/bin:$PATH"
             rustc --version
             cargo --version
-
-      - run:
-          name: Install maturin
-          command: |
-            source $BASH_ENV
             pip install maturin
-
-      - run:
-          name: Update & Activate venv
-          command: |
             python -m venv .venv
             . .venv/bin/activate
             python -m pip install --upgrade uv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,9 +97,9 @@ jobs:
           name: Update & Activate venv
           command: |
             python -m venv .venv
-            . .venv/bin/activate
-            python -m pip install --upgrade uv
-            uv sync --all-extras --dev
+            python -m pip install --upgrade pip
+            python -m pip install '.[dev]'
+            pip install flake8
 
       - save_cache:
           name: Save cached venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,6 @@ jobs:
       - run:
           name: Update & Activate ruff venv
           command: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            . "$HOME/.cargo/env"
             python -m venv .venv
             . .venv/bin/activate
             python -m pip install --upgrade uv
@@ -94,6 +92,21 @@ jobs:
           keys:
             - v2-pypi-py<< parameters.python-version >>-{{ checksum "requirements/prod.txt" }}+{{ checksum "requirements/dev.txt" }}
             - v2-pypi-py<< parameters.python-version >>
+
+      - run:
+          name: Install Rust toolchain
+          command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
+            source $BASH_ENV
+            rustc --version
+            cargo --version
+
+      - run:
+          name: Install maturin
+          command: |
+            source $BASH_ENV
+            pip install maturin
 
       - run:
           name: Update & Activate venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,9 +97,9 @@ jobs:
           name: Update & Activate venv
           command: |
             python -m venv .venv
-            python -m pip install --upgrade pip
-            python -m pip install '.[dev]'
-            pip install flake8
+            python -m pip install --upgrade uv
+            uv sync --all-extras --dev
+            uv pip install flake8
 
       - save_cache:
           name: Save cached venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,13 +94,8 @@ jobs:
             - v2-pypi-py<< parameters.python-version >>
 
       - run:
-          name: Setup Rust and Install Dependencies
+          name: Update & Activate venv
           command: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            export PATH="$HOME/.cargo/bin:$PATH"
-            rustc --version
-            cargo --version
-            pip install maturin
             python -m venv .venv
             . .venv/bin/activate
             python -m pip install --upgrade uv
@@ -295,6 +290,9 @@ workflows:
       - check_compatibility:
           python_version: "3.12"
           name: check-compatibility-3.12
+      - check_compatibility:
+          python_version: "3.13"
+          name: check-compatibility-3.13
 
 
   pr-requirements:
@@ -307,7 +305,7 @@ workflows:
       - build-and-test:
           matrix:
             parameters:
-              python-version: [ "3.9.13", "3.10.6", "3.11.4", "3.12.7" ]
+              python-version: [ "3.9.13", "3.10.6", "3.11.4", "3.12.7", "3.13.1"]
           requires:
             - check-if-pr-is-draft
       - unit-tests-all-python-versions:
@@ -316,7 +314,7 @@ workflows:
       - lint-and-type-check:
           matrix:
             parameters:
-              python-version: [ "3.9.13", "3.10.6", "3.11.4", "3.12.7" ]
+              python-version: [ "3.9.13", "3.10.6", "3.11.4", "3.12.7", "3.13.1" ]
           requires:
             - check-if-pr-is-draft
       #- coveralls:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,12 @@ jobs:
       - run:
           name: Update & Activate ruff venv
           command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            . "$HOME/.cargo/env"
             python -m venv .venv
             . .venv/bin/activate
-            python -m pip install --upgrade pip
-            pip install ruff -c requirements/dev.txt
+            python -m pip install --upgrade uv
+            uv pip install ruff -c requirements/dev.txt
 
       - save_cache:
           name: Save cached ruff venv
@@ -98,8 +100,8 @@ jobs:
           command: |
             python -m venv .venv
             . .venv/bin/activate
-            python -m pip install --upgrade pip
-            python -m pip install '.[dev]'
+            python -m pip install --upgrade uv
+            uv sync --all-extras --dev
 
       - save_cache:
           name: Save cached venv
@@ -111,7 +113,7 @@ jobs:
           name: Install Bittensor
           command: |
             . .venv/bin/activate
-            pip install -e '.[dev]'
+            uv sync --all-extras --dev
 
       - run:
           name: Instantiate Mock Wallet
@@ -189,9 +191,9 @@ jobs:
           command: |
             python -m venv .venv
             . .venv/bin/activate
-            python -m pip install --upgrade pip
-            python -m pip install '.[dev]'
-            pip install flake8
+            python -m pip install --upgrade uv
+            uv sync --all-extras --dev
+            uv pip install flake8
 
       - save_cache:
           name: Save cached venv
@@ -203,7 +205,7 @@ jobs:
           name: Install Bittensor
           command: |
             . .venv/bin/activate
-            pip install -e '.[dev]'
+            uv sync --all-extras --dev
 
       - run:
           name: Lint with flake8
@@ -232,7 +234,7 @@ jobs:
       - run:
           name: Combine Coverage
           command: |
-            pip3 install --upgrade coveralls
+            uv pip install --upgrade coveralls
             coveralls --finish --rcfile .coveragerc || echo "Failed to upload coverage"
 
   check-version-updated:
@@ -290,9 +292,6 @@ workflows:
       - check_compatibility:
           python_version: "3.12"
           name: check-compatibility-3.12
-      - check_compatibility:
-          python_version: "3.13"
-          name: check-compatibility-3.13
 
 
   pr-requirements:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
           command: |
             python -m venv .venv
             . .venv/bin/activate
-            python -m pip install --upgrade uv
-            uv pip install ruff -c requirements/dev.txt
+            python -m pip install --upgrade pip
+            pip install ruff -c requirements/dev.txt
 
       - save_cache:
           name: Save cached ruff venv
@@ -98,9 +98,8 @@ jobs:
           command: |
             python -m venv .venv
             . .venv/bin/activate
-            python -m pip install --upgrade uv
-            uv sync --all-extras --dev
-            uv pip install flake8
+            python -m pip install --upgrade pip
+            upython -m pip install '.[dev]'
 
       - save_cache:
           name: Save cached venv
@@ -112,7 +111,7 @@ jobs:
           name: Install Bittensor
           command: |
             . .venv/bin/activate
-            uv sync --all-extras --dev
+            pip install -e '.[dev]'
 
       - run:
           name: Instantiate Mock Wallet
@@ -190,9 +189,9 @@ jobs:
           command: |
             python -m venv .venv
             . .venv/bin/activate
-            python -m pip install --upgrade uv
-            uv sync --all-extras --dev
-            uv pip install flake8
+            python -m pip install --upgrade pip
+            python -m pip install '.[dev]'
+            pip install flake8
 
       - save_cache:
           name: Save cached venv
@@ -204,7 +203,7 @@ jobs:
           name: Install Bittensor
           command: |
             . .venv/bin/activate
-            uv sync --all-extras --dev
+            pip install -e '.[dev]'
 
       - run:
           name: Lint with flake8
@@ -233,7 +232,7 @@ jobs:
       - run:
           name: Combine Coverage
           command: |
-            uv pip install --upgrade coveralls
+            pip3 install --upgrade coveralls
             coveralls --finish --rcfile .coveragerc || echo "Failed to upload coverage"
 
   check-version-updated:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ jobs:
           name: Update & Activate venv
           command: |
             python -m venv .venv
+            . .venv/bin/activate
             python -m pip install --upgrade uv
             uv sync --all-extras --dev
             uv pip install flake8

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -27,9 +27,14 @@ from bittensor.core.chain_data import (
     decode_account_id,
     DynamicInfo,
 )
+from bittensor_commit_reveal import get_encrypted_commitment
 from bittensor.core.chain_data.chain_identity import ChainIdentity
 from bittensor.core.chain_data.delegate_info import DelegatedInfo
-from bittensor.core.chain_data.utils import decode_metadata
+from bittensor.core.chain_data.utils import (
+    decode_metadata,
+    decode_revealed_commitment,
+    decode_revealed_commitment_with_hotkey,
+)
 from bittensor.core.config import Config
 from bittensor.core.errors import ChainError, SubstrateRequestException
 from bittensor.core.extrinsics.asyncex.commit_reveal import commit_reveal_v3_extrinsic
@@ -1057,6 +1062,68 @@ class AsyncSubtensor(SubtensorMixin):
         result = {}
         async for id_, value in query:
             result[decode_account_id(id_[0])] = decode_metadata(value)
+        return result
+
+    async def get_reveled_commitment(
+        self,
+        netuid: int,
+        hotkey_ss58_address: Optional[str] = None,
+        block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        reuse_block: bool = False,
+    ) -> Optional[tuple[int, str]]:
+        """Returns hotkey related revealed commitment for a given netuid.
+
+        Arguments:
+            netuid (int): The unique identifier of the subnetwork.
+            block (Optional[int]): The block number to retrieve the commitment from. Default is ``None``.
+            hotkey_ss58_address (str): The ss58 address of the committee member.
+            block_hash (Optional[str]): The hash of the block to retrieve the subnet unique identifiers from.
+            reuse_block (bool): Whether to reuse the last-used block hash.
+
+        Returns:
+            result (tuple[int, str): A tuple of reveal block and commitment message.
+        """
+        query = await self.query_module(
+            module="Commitments",
+            name="RevealedCommitments",
+            params=[netuid, hotkey_ss58_address],
+            block=block,
+            block_hash=block_hash,
+            reuse_block=reuse_block,
+        )
+        return decode_revealed_commitment(query)
+
+    async def get_all_revealed_commitments(
+        self,
+        netuid: int,
+        block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        reuse_block: bool = False,
+    ) -> dict[str, tuple[int, str]]:
+        """Returns all revealed commitments for a given netuid.
+
+        Arguments:
+            netuid (int): The unique identifier of the subnetwork.
+            block (Optional[int]): The block number to retrieve the commitment from. Default is ``None``.
+            block_hash (Optional[str]): The hash of the block to retrieve the subnet unique identifiers from.
+            reuse_block (bool): Whether to reuse the last-used block hash.
+
+        Returns:
+            result (dict): A dictionary of all revealed commitments in view {ss58_address: (reveal block, commitment message)}.
+        """
+        query = await self.query_map(
+            module="Commitments",
+            name="RevealedCommitments",
+            params=[netuid],
+            block=block,
+            block_hash=block_hash,
+            reuse_block=reuse_block,
+        )
+
+        result = {}
+        async for item in query:
+            result.update(decode_revealed_commitment_with_hotkey(item))
         return result
 
     async def get_current_weight_commit_info(
@@ -2619,6 +2686,46 @@ class AsyncSubtensor(SubtensorMixin):
             reuse_block=reuse_block,
         )
         return None if call is None else Balance.from_rao(int(call))
+
+    async def set_reveal_commitment(
+        self,
+        wallet,
+        netuid: int,
+        data: str,
+        blocks_until_reveal: int = 360,
+        block_time: Union[int, float] = 12,
+    ) -> tuple[bool, int]:
+        """
+        Commits arbitrary data to the Bittensor network by publishing metadata.
+
+        Arguments:
+            wallet (bittensor_wallet.Wallet): The wallet associated with the neuron committing the data.
+            netuid (int): The unique identifier of the subnetwork.
+            data (str): The data to be committed to the network.
+            blocks_until_reveal (int): The number of blocks from now after which the data will be revealed. Defaults to `360`.
+                Then amount of blocks in one epoch.
+            block_time (Union[int, float]): The number of seconds between each block. Defaults to `12`.
+
+        Returns:
+            bool: `True` if the commitment was successful, `False` otherwise.
+
+        Note: A commitment can be set once per subnet epoch and is reset at the next epoch in the chain automatically.
+        """
+
+        encrypted, reveal_round = get_encrypted_commitment(
+            data, blocks_until_reveal, block_time
+        )
+
+        # increase reveal_round in return + 1 because we want to fetch data from the chain after that round was revealed
+        # and stored.
+        data_ = {"encrypted": encrypted, "reveal_round": reveal_round}
+        return await publish_metadata(
+            subtensor=self,
+            wallet=wallet,
+            netuid=netuid,
+            data_type=f"TimelockEncrypted",
+            data=data_,
+        ), reveal_round
 
     async def subnet(
         self,

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1064,7 +1064,7 @@ class AsyncSubtensor(SubtensorMixin):
             result[decode_account_id(id_[0])] = decode_metadata(value)
         return result
 
-    async def get_reveled_commitment(
+    async def get_revealed_commitment(
         self,
         netuid: int,
         hotkey_ss58_address: Optional[str] = None,

--- a/bittensor/core/chain_data/utils.py
+++ b/bittensor/core/chain_data/utils.py
@@ -159,11 +159,11 @@ def decode_revealed_commitment(
             return 4
 
     v = next(iter(value))
-    reveled_block = v[1]
+    revealed_block = v[1]
     cut = scale_decode_offset(v[0])
 
-    reveled_commitment = bytes(v[0][cut:]).decode("utf-8", errors="ignore")
-    return reveled_block, reveled_commitment
+    revealed_commitment = bytes(v[0][cut:]).decode("utf-8", errors="ignore")
+    return revealed_block, revealed_commitment
 
 
 def decode_revealed_commitment_with_hotkey(data: list) -> dict[str, tuple[int, str]]:

--- a/bittensor/core/chain_data/utils.py
+++ b/bittensor/core/chain_data/utils.py
@@ -1,7 +1,7 @@
 """Chain data helper functions and data."""
 
 from enum import Enum
-from typing import Optional, Union
+from typing import Optional, Union, TYPE_CHECKING
 
 from scalecodec.base import RuntimeConfiguration, ScaleBytes
 from scalecodec.type_registry import load_type_registry_preset
@@ -9,6 +9,9 @@ from scalecodec.utils.ss58 import ss58_encode
 
 from bittensor.core.settings import SS58_FORMAT
 from bittensor.utils.balance import Balance
+
+if TYPE_CHECKING:
+    from async_substrate_interface.types import ScaleObj
 
 
 class ChainDataType(Enum):
@@ -135,3 +138,36 @@ def decode_metadata(metadata: dict) -> str:
     commitment = metadata["info"]["fields"][0][0]
     bytes_tuple = commitment[next(iter(commitment.keys()))][0]
     return bytes(bytes_tuple).decode()
+
+
+def decode_revealed_commitment(
+    value: Optional["ScaleObj"],
+) -> Optional[tuple[int, str]]:
+    """Decode the revealed commitment data from the given input if it is not None."""
+    if value is None:
+        return None
+
+    def scale_decode_offset(data: bytes) -> int:
+        """Decodes the scale offset from a given byte data sequence."""
+        first_byte = data[0]
+        mode = first_byte & 0b11
+        if mode == 0:
+            return 1
+        elif mode == 1:
+            return 2
+        else:
+            return 4
+
+    v = next(iter(value))
+    reveled_block = v[1]
+    cut = scale_decode_offset(v[0])
+
+    reveled_commitment = bytes(v[0][cut:]).decode("utf-8", errors="ignore")
+    return reveled_block, reveled_commitment
+
+
+def decode_revealed_commitment_with_hotkey(data: list) -> dict[str, tuple[int, str]]:
+    """Decode revealed commitment using a hotkey."""
+    key, value = data
+    ss58_address = decode_account_id(key[0])
+    return {ss58_address: decode_revealed_commitment(value)}

--- a/bittensor/core/extrinsics/asyncex/serving.py
+++ b/bittensor/core/extrinsics/asyncex/serving.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
 
 from bittensor.core.errors import MetadataError
 from bittensor.core.settings import version_as_int
@@ -226,7 +226,7 @@ async def publish_metadata(
     wallet: "Wallet",
     netuid: int,
     data_type: str,
-    data: bytes,
+    data: Union[bytes, dict],
     wait_for_inclusion: bool = False,
     wait_for_finalization: bool = True,
 ) -> bool:
@@ -240,8 +240,8 @@ async def publish_metadata(
         data_type (str): The data type of the information being submitted. It should be one of the following:
             ``'Sha256'``, ``'Blake256'``, ``'Keccak256'``, or ``'Raw0-128'``. This specifies the format or hashing
             algorithm used for the data.
-        data (str): The actual metadata content to be published. This should be formatted or hashed according to the
-            ``type`` specified. (Note: max ``str`` length is 128 bytes)
+        data (Union[bytes, dict]): The actual metadata content to be published. This should be formatted or hashed
+            according to the ``type`` specified. (Note: max ``str`` length is 128 bytes for ``'Raw0-128'``.)
         wait_for_inclusion (bool, optional): If ``True``, the function will wait for the extrinsic to be included in a
             block before returning. Defaults to ``False``.
         wait_for_finalization (bool, optional): If ``True``, the function will wait for the extrinsic to be finalized

--- a/bittensor/core/extrinsics/serving.py
+++ b/bittensor/core/extrinsics/serving.py
@@ -1,4 +1,4 @@
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
 
 from bittensor.core.errors import MetadataError
 from bittensor.core.settings import version_as_int
@@ -222,7 +222,7 @@ def publish_metadata(
     wallet: "Wallet",
     netuid: int,
     data_type: str,
-    data: bytes,
+    data: Union[bytes, dict],
     wait_for_inclusion: bool = False,
     wait_for_finalization: bool = True,
 ) -> bool:
@@ -236,8 +236,8 @@ def publish_metadata(
         data_type (str): The data type of the information being submitted. It should be one of the following:
             ``'Sha256'``, ``'Blake256'``, ``'Keccak256'``, or ``'Raw0-128'``. This specifies the format or hashing
             algorithm used for the data.
-        data (str): The actual metadata content to be published. This should be formatted or hashed according to the
-            ``type`` specified. (Note: max ``str`` length is 128 bytes)
+        data (Union[bytes, dict]): The actual metadata content to be published. This should be formatted or hashed
+            according to the ``type`` specified. (Note: max ``str`` length is 128 bytes for ``'Raw0-128'``.)
         wait_for_inclusion (bool, optional): If ``True``, the function will wait for the extrinsic to be included in a
             block before returning. Defaults to ``False``.
         wait_for_finalization (bool, optional): If ``True``, the function will wait for the extrinsic to be finalized

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -807,7 +807,7 @@ class Subtensor(SubtensorMixin):
             result[decode_account_id(id_[0])] = decode_metadata(value)
         return result
 
-    def get_reveled_commitment(
+    def get_revealed_commitment(
         self,
         netuid: int,
         hotkey_ss58_address: Optional[str] = None,

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -21,6 +21,6 @@ python-Levenshtein
 scalecodec==1.2.11
 uvicorn
 websockets>=14.1
-bittensor-commit-reveal>=0.3.0
+bittensor-commit-reveal>=0.3.1
 bittensor-wallet>=3.0.4
 async-substrate-interface>=1.0.4

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -21,6 +21,6 @@ python-Levenshtein
 scalecodec==1.2.11
 uvicorn
 websockets>=14.1
-bittensor-commit-reveal>=0.2.0
+bittensor-commit-reveal>=0.3.0
 bittensor-wallet>=3.0.4
 async-substrate-interface>=1.0.4

--- a/tests/e2e_tests/test_reveal_commitements.py
+++ b/tests/e2e_tests/test_reveal_commitements.py
@@ -1,0 +1,97 @@
+import time
+
+import pytest
+
+from bittensor.utils.btlogging import logging
+
+
+@pytest.mark.parametrize("local_chain", [False], indirect=True)
+@pytest.mark.asyncio
+async def test_set_reveal_commitment(local_chain, subtensor, alice_wallet, bob_wallet):
+    """
+    Tests the set/reveal commitments with TLE (time-locked encrypted commitments) mechanism.
+
+    Steps:
+        1. Register a subnet through Alice
+        2. Register Bob's neuron and add stake
+        3. Set commitment from Alice hotkey
+        4. Set commitment from Bob hotkey
+        5. Wait until commitment is revealed.
+        5. Verify commitment is revealed by Alice and Bob and available via mutual call.
+        6. Verify commitment is revealed by Alice and Bob and available via separate calls.
+    Raises:
+        AssertionError: If any of the checks or verifications fail
+
+    Note: Actually we can run this tests in fast block mode. For this we need to set `BLOCK_TIME` to 0.25 and replace
+    `False` to `True` in `pytest.mark.parametrize` decorator.
+    """
+    BLOCK_TIME = 12  # 12 for non-fast-block, 0.25 for fast block
+    BLOCKS_UNTIL_REVEAL = 15
+
+    NETUID = 2
+
+    logging.console.info("Testing Drand encrypted commitments.")
+
+    # Register subnet as Alice
+    assert subtensor.register_subnet(
+        alice_wallet, True, True
+    ), "Unable to register the subnet"
+
+    # Register Bob's neuron
+    assert subtensor.burned_register(
+        bob_wallet, NETUID, True, True
+    ), "Bob's neuron was not register."
+
+    # Verify subnet 2 created successfully
+    assert subtensor.subnet_exists(NETUID), "Subnet wasn't created successfully"
+
+    # Set commitment from Alice hotkey
+    message_alice = f"This is test message with time {time.time()} from Alice."
+
+    response = subtensor.set_reveal_commitment(
+        alice_wallet, NETUID, message_alice, BLOCKS_UNTIL_REVEAL, BLOCK_TIME
+    )
+    assert response[0] is True
+
+    # Set commitment from Bob's hotkey
+    message_bob = f"This is test message with time {time.time()} from Bob."
+
+    response = subtensor.set_reveal_commitment(
+        bob_wallet, NETUID, message_bob, BLOCKS_UNTIL_REVEAL, block_time=BLOCK_TIME
+    )
+    assert response[0] is True
+
+    target_reveal_round = response[1]
+
+    # Sometimes the chain doesn't update the repository right away and the commit doesn't appear in the expected
+    # `last_drand_round`. In this case need to wait a bit.
+    while subtensor.last_drand_round() < target_reveal_round + 1:
+        # wait one drand period (3 sec)
+        time.sleep(3)
+
+    actual_all = subtensor.get_all_revealed_commitments(NETUID)
+
+    alice_result = actual_all.get(alice_wallet.hotkey.ss58_address)
+    assert alice_result is not None, "Alice's commitment was not received."
+
+    bob_result = actual_all.get(bob_wallet.hotkey.ss58_address)
+    assert bob_result is not None, "Bob's commitment was not received."
+
+    alice_actual_block, alice_actual_message = alice_result
+    bob_actual_block, bob_actual_message = bob_result
+
+    # We do not check the release block because it is a dynamic number. It depends on the load of the chain, the number
+    # of commits in the chain and the computing power.
+    assert message_alice == alice_actual_message
+    assert message_bob == bob_actual_message
+
+    # Assertions for get_reveled_commitment (based of hotkey)
+    actual_alice_block, actual_alice_message = subtensor.get_reveled_commitment(
+        NETUID, alice_wallet.hotkey.ss58_address
+    )
+    actual_bob_block, actual_bob_message = subtensor.get_reveled_commitment(
+        NETUID, bob_wallet.hotkey.ss58_address
+    )
+
+    assert message_alice == actual_alice_message
+    assert message_bob == actual_bob_message

--- a/tests/e2e_tests/test_reveal_commitements.py
+++ b/tests/e2e_tests/test_reveal_commitements.py
@@ -85,11 +85,11 @@ async def test_set_reveal_commitment(local_chain, subtensor, alice_wallet, bob_w
     assert message_alice == alice_actual_message
     assert message_bob == bob_actual_message
 
-    # Assertions for get_reveled_commitment (based of hotkey)
-    actual_alice_block, actual_alice_message = subtensor.get_reveled_commitment(
+    # Assertions for get_revealed_commitment (based of hotkey)
+    actual_alice_block, actual_alice_message = subtensor.get_revealed_commitment(
         NETUID, alice_wallet.hotkey.ss58_address
     )
-    actual_bob_block, actual_bob_message = subtensor.get_reveled_commitment(
+    actual_bob_block, actual_bob_message = subtensor.get_revealed_commitment(
         NETUID, bob_wallet.hotkey.ss58_address
     )
 


### PR DESCRIPTION
Added Subtensor methods (async/sync):
- `get_revealed_commitment` get revealed commitments based on netuid and hotkey
- `get_all_revealed_commitments` get all reveled commitments in subnet based in netuid
- `set_reveal_commitment` set commitments to specific subnet with `blocks_until_reveal` (number of blocks from now after which the data will be revealed)
- a few helper functions
- e2e test for mentioned methods