### PR TITLE
Rename argument `fallback_chains` to `fallback_endpoints`

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -115,7 +115,7 @@ class AsyncSubtensor(SubtensorMixin):
         network: Optional[str] = None,
         config: Optional["Config"] = None,
         log_verbose: bool = False,
-        fallback_chains: Optional[list[str]] = None,
+        fallback_endpoints: Optional[list[str]] = None,
         retry_forever: bool = False,
         _mock: bool = False,
     ):
@@ -123,11 +123,11 @@ class AsyncSubtensor(SubtensorMixin):
         Initializes an instance of the AsyncSubtensor class.
 
         Arguments:
-            network (str): The network name or type to connect to.
-            config (Optional[Config]): Configuration object for the AsyncSubtensor instance.
-            log_verbose (bool): Enables or disables verbose logging.
-            fallback_chains (list): List of fallback chains endpoints to use if no network is specified. Defaults to `None`.
-            retry_forever (bool): Whether to retry forever on connection errors. Defaults to `False`.
+            network: The network name or type to connect to.
+            config: Configuration object for the AsyncSubtensor instance.
+            log_verbose: Enables or disables verbose logging.
+            fallback_endpoints: List of fallback endpoints to use if default or provided network is not available. Defaults to `None`.
+            retry_forever: Whether to retry forever on connection errors. Defaults to `False`.
             _mock: Whether this is a mock instance. Mainly just for use in testing.
 
         Raises:
@@ -148,7 +148,9 @@ class AsyncSubtensor(SubtensorMixin):
             f"chain_endpoint: [blue]{self.chain_endpoint}[/blue]..."
         )
         self.substrate = self._get_substrate(
-            fallback_chains=fallback_chains, retry_forever=retry_forever, _mock=_mock
+            fallback_endpoints=fallback_endpoints,
+            retry_forever=retry_forever,
+            _mock=_mock,
         )
         if self.log_verbose:
             logging.info(
@@ -284,24 +286,24 @@ class AsyncSubtensor(SubtensorMixin):
 
     def _get_substrate(
         self,
-        fallback_chains: Optional[list[str]] = None,
+        fallback_endpoints: Optional[list[str]] = None,
         retry_forever: bool = False,
         _mock: bool = False,
     ) -> Union[AsyncSubstrateInterface, RetryAsyncSubstrate]:
         """Creates the Substrate instance based on provided arguments.
 
         Arguments:
-            fallback_chains (list): List of fallback chains endpoints to use if no network is specified. Defaults to `None`.
-            retry_forever (bool): Whether to retry forever on connection errors. Defaults to `False`.
+            fallback_endpoints: List of fallback endpoints to use if default or provided network is not available. Defaults to `None`.
+            retry_forever: Whether to retry forever on connection errors. Defaults to `False`.
             _mock: Whether this is a mock instance. Mainly just for use in testing.
 
         Returns:
             the instance of the SubstrateInterface or RetrySyncSubstrate class.
         """
-        if fallback_chains or retry_forever:
+        if fallback_endpoints or retry_forever:
             return RetryAsyncSubstrate(
                 url=self.chain_endpoint,
-                fallback_chains=fallback_chains,
+                fallback_chains=fallback_endpoints,
                 ss58_format=SS58_FORMAT,
                 type_registry=TYPE_REGISTRY,
                 retry_forever=retry_forever,

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -190,7 +190,7 @@ class Subtensor(SubtensorMixin):
                 type_registry=TYPE_REGISTRY,
                 use_remote_preset=True,
                 chain_name="Bittensor",
-                fallback_endpoints=fallback_endpoints,
+                fallback_chains=fallback_endpoints,
                 retry_forever=retry_forever,
                 _mock=_mock,
             )

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -117,7 +117,7 @@ class Subtensor(SubtensorMixin):
         network: Optional[str] = None,
         config: Optional["Config"] = None,
         log_verbose: bool = False,
-        fallback_chains: Optional[list[str]] = None,
+        fallback_endpoints: Optional[list[str]] = None,
         retry_forever: bool = False,
         _mock: bool = False,
     ):
@@ -125,11 +125,11 @@ class Subtensor(SubtensorMixin):
         Initializes an instance of the Subtensor class.
 
         Arguments:
-            network (str): The network name or type to connect to.
-            config (Optional[Config]): Configuration object for the AsyncSubtensor instance.
-            log_verbose (bool): Enables or disables verbose logging.
-            fallback_chains (list): List of fallback chains endpoints to use if no network is specified. Defaults to `None`.
-            retry_forever (bool): Whether to retry forever on connection errors. Defaults to `False`.
+            network: The network name or type to connect to.
+            config: Configuration object for the AsyncSubtensor instance.
+            log_verbose: Enables or disables verbose logging.
+            fallback_endpoints: List of fallback endpoints to use if default or provided network is not available. Defaults to `None`.
+            retry_forever: Whether to retry forever on connection errors. Defaults to `False`.
             _mock: Whether this is a mock instance. Mainly just for use in testing.
 
         Raises:
