### PR TITLE
Add local env variable for `config.wallet.*`

### DIFF
--- a/bittensor/core/settings.py
+++ b/bittensor/core/settings.py
@@ -126,9 +126,9 @@ DEFAULTS = munchify(
             "_mock": False,
         },
         "wallet": {
-            "name": "default",
-            "hotkey": "default",
-            "path": str(WALLETS_DIR),
+            "name": os.getenv("BT_WALLET_NAME") or "default",
+            "hotkey": os.getenv("BT_WALLET_HOTKEY") or "default",
+            "path": os.getenv("BT_WALLET_PATH") or str(WALLETS_DIR),
         },
     }
 )


### PR DESCRIPTION
Let's be consistent with https://github.com/opentensor/btwallet/blob/main/src/python_bindings.rs#L791-L795