### PR TITLE
Add defaults for endpoint and network from local env

### DIFF
--- a/bittensor/core/settings.py
+++ b/bittensor/core/settings.py
@@ -121,8 +121,8 @@ DEFAULTS = munchify(
             "maxsize": int(_BT_PRIORITY_MAXSIZE) if _BT_PRIORITY_MAXSIZE else 10,
         },
         "subtensor": {
-            "chain_endpoint": DEFAULT_ENDPOINT,
-            "network": DEFAULT_NETWORK,
+            "chain_endpoint": os.getenv("BT_CHAIN_ENDPOINT") or DEFAULT_ENDPOINT,
+            "network": os.getenv("BT_NETWORK") or DEFAULT_NETWORK,
             "_mock": False,
         },
         "wallet": {

--- a/bittensor/core/types.py
+++ b/bittensor/core/types.py
@@ -124,8 +124,8 @@ class SubtensorMixin(ABC):
         """
         prefix_str = "" if prefix is None else f"{prefix}."
         try:
-            default_network = settings.DEFAULT_NETWORK
-            default_chain_endpoint = settings.FINNEY_ENTRYPOINT
+            default_network = settings.DEFAULTS.subtensor.network
+            default_chain_endpoint = settings.DEFAULTS.subtensor.chain_endpoint
 
             parser.add_argument(
                 f"--{prefix_str}subtensor.network",

--- a/tests/unit_tests/test_subtensor_api.py
+++ b/tests/unit_tests/test_subtensor_api.py
@@ -6,8 +6,12 @@ import pytest
 def test_properties_methods_comparable(other_class: "Subtensor" = None):
     """Verifies that methods in SubtensorApi and its properties contains all Subtensors methods."""
     # Preps
-    subtensor = other_class(_mock=True) if other_class else Subtensor(_mock=True)
-    subtensor_api = SubtensorApi(mock=True)
+    subtensor = (
+        other_class(network="latent-lite", _mock=True)
+        if other_class
+        else Subtensor(network="latent-lite", _mock=True)
+    )
+    subtensor_api = SubtensorApi(network="latent-lite", mock=True)
 
     subtensor_methods = [m for m in dir(subtensor) if not m.startswith("_")]
 
@@ -62,8 +66,12 @@ def test__methods_comparable_with_passed_legacy_methods(
 ):
     """Verifies that methods in SubtensorApi contains all Subtensors methods if `legacy_methods=True` is passed."""
     # Preps
-    subtensor = other_class(mock=True) if other_class else Subtensor(_mock=True)
-    subtensor_api = SubtensorApi(mock=True, legacy_methods=True)
+    subtensor = (
+        other_class(network="latent-lite", mock=True)
+        if other_class
+        else Subtensor(network="latent-lite", _mock=True)
+    )
+    subtensor_api = SubtensorApi(network="latent-lite", mock=True, legacy_methods=True)
 
     subtensor_methods = [m for m in dir(subtensor) if not m.startswith("_")]
     subtensor_api_methods = [m for m in dir(subtensor_api) if not m.startswith("_")]


### PR DESCRIPTION
Adds:
- local env variable`BT_NETWORK`
- local env variable `BT_CHAIN_ENDPOINT`

Logic:
Just add local env variable `BT_NETWORK` with known settings.NETWORKS (`finney`, `test`, `archive`, `local`, `subvortex`, `latent-lite`) or `BT_CHAIN_ENDPOINT` with custom endpoint.