### PR TITLE
Remove cubit as extra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,3 @@ install:
 
 install-dev:
 	python3 -m pip install '.[dev]'
-
-install-cubit:
-	python3 -m pip install '.[cubit]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,6 @@ torch = [
 cli = [
     "bittensor-cli>=9.0.2"
 ]
-cubit = [
-    "torch>=1.13.1,<3.0",
-    "cubit @ git+https://github.com/opentensor/cubit.git@v1.1.2"
-]
 
 
 [project.urls]


### PR DESCRIPTION
Removes cubit as an extra. It's difficult to package, nobody uses it, and installation instructions are covered in the README as well as the attempt to import it (`bittensor/utils/registration/register_cuda.py`)