### PR TITLE
Improve `Monitor SDK Requirements Size` workflow

### DIFF
--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   measure-venv:
+    if: github.event_name == 'pull_request' && github.base_ref == 'master' || contains( github.event.pull_request.labels.*.name, 'show-venv-size')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -54,7 +55,7 @@ jobs:
           esac
 
   comment-on-pr:
-    if: github.event_name == 'pull_request' && github.base_ref == 'master' || contains( github.event.pull_request.labels.*.name, 'show-venv-size')
+#    if: github.event_name == 'pull_request' && github.base_ref == 'master' || contains( github.event.pull_request.labels.*.name, 'show-venv-size')
     needs: measure-venv
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -55,7 +55,6 @@ jobs:
           esac
 
   comment-on-pr:
-#    if: github.event_name == 'pull_request' && github.base_ref == 'master' || contains( github.event.pull_request.labels.*.name, 'show-venv-size')
     needs: measure-venv
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Avoid running the first job to install and measure the size of the python virtual environment for all PR. 
Occurs only if the label is added or in the master branch