### PR TITLE
Make `unstake` and `unstake_multiple` for all Alphas more clear

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -3119,6 +3119,9 @@ class AsyncSubtensor(SubtensorMixin):
             bool: True if the target block was reached, False if timeout occurred.
 
         Example:
+            import bittensor as bt
+            subtensor = bt.Subtensor()
+
             await subtensor.wait_for_block() # Waits for next block
             await subtensor.wait_for_block(block=1234) # Waits for a specific block
         """
@@ -4452,7 +4455,7 @@ class AsyncSubtensor(SubtensorMixin):
             period (Optional[int]): The number of blocks during which the transaction will remain valid after it's submitted. If
                 the transaction is not included in a block within that number of blocks, it will expire and be rejected.
                 You can think of it as an expiration date for the transaction.
-            unstake_all: If true, unstakes all tokens. Default is ``False``.
+            unstake_all: If true, unstakes all tokens. Default is ``False``. If `True` amount is ignored.
 
         Returns:
             bool: ``True`` if the unstaking process is successful, False otherwise.
@@ -4503,7 +4506,7 @@ class AsyncSubtensor(SubtensorMixin):
             period (Optional[int]): The number of blocks during which the transaction will remain valid after it's submitted. If
                 the transaction is not included in a block within that number of blocks, it will expire and be rejected.
                 You can think of it as an expiration date for the transaction.
-            unstake_all: If true, unstakes all tokens. Default is ``False``.
+            unstake_all: If true, unstakes all tokens. Default is ``False``. If `True` amounts are ignored.
 
         Returns:
             bool: ``True`` if the batch unstaking is successful, False otherwise.

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -3380,27 +3380,27 @@ class AsyncSubtensor(SubtensorMixin):
         period: Optional[int] = None,
     ) -> bool:
         """
-        Adds the specified amount of stake to a neuron identified by the hotkey ``SS58`` address.
-        Staking is a fundamental process in the Bittensor network that enables neurons to participate actively and earn
-            incentives.
+        Adds a stake from the specified wallet to the neuron identified by the SS58 address of its hotkey in specified subnet.
+        Staking is a fundamental process in the Bittensor network that enables neurons to participate actively and earn incentives.
 
         Args:
-            wallet (bittensor_wallet.Wallet): The wallet to be used for staking.
-            hotkey_ss58 (Optional[str]): The ``SS58`` address of the hotkey associated with the neuron.
-            netuid: subnet UID
-            amount (Balance): The amount of TAO to stake.
-            wait_for_inclusion (bool): Waits for the transaction to be included in a block.
-            wait_for_finalization (bool): Waits for the transaction to be finalized on the blockchain.
-            safe_staking (bool): If true, enables price safety checks to protect against fluctuating prices. The stake
-                will only execute if the price change doesn't exceed the rate tolerance. Default is False.
-            allow_partial_stake (bool): If true and safe_staking is enabled, allows partial staking when
-                the full amount would exceed the price threshold. If false, the entire stake fails if it would
-                exceed the threshold. Default is False.
-            rate_tolerance (float): The maximum allowed price change ratio when staking. For example,
-                0.005 = 0.5% maximum price increase. Only used when safe_staking is True. Default is 0.005.
-            period (Optional[int]): The number of blocks during which the transaction will remain valid after it's
-                submitted. If the transaction is not included in a block within that number of blocks, it will expire
-                and be rejected. You can think of it as an expiration date for the transaction.
+            wallet: The wallet to be used for staking.
+            hotkey_ss58: The SS58 address of the hotkey associated with the neuron to which you intend to delegate your
+                stake. If not specified, the wallet's hotkey will be used. Defaults to ``None``.
+            netuid: The unique identifier of the subnet to which the neuron belongs.
+            amount: The amount of TAO to stake.
+            wait_for_inclusion: Waits for the transaction to be included in a block. Defaults to ``True``.
+            wait_for_finalization: Waits for the transaction to be finalized on the blockchain. Defaults to ``False``.
+            safe_staking: If true, enables price safety checks to protect against fluctuating prices. The stake will
+                only execute if the price change doesn't exceed the rate tolerance. Default is ``False``.
+            allow_partial_stake: If true and safe_staking is enabled, allows partial staking when the full amount would
+                exceed the price tolerance. If false, the entire stake fails if it would exceed the tolerance.
+                Default is ``False``.
+            rate_tolerance: The maximum allowed price change ratio when staking. For example,
+                0.005 = 0.5% maximum price increase. Only used when safe_staking is True. Default is ``0.005``.
+            period: The number of blocks during which the transaction will remain valid after it's submitted. If the
+                transaction is not included in a block within that number of blocks, it will expire and be rejected. You
+                can think of it as an expiration date for the transaction. Defaults to ``None``.
 
         Returns:
             bool: ``True`` if the staking is successful, False otherwise.
