### PR TITLE
Fix broken pull request template links (#2867)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,6 @@ please switch to **Preview** for links to render properly.
 
 Please choose the right template for your pull request:
 
-- 🐛 Are you fixing a bug? [Bug fix](?template=.github/PULL_REQUEST_TEMPLATE/bug_fix.md)
-- 📈 Are you improving performance? [Performance improvement](?template=.github/PULL_REQUEST_TEMPLATE/performance_improvement.md)
-- 💻 Are you changing functionality? [Feature change](?template=.github/PULL_REQUEST_TEMPLATE/feature_change.md)
+- 🐛 Are you fixing a bug? [Bug fix](?expand=1&template=bug_fix.md)
+- 📈 Are you improving performance? [Performance improvement](?expand=1&template=performance_improvement.md)
+- 💻 Are you changing functionality? [Feature change](?expand=1&template=feature_change.md)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,6 @@ please switch to **Preview** for links to render properly.
 
 Please choose the right template for your pull request:
 
-- 🐛 Are you fixing a bug? [Bug fix](?template=bug_fix.md)
-- 📈 Are you improving performance? [Performance improvement](?template=performance_improvement.md)
-- 💻 Are you changing functionality? [Feature change](?template=feature_change.md)
+- 🐛 Are you fixing a bug? [Bug fix](?template=bug_fix)
+- 📈 Are you improving performance? [Performance improvement](?template=performance_improvement)
+- 💻 Are you changing functionality? [Feature change](?template=feature_change)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,6 @@ please switch to **Preview** for links to render properly.
 
 Please choose the right template for your pull request:
 
-- 🐛 Are you fixing a bug? [Bug fix](?template=bug_fix)
-- 📈 Are you improving performance? [Performance improvement](?template=performance_improvement)
-- 💻 Are you changing functionality? [Feature change](?template=feature_change)
+- 🐛 Are you fixing a bug? [Bug fix](?template=.github/PULL_REQUEST_TEMPLATE/bug_fix.md)
+- 📈 Are you improving performance? [Performance improvement](?template=.github/PULL_REQUEST_TEMPLATE/performance_improvement.md)
+- 💻 Are you changing functionality? [Feature change](?template=.github/PULL_REQUEST_TEMPLATE/feature_change.md)


### PR DESCRIPTION
This PR updates the pull request template links to use full paths. This change attempts to address the issue outlined in [#2867](https://github.com/opentensor/bittensor/issues/2867#event-17700144149), where links do not render correctly.

Changes:
- Replaced links with full paths to .md files
- Ensured compatibility with GitHub’s preview/render behavior

Related Issue:
Closes #2867