### PR TITLE
Add manual way to show the size of virtual environments in the PR

### DIFF
--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -6,8 +6,8 @@ name: Monitor SDK Requirements Size
 
 on:
   pull_request:
-    types: [opened]
-    branches: [master]
+    types: [opened, labeled]
+    branches: [master, staging]
 
 permissions:
   pull-requests: write
@@ -54,7 +54,7 @@ jobs:
           esac
 
   comment-on-pr:
-    if: github.event_name == 'pull_request' && github.base_ref == 'master'
+    if: github.event_name == 'pull_request' && github.base_ref == 'master' || contains( github.event.pull_request.labels.*.name, 'show-venv-size')
     needs: measure-venv
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Sometimes when the dependency list changes it will be useful to know how the python virtual environment has changed. Now we can use the `show-venv-size` label for this.