@@ -4428,6 +4428,7 @@ class AsyncSubtensor(SubtensorMixin):
         allow_partial_stake: bool = False,
         rate_tolerance: float = 0.005,
         period: Optional[int] = None,
+        unstake_all: bool = False,
     ) -> bool:
         """
         Removes a specified amount of stake from a single hotkey account. This function is critical for adjusting
@@ -4451,6 +4452,7 @@ class AsyncSubtensor(SubtensorMixin):
             period (Optional[int]): The number of blocks during which the transaction will remain valid after it's submitted. If
                 the transaction is not included in a block within that number of blocks, it will expire and be rejected.
                 You can think of it as an expiration date for the transaction.
+            unstake_all: If true, unstakes all tokens. Default is ``False``.
 
         Returns:
             bool: ``True`` if the unstaking process is successful, False otherwise.
@@ -4471,6 +4473,7 @@ class AsyncSubtensor(SubtensorMixin):
             allow_partial_stake=allow_partial_stake,
             rate_tolerance=rate_tolerance,
             period=period,
+            unstake_all=unstake_all,
         )
 
     async def unstake_multiple(
@@ -4482,6 +4485,7 @@ class AsyncSubtensor(SubtensorMixin):
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
         period: Optional[int] = None,
+        unstake_all: bool = False,
     ) -> bool:
         """
         Performs batch unstaking from multiple hotkey accounts, allowing a neuron to reduce its staked amounts
@@ -4499,6 +4503,7 @@ class AsyncSubtensor(SubtensorMixin):
             period (Optional[int]): The number of blocks during which the transaction will remain valid after it's submitted. If
                 the transaction is not included in a block within that number of blocks, it will expire and be rejected.
                 You can think of it as an expiration date for the transaction.
+            unstake_all: If true, unstakes all tokens. Default is ``False``.
 
         Returns:
             bool: ``True`` if the batch unstaking is successful, False otherwise.
@@ -4515,6 +4520,7 @@ class AsyncSubtensor(SubtensorMixin):
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,
             period=period,
+            unstake_all=unstake_all,
         )
 
 

--- a/bittensor/core/extrinsics/asyncex/staking.py
+++ b/bittensor/core/extrinsics/asyncex/staking.py
@@ -28,25 +28,27 @@ async def add_stake_extrinsic(
     period: Optional[int] = None,
 ) -> bool:
     """
-    Adds the specified amount of stake to passed hotkey `uid`.
+    Adds a stake from the specified wallet to the neuron identified by the SS58 address of its hotkey in specified subnet.
+    Staking is a fundamental process in the Bittensor network that enables neurons to participate actively and earn incentives.
 
     Arguments:
-        subtensor: the initialized SubtensorInterface object to use
+        subtensor: Subtensor instance with the connection to the chain.
         wallet: Bittensor wallet object.
         old_balance: the balance prior to the staking
-        hotkey_ss58: The `ss58` address of the hotkey account to stake to defaults to the wallet's hotkey.
-        netuid: The netuid of the stake to be added
-        amount: Amount to stake as Bittensor balance, `None` if staking all.
+        hotkey_ss58: The `ss58` address of the hotkey account to stake to default to the wallet's hotkey. If not
+            specified, the wallet's hotkey will be used. Defaults to ``None``.
+        netuid: The unique identifier of the subnet to which the neuron belongs.
+        amount: Amount to stake as Bittensor balance in TAO always, `None` if staking all. Defaults is ``None``.
         wait_for_inclusion: If set, waits for the extrinsic to enter a block before returning `True`, or returns
-            `False` if the extrinsic fails to enter the block within the timeout.
+            `False` if the extrinsic fails to enter the block within the timeout.  Defaults to ``True``.
         wait_for_finalization: If set, waits for the extrinsic to be finalized on the chain before returning `True`,
-            or returns `False` if the extrinsic fails to be finalized within the timeout.
-        safe_staking: If set, uses safe staking logic
-        allow_partial_stake: If set, allows partial stake
-        rate_tolerance: The rate tolerance for safe staking
+            or returns `False` if the extrinsic fails to be finalized within the timeout. Defaults to ``False``.
+        safe_staking: If True, enables price safety checks. Default is ``False``.
+        allow_partial_stake: If True, allows partial unstaking if price tolerance exceeded. Default is ``False``.
+        rate_tolerance: Maximum allowed price increase percentage (0.005 = 0.5%). Default is ``0.005``.
         period: The number of blocks during which the transaction will remain valid after it's submitted. If
             the transaction is not included in a block within that number of blocks, it will expire and be rejected.
-            You can think of it as an expiration date for the transaction.
+            You can think of it as an expiration date for the transaction. Defaults to ``None``.
 
     Returns:
         success: Flag is `True` if extrinsic was finalized or included in the block. If we did not wait for
@@ -93,7 +95,6 @@ async def add_stake_extrinsic(
         )
     else:
         staking_balance = amount
-    staking_balance.set_unit(netuid)
 
     # Leave existential balance to keep key alive.
     if staking_balance > old_balance - existential_deposit:

--- a/bittensor/core/extrinsics/asyncex/unstaking.py
+++ b/bittensor/core/extrinsics/asyncex/unstaking.py
@@ -25,6 +25,7 @@ async def unstake_extrinsic(
     allow_partial_stake: bool = False,
     rate_tolerance: float = 0.005,
     period: Optional[int] = None,
+    unstake_all: bool = False,
 ) -> bool:
     """Removes stake into the wallet coldkey from the specified hotkey ``uid``.
 
