### PR TITLE
Add `Monitor-Requirements-Size` workflow

### DIFF
--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -16,6 +16,10 @@ on:
     branches:
       - master
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   measure-venv:
     runs-on: ubuntu-latest

--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -5,16 +5,10 @@
 
 name: Monitor SDK Requirements Size
 
-#on:
-#  pull_request:
-#    types: [opened]
-#    branches: [master]
-
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
-    branches:
-      - master
+    types: [opened]
+    branches: [master]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -2,7 +2,6 @@
 # after installing the Bittensor SDK across multiple Python versions.
 # It runs only when a new pull request targets the master branch,
 # and posts a comment with the results.
-
 name: Monitor SDK Requirements Size
 
 on:

--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -1,0 +1,76 @@
+# This workflow measures the disk size of a virtual environment
+# after installing the Bittensor SDK across multiple Python versions.
+# It runs only when a new pull request targets the master branch,
+# and posts a comment with the results.
+
+name: Monitor SDK Requirements Size
+
+on:
+  pull_request:
+    types: [opened]
+    branches: [master]
+
+jobs:
+  measure-venv:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
+    name: Python ${{ matrix.python-version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Create virtualenv and install Bittensor SDK
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install --upgrade pip
+          pip install .
+
+      - name: Measure venv folder size
+        id: venv-size
+        run: |
+          du -sm venv | cut -f1 > venv_size_mb.txt
+          echo "venv_size=$(cat venv_size_mb.txt)" >> $GITHUB_OUTPUT
+
+      - name: Save size for summary
+        run: |
+          echo "Python ${{ matrix.python-version }}: ${{ steps.venv-size.outputs.venv_size }} MB" >> $GITHUB_WORKSPACE/venv_sizes.txt
+
+      - name: Upload summary file as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: venv_sizes
+          path: $GITHUB_WORKSPACE/venv_sizes.txt
+
+  comment-on-pr:
+    if: github.event_name == 'pull_request' && github.base_ref == 'master'
+    runs-on: ubuntu-latest
+    needs: measure-venv
+
+    steps:
+      - name: Download summary
+        uses: actions/download-artifact@v4
+        with:
+          name: venv_sizes
+          path: .
+
+      - name: Read summary and comment it
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const comment = fs.readFileSync('venv_sizes.txt', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.name,
+              body: `Bittensor SDK virtual environment sizes by Python version:**\n\n\`\`\`\n${comment}\n\`\`\``
+            });

--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -60,21 +60,24 @@ jobs:
     needs: measure-venv
     runs-on: ubuntu-latest
     steps:
-      - name: Comment on PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const sizes = {
-              "3.9": "${{ needs.measure-venv.outputs.py39 || 'N/A' }}",
-              "3.10": "${{ needs.measure-venv.outputs.py310 || 'N/A' }}",
-              "3.11": "${{ needs.measure-venv.outputs.py311 || 'N/A' }}",
-              "3.12": "${{ needs.measure-venv.outputs.py312 || 'N/A' }}",
-              "3.13": "${{ needs.measure-venv.outputs.py313 || 'N/A' }}"
-            };
-            const lines = Object.entries(sizes).map(([ver, size]) => `Python ${ver}: ${size} MB`);
-            github.rest.issues.createComment({
-              issue_number: context.payload.pull_request.number,
-              owner: context.repo.owner,
-              repo: context.repo.name,
-              body: `Bittensor SDK virtual environment sizes by Python version:**\n\n\`\`\`\n${lines.join("\n")}\n\`\`\``
-            });
+    - name: Post comment to PR
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const sizes = {
+            "3.9": "${{ needs.measure-venv.outputs.py39 || 'N/A' }}",
+            "3.10": "${{ needs.measure-venv.outputs.py310 || 'N/A' }}",
+            "3.11": "${{ needs.measure-venv.outputs.py311 || 'N/A' }}",
+            "3.12": "${{ needs.measure-venv.outputs.py312 || 'N/A' }}",
+            "3.13": "${{ needs.measure-venv.outputs.py313 || 'N/A' }}"
+          };
+          const lines = Object.entries(sizes).map(([ver, size]) => `Python ${ver}: ${size} MB`);
+          const body = `Bittensor SDK virtual environment sizes by Python version:**\n\n\`\`\`\n${lines.join("\n")}\n\`\`\``;
+    
+          const { owner, repo } = context.repo;
+          github.rest.issues.createComment({
+            issue_number: context.payload.pull_request.number,
+            owner,
+            repo,
+            body
+          });

--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -25,12 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     outputs:
       py39: ${{ steps.set-output.outputs.py39 }}
       py310: ${{ steps.set-output.outputs.py310 }}
       py311: ${{ steps.set-output.outputs.py311 }}
       py312: ${{ steps.set-output.outputs.py312 }}
+      py313: ${{ steps.set-output.outputs.py313 }}
 
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +57,7 @@ jobs:
             3.10) echo "py310=$SIZE" >> $GITHUB_OUTPUT ;;
             3.11) echo "py311=$SIZE" >> $GITHUB_OUTPUT ;;
             3.12) echo "py312=$SIZE" >> $GITHUB_OUTPUT ;;
