### PR TITLE
Fix bug in `get_next_epoch_start_block`

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1796,7 +1796,7 @@ class AsyncSubtensor(SubtensorMixin):
             netuid=netuid, block=block, block_hash=block_hash, reuse_block=reuse_block
         )
 
-        if block and blocks_since_last_step and tempo:
+        if block and blocks_since_last_step is not None and tempo:
             return block - blocks_since_last_step + tempo + 1
         return None
 

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1385,7 +1385,7 @@ class Subtensor(SubtensorMixin):
         blocks_since_last_step = self.blocks_since_last_step(netuid=netuid, block=block)
         tempo = self.tempo(netuid=netuid, block=block)
 
-        if block and blocks_since_last_step and tempo:
+        if block and blocks_since_last_step is not None and tempo:
             return block - blocks_since_last_step + tempo + 1
         return None
 

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -3719,3 +3719,30 @@ def test_get_subnet_info_no_data(mocker, subtensor):
     )
     subtensor_module.SubnetInfo.from_dict.assert_not_called()
     assert result is None
+
+
+@pytest.mark.parametrize(
+    "call_return, expected",
+    [[10, 111], [None, None], [0, 121]],
+)
+def test_get_next_epoch_start_block(mocker, subtensor, call_return, expected):
+    """Check that get_next_epoch_start_block returns the correct value."""
+    # Prep
+    netuid = mocker.Mock()
+    block = 20
+
+    mocked_blocks_since_last_step = mocker.Mock(return_value=call_return)
+    subtensor.blocks_since_last_step = mocked_blocks_since_last_step
+
+    mocker.patch.object(subtensor, "tempo", return_value=100)
+
+    # Call
+    result = subtensor.get_next_epoch_start_block(netuid=netuid, block=block)
+
+    # Asserts
+    mocked_blocks_since_last_step.assert_called_once_with(
+        netuid=netuid,
+        block=block,
+    )
+    subtensor.tempo.assert_called_once_with(netuid=netuid, block=block)
+    assert result == expected


### PR DESCRIPTION
Currently if `blocks_since_last_step==0` then function `get_next_epoch_start_block` returns `None`. 
This PR fixes this bug.