### PR TITLE
Add `SKIP_PULL` variable for conftest.py

### DIFF
--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -129,7 +129,7 @@ def docker_runner(params):
     """Starts a Docker container before tests and gracefully terminates it after."""
 
     def is_docker_running():
-        """Check if Docker has been run."""
+        """Check if Docker is running and optionally skip pulling the image."""
         try:
             subprocess.run(
                 ["docker", "info"],
@@ -137,7 +137,13 @@ def docker_runner(params):
                 stderr=subprocess.DEVNULL,
                 check=True,
             )
-            subprocess.run(["docker", "pull", LOCALNET_IMAGE_NAME], check=True)
+
+            skip_pull = os.getenv("SKIP_PULL", "0") == "1"
+            if not skip_pull:
+                subprocess.run(["docker", "pull", LOCALNET_IMAGE_NAME], check=True)
+            else:
+                print(f"[SKIP_PULL=1] Skipping 'docker pull {LOCALNET_IMAGE_NAME}'")
+
             return True
         except subprocess.CalledProcessError:
             return False


### PR DESCRIPTION
- apply for running built image during subtensor e2e tests

@MichaelTrestman pls add the variable `SKIP_PULL` to the docs with the next description or something similar:
```
Controls whether the Docker image used for end-to-end tests should be pulled from a remote container registry (e.g. GitHub Container Registry) before the test run.
	•	When SKIP_PULL=0 (default), the test framework runs docker pull to ensure the latest version of the image is used.
	•	When SKIP_PULL=1, the pull step is skipped. The tests will only run if the required Docker image is already available locally.
This is useful in CI pipelines where a custom image is built and should not be overwritten by a remote version.
```