+            3.13) echo "py313=$SIZE" >> $GITHUB_OUTPUT ;;
           esac
 
   comment-on-pr:
@@ -73,6 +75,7 @@ jobs:
               "3.10": "${{ needs.measure-venv.outputs.py310 || 'N/A' }}",
               "3.11": "${{ needs.measure-venv.outputs.py311 || 'N/A' }}",
               "3.12": "${{ needs.measure-venv.outputs.py312 || 'N/A' }}",
+              "3.13": "${{ needs.measure-venv.outputs.py313 || 'N/A' }}",
             };
 
             const body = [

--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -27,7 +27,7 @@ jobs:
       py310: ${{ steps.set-output.outputs.py310 }}
       py311: ${{ steps.set-output.outputs.py311 }}
       py312: ${{ steps.set-output.outputs.py312 }}
-#      py313: ${{ steps.set-output.outputs.py313 }}
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -52,7 +52,6 @@ jobs:
             3.10) echo "py310=$SIZE" >> $GITHUB_OUTPUT ;;
             3.11) echo "py311=$SIZE" >> $GITHUB_OUTPUT ;;
             3.12) echo "py312=$SIZE" >> $GITHUB_OUTPUT ;;
-#            3.13) echo "py313=$SIZE" >> $GITHUB_OUTPUT ;;
           esac
 
   comment-on-pr:
@@ -69,7 +68,6 @@ jobs:
             "3.10": "${{ needs.measure-venv.outputs.py310 || 'N/A' }}",
             "3.11": "${{ needs.measure-venv.outputs.py311 || 'N/A' }}",
             "3.12": "${{ needs.measure-venv.outputs.py312 || 'N/A' }}",
-#            "3.13": "${{ needs.measure-venv.outputs.py313 || 'N/A' }}"
           };
           const lines = Object.entries(sizes).map(([ver, size]) => `Python ${ver}: ${size} MB`);
           const body = `Bittensor SDK virtual environment sizes by Python version:**\n\n\`\`\`\n${lines.join("\n")}\n\`\`\``;

--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -7,7 +7,7 @@ name: Monitor SDK Requirements Size
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
     branches: [master]
 
 jobs:
@@ -16,61 +16,59 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-
-    name: Python ${{ matrix.python-version }}
+    outputs:
+      py39: ${{ steps.set-output.outputs.py39 }}
+      py310: ${{ steps.set-output.outputs.py310 }}
+      py311: ${{ steps.set-output.outputs.py311 }}
+      py312: ${{ steps.set-output.outputs.py312 }}
+      py313: ${{ steps.set-output.outputs.py313 }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Create virtualenv and install Bittensor SDK
+      - name: Create virtualenv and install
         run: |
           python -m venv venv
           source venv/bin/activate
           pip install --upgrade pip
           pip install .
 
-      - name: Measure venv folder size
-        id: venv-size
+      - name: Measure venv size
+        id: set-output
         run: |
-          du -sm venv | cut -f1 > venv_size_mb.txt
-          echo "venv_size=$(cat venv_size_mb.txt)" >> $GITHUB_OUTPUT
-
-      - name: Save size for summary
-        run: |
-          echo "Python ${{ matrix.python-version }}: ${{ steps.venv-size.outputs.venv_size }} MB" >> $GITHUB_WORKSPACE/venv_sizes.txt
-
-      - name: Upload summary file as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: venv_sizes
-          path: $GITHUB_WORKSPACE/venv_sizes.txt
+          SIZE=$(du -sm venv | cut -f1)
+          VERSION=${{ matrix.python-version }}
+          echo "Detected size: $SIZE MB for Python $VERSION"
+          case "$VERSION" in
+            3.9)  echo "py39=$SIZE" >> $GITHUB_OUTPUT ;;
+            3.10) echo "py310=$SIZE" >> $GITHUB_OUTPUT ;;
+            3.11) echo "py311=$SIZE" >> $GITHUB_OUTPUT ;;
+            3.12) echo "py312=$SIZE" >> $GITHUB_OUTPUT ;;
+            3.13) echo "py313=$SIZE" >> $GITHUB_OUTPUT ;;
+          esac
 
   comment-on-pr:
     if: github.event_name == 'pull_request' && github.base_ref == 'master'
-    runs-on: ubuntu-latest
     needs: measure-venv
-
+    runs-on: ubuntu-latest
     steps:
-      - name: Download summary
-        uses: actions/download-artifact@v4
-        with:
-          name: venv_sizes
-          path: .
-
-      - name: Read summary and comment it
+      - name: Comment on PR
         uses: actions/github-script@v7
         with:
           script: |