@@ -148,7 +148,9 @@ class Subtensor(SubtensorMixin):
             f"chain_endpoint: [blue]{self.chain_endpoint}[/blue]> ..."
         )
         self.substrate = self._get_substrate(
-            fallback_chains=fallback_chains, retry_forever=retry_forever, _mock=_mock
+            fallback_endpoints=fallback_endpoints,
+            retry_forever=retry_forever,
+            _mock=_mock,
         )
         if self.log_verbose:
             logging.info(
@@ -167,28 +169,28 @@ class Subtensor(SubtensorMixin):
 
     def _get_substrate(
         self,
-        fallback_chains: Optional[list[str]] = None,
+        fallback_endpoints: Optional[list[str]] = None,
         retry_forever: bool = False,
         _mock: bool = False,
     ) -> Union[SubstrateInterface, RetrySyncSubstrate]:
         """Creates the Substrate instance based on provided arguments.
 
         Arguments:
-            fallback_chains (list): List of fallback chains endpoints to use if no network is specified. Defaults to `None`.
-            retry_forever (bool): Whether to retry forever on connection errors. Defaults to `False`.
+            fallback_endpoints: List of fallback chains endpoints to use if main network isn't available. Defaults to `None`.
+            retry_forever: Whether to retry forever on connection errors. Defaults to `False`.
             _mock: Whether this is a mock instance. Mainly just for use in testing.
 
         Returns:
             the instance of the SubstrateInterface or RetrySyncSubstrate class.
         """
-        if fallback_chains or retry_forever:
+        if fallback_endpoints or retry_forever:
             return RetrySyncSubstrate(
                 url=self.chain_endpoint,
                 ss58_format=SS58_FORMAT,
                 type_registry=TYPE_REGISTRY,
                 use_remote_preset=True,
                 chain_name="Bittensor",
-                fallback_chains=fallback_chains,
+                fallback_endpoints=fallback_endpoints,
                 retry_forever=retry_forever,
                 _mock=_mock,
             )

--- a/bittensor/core/subtensor_api/__init__.py
+++ b/bittensor/core/subtensor_api/__init__.py
@@ -25,9 +25,9 @@ class SubtensorApi:
         network: The network to connect to. Defaults to `None` -> "finney".
         config: Bittensor configuration object. Defaults to `None`.
         legacy_methods: If `True`, all methods from the Subtensor class will be added to the root level of this class.
-        fallback_chains (list): List of fallback chains to use if no network is specified. Defaults to `None`.
-        retry_forever (bool): Whether to retry forever on connection errors. Defaults to `False`.
-        log_verbose (bool): Enables or disables verbose logging.
+        fallback_endpoints: List of fallback endpoints to use if default or provided network is not available. Defaults to `None`.
+        retry_forever: Whether to retry forever on connection errors. Defaults to `False`.
+        log_verbose: Enables or disables verbose logging.
         mock: Whether this is a mock instance. Mainly just for use in testing.
 
     Example:
@@ -54,10 +54,15 @@ class SubtensorApi:
         subtensor = bt.SubtensorApi(legacy_methods=True)
         print(subtensor.bonds(0))
 
-        # using `fallback_chains` or `retry_forever`
+        # using `fallback_endpoints` or `retry_forever`
         import bittensor as bt
 
-
+        subtensor = bt.SubtensorApi(
+            network="finney",
+            fallback_endpoints=["wss://localhost:9945", "wss://some-other-endpoint:9945"],
+            retry_forever=True,
+        )
+        print(subtensor.block)
     """
 
     def __init__(
@@ -66,13 +71,13 @@ class SubtensorApi:
         config: Optional["Config"] = None,
         async_subtensor: bool = False,
         legacy_methods: bool = False,
-        fallback_chains: Optional[list[str]] = None,
+        fallback_endpoints: Optional[list[str]] = None,
         retry_forever: bool = False,
         log_verbose: bool = False,
         mock: bool = False,
     ):
         self.network = network
-        self._fallback_chains = fallback_chains
+        self._fallback_endpoints = fallback_endpoints
         self._retry_forever = retry_forever
         self._mock = mock
         self.log_verbose = log_verbose
@@ -111,7 +116,7 @@ class SubtensorApi:
                 network=self.network,
                 config=self._config,
                 log_verbose=self.log_verbose,
-                fallback_chains=self._fallback_chains,
+                fallback_endpoints=self._fallback_endpoints,
                 retry_forever=self._retry_forever,
                 _mock=self._mock,
             )
@@ -122,7 +127,7 @@ class SubtensorApi:
                 network=self.network,
                 config=self._config,
                 log_verbose=self.log_verbose,
-                fallback_chains=self._fallback_chains,
+                fallback_endpoints=self._fallback_endpoints,
                 retry_forever=self._retry_forever,
                 _mock=self._mock,
             )


### PR DESCRIPTION
The name of the `fallback_chains` argument in its description confuses users. They perceive it as a list of network names, not endpoints.
The current changes bring clarity and transparency.