### PR TITLE
Websocket shutdown timer support

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -119,6 +119,7 @@ class AsyncSubtensor(SubtensorMixin):
         retry_forever: bool = False,
         _mock: bool = False,
         archive_endpoints: Optional[list[str]] = None,
+        websocket_shutdown_timer: float = 5.0
     ):
         """
         Initializes an instance of the AsyncSubtensor class.
@@ -134,6 +135,8 @@ class AsyncSubtensor(SubtensorMixin):
             archive_endpoints: Similar to fallback_endpoints, but specifically only archive nodes. Will be used in cases
                 where you are requesting a block that is too old for your current (presumably lite) node. Defaults to
                 `None`
+            websocket_shutdown_timer: Number of seconds to wait after last request before shutting down connection to
+                the node
 
         Raises:
             Any exceptions raised during the setup, configuration, or connection process.
@@ -157,6 +160,7 @@ class AsyncSubtensor(SubtensorMixin):
             retry_forever=retry_forever,
             _mock=_mock,
             archive_endpoints=archive_endpoints,
+            ws_shutdown_timer=websocket_shutdown_timer
         )
         if self.log_verbose:
             logging.info(
@@ -296,6 +300,7 @@ class AsyncSubtensor(SubtensorMixin):
         retry_forever: bool = False,
         _mock: bool = False,
         archive_endpoints: Optional[list[str]] = None,
+        ws_shutdown_timer: float = 5.0
     ) -> Union[AsyncSubstrateInterface, RetryAsyncSubstrate]:
         """Creates the Substrate instance based on provided arguments.
 
@@ -307,6 +312,7 @@ class AsyncSubtensor(SubtensorMixin):
             archive_endpoints: Similar to fallback_endpoints, but specifically only archive nodes. Will be used in cases
                 where you are requesting a block that is too old for your current (presumably lite) node. Defaults to
                 `None`
+            ws_shutdown_timer: Number of seconds to wait after last request before shutting down connection to the node
 
         Returns:
             the instance of the SubstrateInterface or RetrySyncSubstrate class.
@@ -322,6 +328,7 @@ class AsyncSubtensor(SubtensorMixin):
                 chain_name="Bittensor",
                 _mock=_mock,
                 archive_nodes=archive_endpoints,
+                ws_shutdown_timer=ws_shutdown_timer
             )
         return AsyncSubstrateInterface(
             url=self.chain_endpoint,
@@ -330,6 +337,7 @@ class AsyncSubtensor(SubtensorMixin):
             use_remote_preset=True,
             chain_name="Bittensor",
             _mock=_mock,
+            ws_shutdown_timer=ws_shutdown_timer
         )
 
     # Subtensor queries ===========================================================================================

--- a/bittensor/core/subtensor_api/__init__.py
+++ b/bittensor/core/subtensor_api/__init__.py
@@ -30,8 +30,9 @@ class SubtensorApi:
         log_verbose: Enables or disables verbose logging.
         mock: Whether this is a mock instance. Mainly just for use in testing.
         archive_endpoints: Similar to fallback_endpoints, but specifically only archive nodes. Will be used in cases
-                where you are requesting a block that is too old for your current (presumably lite) node. Defaults to
-                `None`
+            where you are requesting a block that is too old for your current (presumably lite) node. Defaults to `None`
+        websocket_shutdown_timer: Number of seconds to wait after last request before shutting down connection to
+            the node. Only applicable to AsyncSubtensor (and RetryAsyncSubtensor).
 
     Example:
         # sync version
@@ -79,6 +80,7 @@ class SubtensorApi:
         log_verbose: bool = False,
         mock: bool = False,
         archive_endpoints: Optional[list[str]] = None,
+        websocket_shutdown_timer: float = 5.0,
     ):
         self.network = network
         self._fallback_endpoints = fallback_endpoints
@@ -88,6 +90,7 @@ class SubtensorApi:
         self.log_verbose = log_verbose
         self.is_async = async_subtensor
         self._config = config
+        self._ws_shutdown_timer = websocket_shutdown_timer
 
         # assigned only for async instance
         self.initialize = None
@@ -125,6 +128,7 @@ class SubtensorApi:
                 retry_forever=self._retry_forever,
                 _mock=self._mock,
                 archive_endpoints=self._archive_endpoints,
+                websocket_shutdown_timer=self._ws_shutdown_timer,
             )
             self.initialize = _subtensor.initialize
             return _subtensor


### PR DESCRIPTION
Adds support for the new `ws_shutdown_timer` arg in `AsyncSubstrate` and `RetryAsyncSubstrate`