-            const fs = require('fs');
-            const comment = fs.readFileSync('venv_sizes.txt', 'utf8');
+            const sizes = {
+              "3.9": "${{ needs.measure-venv.outputs.py39 || 'N/A' }}",
+              "3.10": "${{ needs.measure-venv.outputs.py310 || 'N/A' }}",
+              "3.11": "${{ needs.measure-venv.outputs.py311 || 'N/A' }}",
+              "3.12": "${{ needs.measure-venv.outputs.py312 || 'N/A' }}",
+              "3.13": "${{ needs.measure-venv.outputs.py313 || 'N/A' }}"
+            };
+            const lines = Object.entries(sizes).map(([ver, size]) => `Python ${ver}: ${size} MB`);
             github.rest.issues.createComment({
               issue_number: context.payload.pull_request.number,
               owner: context.repo.owner,
               repo: context.repo.name,
-              body: `Bittensor SDK virtual environment sizes by Python version:**\n\n\`\`\`\n${comment}\n\`\`\``
+              body: `Bittensor SDK virtual environment sizes by Python version:**\n\n\`\`\`\n${lines.join("\n")}\n\`\`\``
             });

--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -59,23 +59,30 @@ jobs:
     needs: measure-venv
     runs-on: ubuntu-latest
     steps:
-    - name: Post comment to PR
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const sizes = {
-            "3.9": "${{ needs.measure-venv.outputs.py39 || 'N/A' }}",
-            "3.10": "${{ needs.measure-venv.outputs.py310 || 'N/A' }}",
-            "3.11": "${{ needs.measure-venv.outputs.py311 || 'N/A' }}",
-            "3.12": "${{ needs.measure-venv.outputs.py312 || 'N/A' }}",
-          };
-          const lines = Object.entries(sizes).map(([ver, size]) => `Python ${ver}: ${size} MB`);
-          const body = `Bittensor SDK virtual environment sizes by Python version:**\n\n\`\`\`\n${lines.join("\n")}\n\`\`\``;
-    
-          const { owner, repo } = context.repo;
-          github.rest.issues.createComment({
-            issue_number: context.payload.pull_request.number,
-            owner,
-            repo,
-            body
-          });
+      - name: Post venv size summary to PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const sizes = {
+              "3.9": "${{ needs.measure-venv.outputs.py39 || 'N/A' }}",
+              "3.10": "${{ needs.measure-venv.outputs.py310 || 'N/A' }}",
+              "3.11": "${{ needs.measure-venv.outputs.py311 || 'N/A' }}",
+              "3.12": "${{ needs.measure-venv.outputs.py312 || 'N/A' }}",
+            };
+
+            const body = [
+              '**Bittensor SDK virtual environment sizes by Python version:**',
+              '',
+              '```'
+            ]
+              .concat(Object.entries(sizes).map(([v, s]) => `Python ${v}: ${s} MB`))
+              .concat(['```'])
+              .join('\n');
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });

--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -5,10 +5,16 @@
 
 name: Monitor SDK Requirements Size
 
+#on:
+#  pull_request:
+#    types: [opened]
+#    branches: [master]
+
 on:
   pull_request:
-    types: [opened, synchronize]
-    branches: [master]
+    types: [opened, synchronize, reopened]
+    branches:
+      - master
 
 jobs:
   measure-venv:

--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     outputs:
       py39: ${{ steps.set-output.outputs.py39 }}
       py310: ${{ steps.set-output.outputs.py310 }}
       py311: ${{ steps.set-output.outputs.py311 }}
       py312: ${{ steps.set-output.outputs.py312 }}
-      py313: ${{ steps.set-output.outputs.py313 }}
+#      py313: ${{ steps.set-output.outputs.py313 }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -52,7 +52,7 @@ jobs:
             3.10) echo "py310=$SIZE" >> $GITHUB_OUTPUT ;;
             3.11) echo "py311=$SIZE" >> $GITHUB_OUTPUT ;;
             3.12) echo "py312=$SIZE" >> $GITHUB_OUTPUT ;;
-            3.13) echo "py313=$SIZE" >> $GITHUB_OUTPUT ;;
+#            3.13) echo "py313=$SIZE" >> $GITHUB_OUTPUT ;;
           esac
 
   comment-on-pr:
@@ -69,7 +69,7 @@ jobs:
             "3.10": "${{ needs.measure-venv.outputs.py310 || 'N/A' }}",
             "3.11": "${{ needs.measure-venv.outputs.py311 || 'N/A' }}",
             "3.12": "${{ needs.measure-venv.outputs.py312 || 'N/A' }}",
-            "3.13": "${{ needs.measure-venv.outputs.py313 || 'N/A' }}"
+#            "3.13": "${{ needs.measure-venv.outputs.py313 || 'N/A' }}"
           };
           const lines = Object.entries(sizes).map(([ver, size]) => `Python ${ver}: ${size} MB`);
           const body = `Bittensor SDK virtual environment sizes by Python version:**\n\n\`\`\`\n${lines.join("\n")}\n\`\`\``;


### PR DESCRIPTION
This workflow measures the disk size of a virtual environment after installing the Bittensor SDK across multiple Python versions.  
It runs only when a new pull request targets the master branch, and posts a comment with the results.

Comments view:
![image](https://github.com/user-attachments/assets/d7c8f625-bfc7-4bae-abee-4e4db44f859e)

Testes https://github.com/opentensor/bittensor/pull/2841