@@ -45,11 +46,15 @@ async def unstake_extrinsic(
         period (Optional[int]): The number of blocks during which the transaction will remain valid after it's submitted.
             If the transaction is not included in a block within that number of blocks, it will expire and be rejected.
             You can think of it as an expiration date for the transaction.
+        unstake_all: If true, unstakes all tokens. Default is ``False``.
 
     Returns:
         success (bool): Flag is ``True`` if extrinsic was finalized or included in the block. If we did not wait for
             finalization / inclusion, the response is ``True``.
     """
+    if amount and unstake_all:
+        raise ValueError("Cannot specify both `amount` and `unstake_all`.")
+
     # Decrypt keys,
     if not (unlock := unlock_key(wallet)).success:
         logging.error(unlock.message)
@@ -204,6 +209,7 @@ async def unstake_multiple_extrinsic(
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
     period: Optional[int] = None,
+    unstake_all: bool = False,
 ) -> bool:
     """Removes stake from each ``hotkey_ss58`` in the list, using each amount, to a common coldkey.
 
@@ -220,11 +226,15 @@ async def unstake_multiple_extrinsic(
         period (Optional[int]): The number of blocks during which the transaction will remain valid after it's submitted.
             If the transaction is not included in a block within that number of blocks, it will expire and be rejected.
             You can think of it as an expiration date for the transaction.
+        unstake_all: If true, unstakes all tokens. Default is ``False``.
 
     Returns:
         success (bool): Flag is ``True`` if extrinsic was finalized or included in the block. Flag is ``True`` if any
             wallet was unstaked. If we did not wait for finalization / inclusion, the response is ``True``.
     """
+    if amounts and unstake_all:
+        raise ValueError("Cannot specify both `amounts` and `unstake_all`.")
+
     if not isinstance(hotkey_ss58s, list) or not all(
         isinstance(hotkey_ss58, str) for hotkey_ss58 in hotkey_ss58s
     ):

--- a/bittensor/core/extrinsics/staking.py
+++ b/bittensor/core/extrinsics/staking.py
@@ -26,24 +26,26 @@ def add_stake_extrinsic(
     period: Optional[int] = None,
 ) -> bool:
     """
-    Adds the specified amount of stake to passed hotkey `uid`.
+    Adds a stake from the specified wallet to the neuron identified by the SS58 address of its hotkey in specified subnet.
+    Staking is a fundamental process in the Bittensor network that enables neurons to participate actively and earn incentives.
 
     Arguments:
-        subtensor: the Subtensor object to use
+        subtensor: Subtensor instance with the connection to the chain.
         wallet: Bittensor wallet object.
-        hotkey_ss58: The `ss58` address of the hotkey account to stake to default to the wallet's hotkey.
-        netuid (Optional[int]): Subnet unique ID.
-        amount: Amount to stake as Bittensor balance, `None` if staking all.
+        hotkey_ss58: The `ss58` address of the hotkey account to stake to default to the wallet's hotkey. If not
+            specified, the wallet's hotkey will be used. Defaults to ``None``.
+        netuid: The unique identifier of the subnet to which the neuron belongs.
+        amount: Amount to stake as Bittensor balance in TAO always, `None` if staking all. Defaults is ``None``.
         wait_for_inclusion: If set, waits for the extrinsic to enter a block before returning `True`, or returns
-            `False` if the extrinsic fails to enter the block within the timeout.
+            `False` if the extrinsic fails to enter the block within the timeout.  Defaults to ``True``.
         wait_for_finalization: If set, waits for the extrinsic to be finalized on the chain before returning `True`,
-            or returns `False` if the extrinsic fails to be finalized within the timeout.
-        safe_staking (bool): If true, enables price safety checks
-        allow_partial_stake (bool): If true, allows partial unstaking if price tolerance exceeded
-        rate_tolerance (float): Maximum allowed price increase percentage (0.005 = 0.5%)
+            or returns `False` if the extrinsic fails to be finalized within the timeout. Defaults to ``False``.
+        safe_staking: If True, enables price safety checks. Default is ``False``.
+        allow_partial_stake: If True, allows partial unstaking if price tolerance exceeded. Default is ``False``.
+        rate_tolerance: Maximum allowed price increase percentage (0.005 = 0.5%). Default is ``0.005``.
         period: The number of blocks during which the transaction will remain valid after it's submitted. If
             the transaction is not included in a block within that number of blocks, it will expire and be rejected.
-            You can think of it as an expiration date for the transaction.
+            You can think of it as an expiration date for the transaction. Defaults to ``None``.
 
     Returns:
         success: Flag is `True` if extrinsic was finalized or included in the block. If we did not wait for
@@ -87,14 +89,11 @@ def add_stake_extrinsic(
         )
     else:
         staking_balance = amount
-    staking_balance.set_unit(netuid)
 
     # Leave existential balance to keep key alive.
     if staking_balance > old_balance - existential_deposit:
         # If we are staking all, we need to leave at least the existential deposit.
         staking_balance = old_balance - existential_deposit
-    else:
-        staking_balance = staking_balance
 
     # Check enough to stake.
     if staking_balance > old_balance:
@@ -200,7 +199,7 @@ def add_stake_extrinsic(
 
     except SubstrateRequestException as error:
         logging.error(
-            f":cross_mark: [red]Add Stake Error: {format_error_message((error))}[/red]"
+            f":cross_mark: [red]Add Stake Error: {format_error_message(error)}[/red]"
         )
         return False
 

--- a/bittensor/core/extrinsics/unstaking.py
+++ b/bittensor/core/extrinsics/unstaking.py
@@ -107,12 +107,16 @@ def unstake_extrinsic(
             base_price = pool.price.rao
             price_with_tolerance = base_price * (1 - rate_tolerance)
 
+            # For logging
+            base_rate = pool.price.tao
+            rate_with_tolerance = base_rate * (1 - rate_tolerance)
+
             logging.info(
                 f":satellite: [magenta]Safe Unstaking from:[/magenta] "
                 f"netuid: [green]{netuid}[/green], amount: [green]{unstaking_balance}[/green], "
                 f"tolerance percentage: [green]{rate_tolerance * 100}%[/green], "
-                f"price limit: [green]{price_with_tolerance}[/green], "
-                f"original price: [green]{base_price}[/green], "
+                f"price limit: [green]{rate_with_tolerance}[/green], "
+                f"original price: [green]{base_rate}[/green], "
                 f"with partial unstake: [green]{allow_partial_stake}[/green] "
                 f"on [blue]{subtensor.network}[/blue][magenta]...[/magenta]"
             )

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -2412,8 +2412,11 @@ class Subtensor(SubtensorMixin):
             bool: True if the target block was reached, False if timeout occurred.
 
         Example:
-            >>> subtensor.wait_for_block() # Waits for the next block
-            >>> subtensor.wait_for_block(block=1234) # Waits for a specific block
+            import bittensor as bt
+            subtensor = bt.Subtensor()
+
+            subtensor.wait_for_block() # Waits for the next block
+            subtensor.wait_for_block(block=1234) # Waits for a specific block
         """
 
         def handler(block_data: dict):
@@ -2431,7 +2434,7 @@ class Subtensor(SubtensorMixin):
         else:
             target_block = current_block["header"]["number"] + 1
 
-        self.substrate._get_block_handler(
+        self.substrate.get_block_handler(
             current_block_hash, header_only=True, subscription_handler=handler
         )
         return True
@@ -3695,7 +3698,7 @@ class Subtensor(SubtensorMixin):
             period (Optional[int]): The number of blocks during which the transaction will remain valid after it's submitted. If
                 the transaction is not included in a block within that number of blocks, it will expire and be rejected.
                 You can think of it as an expiration date for the transaction.
-            unstake_all: If true, unstakes all tokens. Default is ``False``.
+            unstake_all: If true, unstakes all tokens. Default is ``False``. If `True` amount is ignored.
 
         Returns:
             bool: ``True`` if the unstaking process is successful, False otherwise.
@@ -3747,7 +3750,7 @@ class Subtensor(SubtensorMixin):
             period (Optional[int]): The number of blocks during which the transaction will remain valid after it's submitted. If
                 the transaction is not included in a block within that number of blocks, it will expire and be rejected.
                 You can think of it as an expiration date for the transaction.
-            unstake_all: If true, unstakes all tokens. Default is ``False``.
+            unstake_all: If true, unstakes all tokens. Default is ``False``. If `True` amounts are ignored.
 
         Returns:
             bool: ``True`` if the batch unstaking is successful, False otherwise.

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -2945,6 +2945,7 @@ def test_unstake_success(mocker, subtensor, fake_wallet):
         allow_partial_stake=False,
         rate_tolerance=0.005,
         period=None,
+        unstake_all=False,
     )
     assert result == mock_unstake_extrinsic.return_value
 
@@ -2982,6 +2983,7 @@ def test_unstake_with_safe_staking(mocker, subtensor, fake_wallet):
         allow_partial_stake=True,
         rate_tolerance=fake_rate_tolerance,
         period=None,
+        unstake_all=False,
     )
     assert result == mock_unstake_extrinsic.return_value
 
@@ -3105,6 +3107,7 @@ def test_unstake_multiple_success(mocker, subtensor, fake_wallet):
         wait_for_inclusion=True,
         wait_for_finalization=False,
         period=None,
+        unstake_all=False,
     )
     assert result == mock_unstake_multiple_extrinsic.return_value
 

--- a/tests/unit_tests/test_subtensor_extended.py
+++ b/tests/unit_tests/test_subtensor_extended.py
@@ -1564,7 +1564,7 @@ def test_wait_for_block(mock_substrate, subtensor, mocker):
             },
         },
     ]
-    mock_substrate._get_block_handler.side_effect = get_block_handler
+    mock_substrate.get_block_handler.side_effect = get_block_handler
 
     subtensor.wait_for_block(block=9)
 


### PR DESCRIPTION
**Addressing Dynamic Stake Unstaking Challenges in Bittensor**
This Pull Request (PR) addresses a critical issue impacting the unstaking experience for Bittensor users, particularly when attempting to withdraw their entire Alpha (stake) from a hotkey within a specific subnet.

**The Problem: Discrepancy Between Expected and Actual Unstake Amounts**
Due to the highly dynamic nature of stake and emissions in the dTao ecosystem, users attempting an unstake or unstake_multiple operation with a previously retrieved Alpha amount often find that a residual stake remains on hotkey. This discrepancy occurs because network emissions can accrue between the moment the coldkey's Alpha value is queried and when the unstaking extrinsic is executed. As a result, the "full unstake" operation doesn't completely clear the hotkey's stake as intended.

**The Solution: Enhanced Unstake Logic for Full Alpha Withdrawal**
The changes introduced in this PR modify the existing logic to improve the handling of "full Alpha" unstake requests. By refining the SDK's approach to determining the unstake amount, we aim to minimize time where residual stake is left behind due to dynamic network conditions.

**Future Considerations: Chain-Side Improvements for Robustness**
While these SDK-side enhancements provide a significant improvement, the inherent latency and dynamic nature of network operations (especially for users with high latency connections or unstable internet) mean this solution isn't entirely perfect.

For a truly robust and definitive solution, we propose exploring chain-side improvements. This would involve adding new arguments `unstake_all` to the `remove_stake_limit` and `remove_stake` functions within the Subtensor itself. By doing so, the chain would gain a precise understanding of a user's intent to unstake all Alpha currently held on a hotkey within a given subnet. This would allow the network to handle the dynamic nature of stake and emissions directly, ensuring a complete and accurate unstake regardless of client-side latency.

This is the issus created on subtensor: https://github.com/opentensor/subtensor/issues/1661