### PR TITLE
Integrate Liquidity Provider feature

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -112,6 +112,7 @@ from bittensor.utils.liquidity import (
     get_fees,
     tick_to_price,
     price_to_tick,
+    LiquidityPosition,
 )
 from bittensor.utils.weight_utils import generate_weight_hash, convert_uids_and_weights
 
@@ -1829,7 +1830,7 @@ class AsyncSubtensor(SubtensorMixin):
         block: Optional[int] = None,
         block_hash: Optional[str] = None,
         reuse_block: bool = False,
-    ) -> Optional[list[dict[str, Any]]]:
+    ) -> Optional[list[LiquidityPosition]]:
         """
         Retrieves all liquidity positions for the given wallet on a specified subnet (netuid).
         Calculates associated fee rewards based on current global and tick-level fee data.
@@ -1959,14 +1960,20 @@ class AsyncSubtensor(SubtensorMixin):
             )
 
             positions.append(
-                {
-                    "id": p.value.get("id")[0],
-                    "price_low": tick_to_price(p.value.get("tick_low")[0]),
-                    "price_high": tick_to_price(p.value.get("tick_high")[0]),
-                    "liquidity": Balance.from_rao(p.value.get("liquidity")),
-                    "fees_tao": fees_tao,
-                    "fees_alpha": fees_alpha,
-                }
+                LiquidityPosition(
+                    **{
+                        "id": p.value.get("id")[0],
+                        "price_low": Balance.from_rao(
+                            int(tick_to_price(p.value.get("tick_low")[0]))
+                        ),
+                        "price_high": Balance.from_rao(
+                            int(tick_to_price(p.value.get("tick_high")[0]))
+                        ),
+                        "liquidity": Balance.from_rao(p.value.get("liquidity")),
+                        "fees_tao": fees_tao,
+                        "fees_alpha": fees_alpha,
+                    }
+                )
             )
 
         return positions

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1936,7 +1936,7 @@ class AsyncSubtensor(SubtensorMixin):
 
         # Fetch positions
         positions = []
-        for _, p in positions_response:
+        async for _, p in positions_response:
             position = p.value
 
             tick_low_idx = position.get("tick_low")[0]

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1847,8 +1847,14 @@ class AsyncSubtensor(SubtensorMixin):
         Returns:
             List of liquidity positions, or None if subnet does not exist.
         """
-        if not await self.subnet_exists(netuid):
+        if not await self.subnet_exists(netuid=netuid):
+            logging.debug(f"Subnet {netuid} does not exist.")
             return None
+
+        if not await self.is_subnet_active(netuid=netuid):
+            logging.debug(f"Subnet {netuid} is not active.")
+            return None
+
         block_hash = await self.determine_block_hash(
             block=block, block_hash=block_hash, reuse_block=reuse_block
         )

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -2011,11 +2011,11 @@ class AsyncSubtensor(SubtensorMixin):
                 LiquidityPosition(
                     **{
                         "id": position.get("id")[0],
-                        "price_low": Balance.from_rao(
-                            int(tick_to_price(position.get("tick_low")[0]))
+                        "price_low": Balance.from_tao(
+                            tick_to_price(position.get("tick_low")[0])
                         ),
-                        "price_high": Balance.from_rao(
-                            int(tick_to_price(position.get("tick_high")[0]))
+                        "price_high": Balance.from_tao(
+                            tick_to_price(position.get("tick_high")[0])
                         ),
                         "liquidity": Balance.from_rao(position.get("liquidity")),
                         "fees_tao": fees_tao,
@@ -3783,8 +3783,8 @@ class AsyncSubtensor(SubtensorMixin):
         wallet: "Wallet",
         netuid: int,
         liquidity: Balance,
-        price_low: float,
-        price_high: float,
+        price_low: Balance,
+        price_high: Balance,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
         period: Optional[int] = None,
@@ -3796,8 +3796,8 @@ class AsyncSubtensor(SubtensorMixin):
             wallet: The wallet used to sign the extrinsic (must be unlocked).
             netuid: The UID of the target subnet for which the call is being initiated.
             liquidity: The amount of liquidity to be added.
-            price_low: The lower bound of the price tick range.
-            price_high: The upper bound of the price tick range.
+            price_low: The lower bound of the price tick range. In TAO.
+            price_high: The upper bound of the price tick range. In TAO.
             wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
             wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
             period: The number of blocks during which the transaction will remain valid after it's submitted. If

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -39,15 +39,15 @@ from bittensor.core.chain_data.utils import (
 )
 from bittensor.core.config import Config
 from bittensor.core.errors import ChainError, SubstrateRequestException
+from bittensor.core.extrinsics.asyncex.children import (
+    root_set_pending_childkey_cooldown_extrinsic,
+    set_children_extrinsic,
+)
 from bittensor.core.extrinsics.asyncex.commit_reveal import commit_reveal_v3_extrinsic
 from bittensor.core.extrinsics.asyncex.move_stake import (
     transfer_stake_extrinsic,
     swap_stake_extrinsic,
     move_stake_extrinsic,
-)
-from bittensor.core.extrinsics.asyncex.children import (
-    root_set_pending_childkey_cooldown_extrinsic,
-    set_children_extrinsic,
 )
 from bittensor.core.extrinsics.asyncex.registration import (
     burned_register_extrinsic,
@@ -96,12 +96,23 @@ from bittensor.utils import (
     u16_normalized_float,
     u64_normalized_float,
 )
+from bittensor.core.extrinsics.asyncex.liquidity import (
+    add_liquidity_extrinsic,
+    remove_liquidity_extrinsic,
+    toggle_user_liquidity_extrinsic,
+)
 from bittensor.utils.balance import (
     Balance,
     fixed_to_float,
     check_and_convert_to_balance,
 )
 from bittensor.utils.btlogging import logging
+from bittensor.utils.liquidity import (
+    calculate_fees,
+    get_fees,
+    tick_to_price,
+    price_to_tick,
+)
 from bittensor.utils.weight_utils import generate_weight_hash, convert_uids_and_weights
 
 if TYPE_CHECKING:
@@ -1816,8 +1827,149 @@ class AsyncSubtensor(SubtensorMixin):
         wallet: "Wallet",
         netuid: int,
         block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        reuse_block: bool = False,
     ) -> Optional[list[dict[str, Any]]]:
-        return None
+        """
+        Retrieves all liquidity positions for the given wallet on a specified subnet (netuid).
+        Calculates associated fee rewards based on current global and tick-level fee data.
+
+        Args:
+            wallet: Wallet instance to fetch positions for.
+            netuid: Subnet unique id.
+            block: The blockchain block number for the query.
+            block_hash: The hash of the block to retrieve the parameter from. Do not specify if using block or
+                reuse_block.
+            reuse_block: Whether to use the last-used block. Do not set if using block_hash or block.
+
+        Returns:
+            List of liquidity positions, or None if subnet does not exist.
+        """
+        if not await self.subnet_exists(netuid):
+            return None
+        block_hash = await self.determine_block_hash(
+            block=block, block_hash=block_hash, reuse_block=reuse_block
+        )
+
+        query = self.substrate.query
+        (
+            fee_global_tao,
+            fee_global_alpha,
+            sqrt_price,
+            positions_response,
+        ) = await asyncio.gather(
+            query(
+                module="Swap",
+                storage_function="FeeGlobalTao",
+                params=[netuid],
+                block_hash=block_hash,
+            ),
+            query(
+                module="Swap",
+                storage_function="FeeGlobalAlpha",
+                params=[netuid],
+                block_hash=block_hash,
+            ),
+            query(
+                module="Swap",
+                storage_function="AlphaSqrtPrice",
+                params=[netuid],
+                block_hash=block_hash,
+            ),
+            self.query_map(
+                module="Swap",
+                name="Positions",
+                block=block,
+                params=[netuid, wallet.coldkeypub.ss58_address],
+            ),
+        )
+        # Fetch global fees and current price
+        current_tick = price_to_tick(sqrt_price**2)
+
+        # Fetch positions
+        positions = []
+        for _, p in positions_response:
+            value = p.value
+            tick_low_idx = value["tick_low"][0]
+            tick_high_idx = value["tick_high"][0]
+
+            tick_low, tick_high = await asyncio.gather(
+                query(
+                    module="Swap",
+                    storage_function="Ticks",
+                    params=[netuid, tick_low_idx],
+                    block_hash=block_hash,
+                ),
+                query(
+                    module="Swap",
+                    storage_function="Ticks",
+                    params=[netuid, tick_high_idx],
+                    block_hash=block_hash,
+                ),
+            )
+
+            # Calculate fees above/below range for both tokens
+            tao_below = get_fees(
+                current_tick=current_tick,
+                tick=tick_low,
+                tick_index=tick_low_idx,
+                quote=True,
+                global_fees_tao=fee_global_tao,
+                global_fees_alpha=fee_global_alpha,
+                above=False,
+            )
+            tao_above = get_fees(
+                current_tick=current_tick,
+                tick=tick_high,
+                tick_index=tick_high_idx,
+                quote=True,
+                global_fees_tao=fee_global_tao,
+                global_fees_alpha=fee_global_alpha,
+                above=True,
+            )
+            alpha_below = get_fees(
+                current_tick=current_tick,
+                tick=tick_low,
+                tick_index=tick_low_idx,
+                quote=False,
+                global_fees_tao=fee_global_tao,
+                global_fees_alpha=fee_global_alpha,
+                above=False,
+            )
+            alpha_above = get_fees(
+                current_tick=current_tick,
+                tick=tick_high,
+                tick_index=tick_high_idx,
+                quote=False,
+                global_fees_tao=fee_global_tao,
+                global_fees_alpha=fee_global_alpha,
+                above=True,
+            )
+
+            # Calculate fees earned by position
+            fees_tao, fees_alpha = calculate_fees(
+                position=value,
+                global_fees_tao=fee_global_tao,
+                global_fees_alpha=fee_global_alpha,
+                tao_fees_below_low=tao_below,
+                tao_fees_above_high=tao_above,
+                alpha_fees_below_low=alpha_below,
+                alpha_fees_above_high=alpha_above,
+                netuid=netuid,
+            )
+
+            positions.append(
+                {
+                    "id": p.value.get("id")[0],
+                    "price_low": tick_to_price(p.value.get("tick_low")[0]),
+                    "price_high": tick_to_price(p.value.get("tick_high")[0]),
+                    "liquidity": Balance.from_rao(p.value.get("liquidity")),
+                    "fees_tao": fees_tao,
+                    "fees_alpha": fees_alpha,
+                }
+            )
+
+        return positions
 
     async def get_neuron_for_pubkey_and_subnet(
         self,
@@ -3581,7 +3733,40 @@ class AsyncSubtensor(SubtensorMixin):
         wait_for_finalization: bool = False,
         period: Optional[int] = None,
     ) -> tuple[bool, str]:
-        return True, ""
+        """
+        Adds liquidity to the specified price range.
+
+        Arguments:
+            wallet: The wallet used to sign the extrinsic (must be unlocked).
+            netuid: The UID of the target subnet for which the call is being initiated.
+            liquidity: The amount of liquidity to be added.
+            price_low: The lower bound of the price tick range.
+            price_high: The upper bound of the price tick range.
+            wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
+            wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+            period: The number of blocks during which the transaction will remain valid after it's submitted. If
+                the transaction is not included in a block within that number of blocks, it will expire and be rejected.
+                You can think of it as an expiration date for the transaction.
+
+        Returns:
+            Tuple[bool, str]:
+                - True and a success message if the extrinsic is successfully submitted or processed.
+                - False and an error message if the submission fails or the wallet cannot be unlocked.
+
+        Note: Adding is allowed even when user liquidity is enabled in specified subnet. Call `toggle_user_liquidity`
+            method to enable/disable user liquidity.
+        """
+        return await add_liquidity_extrinsic(
+            subtensor=self,
+            wallet=wallet,
+            netuid=netuid,
+            liquidity=liquidity,
+            price_low=price_low,
+            price_high=price_high,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            period=period,
+        )
 
     async def add_stake_multiple(
         self,
@@ -3895,7 +4080,37 @@ class AsyncSubtensor(SubtensorMixin):
         wait_for_finalization: bool = True,
         period: Optional[int] = None,
     ) -> tuple[bool, str]:
-        return True, ""
+        """Remove liquidity and credit balances back to wallet's hotkey stake.
+
+        Arguments:
+            wallet: The wallet used to sign the extrinsic (must be unlocked).
+            netuid: The UID of the target subnet for which the call is being initiated.
+            position_id: The id of the position record in the pool.
+            wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
+            wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+            period: The number of blocks during which the transaction will remain valid after it's submitted. If
+                the transaction is not included in a block within that number of blocks, it will expire and be rejected.
+                You can think of it as an expiration date for the transaction.
+
+        Returns:
+            Tuple[bool, str]:
+                - True and a success message if the extrinsic is successfully submitted or processed.
+                - False and an error message if the submission fails or the wallet cannot be unlocked.
+
+        Note:
+            - Adding is allowed even when user liquidity is enabled in specified subnet. Call `toggle_user_liquidity`
+                extrinsic to enable/disable user liquidity.
+            - To get the `position_id` use `get_liquidity_list` method.
+        """
+        return await remove_liquidity_extrinsic(
+            subtensor=self,
+            wallet=wallet,
+            netuid=netuid,
+            position_id=position_id,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            period=period,
+        )
 
     async def reveal_weights(
         self,
@@ -4530,7 +4745,34 @@ class AsyncSubtensor(SubtensorMixin):
         wait_for_finalization: bool = False,
         period: Optional[int] = None,
     ) -> tuple[bool, str]:
-        return True, ""
+        """Allow to toggle user liquidity for specified subnet.
+
+        Arguments:
+            wallet: The wallet used to sign the extrinsic (must be unlocked).
+            netuid: The UID of the target subnet for which the call is being initiated.
+            enable: Boolean indicating whether to enable user liquidity.
+            wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
+            wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+            period: The number of blocks during which the transaction will remain valid after it's submitted. If
+                the transaction is not included in a block within that number of blocks, it will expire and be rejected.
+                You can think of it as an expiration date for the transaction.
+
+        Returns:
+            Tuple[bool, str]:
+                - True and a success message if the extrinsic is successfully submitted or processed.
+                - False and an error message if the submission fails or the wallet cannot be unlocked.
+
+        Note: The call can be executed successfully by the subnet owner only.
+        """
+        return await toggle_user_liquidity_extrinsic(
+            subtensor=self,
+            wallet=wallet,
+            netuid=netuid,
+            enable=enable,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            period=period,
+        )
 
     async def transfer(
         self,

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -4163,8 +4163,8 @@ class AsyncSubtensor(SubtensorMixin):
         wallet: "Wallet",
         netuid: int,
         position_id: int,
-        wait_for_inclusion: bool = False,
-        wait_for_finalization: bool = True,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = False,
         period: Optional[int] = None,
     ) -> tuple[bool, str]:
         """Remove liquidity and credit balances back to wallet's hotkey stake.

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1897,9 +1897,10 @@ class AsyncSubtensor(SubtensorMixin):
         # Fetch positions
         positions = []
         for _, p in positions_response:
-            value = p.value
-            tick_low_idx = value["tick_low"][0]
-            tick_high_idx = value["tick_high"][0]
+            position = p.value
+
+            tick_low_idx = position.get("tick_low")[0]
+            tick_high_idx = position.get("tick_high")[0]
 
             tick_low, tick_high = await asyncio.gather(
                 query(
@@ -1956,7 +1957,7 @@ class AsyncSubtensor(SubtensorMixin):
 
             # Calculate fees earned by position
             fees_tao, fees_alpha = calculate_fees(
-                position=value,
+                position=position,
                 global_fees_tao=fee_global_tao,
                 global_fees_alpha=fee_global_alpha,
                 tao_fees_below_low=tao_below,
@@ -1969,14 +1970,14 @@ class AsyncSubtensor(SubtensorMixin):
             positions.append(
                 LiquidityPosition(
                     **{
-                        "id": p.value.get("id")[0],
+                        "id": position.get("id")[0],
                         "price_low": Balance.from_rao(
-                            int(tick_to_price(p.value.get("tick_low")[0]))
+                            int(tick_to_price(position.get("tick_low")[0]))
                         ),
                         "price_high": Balance.from_rao(
-                            int(tick_to_price(p.value.get("tick_high")[0]))
+                            int(tick_to_price(position.get("tick_high")[0]))
                         ),
-                        "liquidity": Balance.from_rao(p.value.get("liquidity")),
+                        "liquidity": Balance.from_rao(position.get("liquidity")),
                         "fees_tao": fees_tao,
                         "fees_alpha": fees_alpha,
                     }

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -4018,6 +4018,8 @@ class AsyncSubtensor(SubtensorMixin):
             import bittensor as bt
 
             subtensor = bt.AsyncSubtensor(network="local")
+            await subtensor.initialize()
+
             my_wallet = bt.Wallet()
 
             # if `liquidity_delta` is negative

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1781,6 +1781,14 @@ class AsyncSubtensor(SubtensorMixin):
             output[decode_account_id(key)] = Certificate(item.value)
         return output
 
+    async def get_liquidity_list(
+        self,
+        wallet: "Wallet",
+        netuid: int,
+        block: Optional[int] = None,
+    ) -> Optional[list[dict[str, Any]]]:
+        return None
+
     async def get_neuron_for_pubkey_and_subnet(
         self,
         hotkey_ss58: str,
@@ -3532,6 +3540,19 @@ class AsyncSubtensor(SubtensorMixin):
             period=period,
         )
 
+    async def add_liquidity(
+        self,
+        wallet: "Wallet",
+        netuid: int,
+        liquidity: Balance,
+        price_low: float,
+        price_high: float,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = False,
+        period: Optional[int] = None,
+    ) -> tuple[bool, str]:
+        return True, ""
+
     async def add_stake_multiple(
         self,
         wallet: "Wallet",
@@ -3834,6 +3855,17 @@ class AsyncSubtensor(SubtensorMixin):
             wait_for_finalization=wait_for_finalization,
             period=period,
         )
+
+    async def remove_liquidity(
+        self,
+        wallet: "Wallet",
+        netuid: int,
+        position_id: int,
+        wait_for_inclusion: bool = False,
+        wait_for_finalization: bool = True,
+        period: Optional[int] = None,
+    ) -> tuple[bool, str]:
+        return True, ""
 
     async def reveal_weights(
         self,
@@ -4458,6 +4490,17 @@ class AsyncSubtensor(SubtensorMixin):
             rate_tolerance=rate_tolerance,
             period=period,
         )
+
+    async def toggle_user_liquidity(
+        self,
+        wallet: "Wallet",
+        netuid: int,
+        enable: bool,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = False,
+        period: Optional[int] = None,
+    ) -> tuple[bool, str]:
+        return True, ""
 
     async def transfer(
         self,

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -98,6 +98,7 @@ from bittensor.utils import (
 )
 from bittensor.core.extrinsics.asyncex.liquidity import (
     add_liquidity_extrinsic,
+    modify_liquidity_extrinsic,
     remove_liquidity_extrinsic,
     toggle_user_liquidity_extrinsic,
 )
@@ -3936,6 +3937,72 @@ class AsyncSubtensor(SubtensorMixin):
                 retries += 1
 
         return success, message
+
+    async def modify_liquidity(
+        self,
+        wallet: "Wallet",
+        netuid: int,
+        position_id: int,
+        liquidity_delta: Balance,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = False,
+        period: Optional[int] = None,
+    ) -> tuple[bool, str]:
+        """Modifies liquidity in liquidity position by adding or removing liquidity from it.
+
+        Arguments:
+            wallet: The wallet used to sign the extrinsic (must be unlocked).
+            netuid: The UID of the target subnet for which the call is being initiated.
+            position_id: The id of the position record in the pool.
+            liquidity_delta: The amount of liquidity to be added or removed (add if positive or remove if negative).
+            wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
+            wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+            period: The number of blocks during which the transaction will remain valid after it's submitted. If
+                the transaction is not included in a block within that number of blocks, it will expire and be rejected.
+                You can think of it as an expiration date for the transaction.
+
+        Returns:
+            Tuple[bool, str]:
+                - True and a success message if the extrinsic is successfully submitted or processed.
+                - False and an error message if the submission fails or the wallet cannot be unlocked.
+
+        Example:
+            import bittensor as bt
+
+            subtensor = bt.AsyncSubtensor(network="local")
+            my_wallet = bt.Wallet()
+
+            # if `liquidity_delta` is negative
+            my_liquidity_delta = Balance.from_tao(100) * -1
+            await subtensor.modify_liquidity(
+                wallet=my_wallet,
+                netuid=123,
+                position_id=2,
+                liquidity_delta=my_liquidity_delta
+            )
+
+            # if `liquidity_delta` is positive
+            my_liquidity_delta = Balance.from_tao(120)
+            await subtensor.modify_liquidity(
+                wallet=my_wallet,
+                netuid=123,
+                position_id=2,
+                liquidity_delta=my_liquidity_delta
+            )
+
+        Note: Modifying is allowed even when user liquidity is enabled in specified subnet. Call `toggle_user_liquidity`
+            to enable/disable user liquidity.
+        """
+        return await modify_liquidity_extrinsic(
+            subtensor=self,
+            wallet=wallet,
+            netuid=netuid,
+            position_id=position_id,
+            liquidity_delta=liquidity_delta,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            period=period,
+        )
 
     async def move_stake(
         self,

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1891,6 +1891,11 @@ class AsyncSubtensor(SubtensorMixin):
                 params=[netuid, wallet.coldkeypub.ss58_address],
             ),
         )
+        # convert to floats
+        fee_global_tao = fixed_to_float(fee_global_tao)
+        fee_global_alpha = fixed_to_float(fee_global_alpha)
+        sqrt_price = fixed_to_float(sqrt_price)
+
         # Fetch global fees and current price
         current_tick = price_to_tick(sqrt_price**2)
 
@@ -1980,6 +1985,7 @@ class AsyncSubtensor(SubtensorMixin):
                         "liquidity": Balance.from_rao(position.get("liquidity")),
                         "fees_tao": fees_tao,
                         "fees_alpha": fees_alpha,
+                        "netuid": position.get("netuid"),
                     }
                 )
             )

--- a/bittensor/core/extrinsics/asyncex/liquidity.py
+++ b/bittensor/core/extrinsics/asyncex/liquidity.py
@@ -74,6 +74,63 @@ async def add_liquidity_extrinsic(
     )
 
 
+async def modify_liquidity_extrinsic(
+    subtensor: "AsyncSubtensor",
+    wallet: "Wallet",
+    netuid: int,
+    position_id: int,
+    liquidity_delta: Balance,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = False,
+    period: Optional[int] = None,
+) -> tuple[bool, str]:
+    """Modifies liquidity in liquidity position by adding or removing liquidity from it.
+
+    Arguments:
+        subtensor: The Subtensor client instance used for blockchain interaction.
+        wallet: The wallet used to sign the extrinsic (must be unlocked).
+        netuid: The UID of the target subnet for which the call is being initiated.
+        position_id: The id of the position record in the pool.
+        liquidity_delta: The amount of liquidity to be added or removed (add if positive or remove if negative).
+        wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
+        wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+        period: The number of blocks during which the transaction will remain valid after it's submitted. If
+            the transaction is not included in a block within that number of blocks, it will expire and be rejected.
+            You can think of it as an expiration date for the transaction.
+
+    Returns:
+        Tuple[bool, str]:
+            - True and a success message if the extrinsic is successfully submitted or processed.
+            - False and an error message if the submission fails or the wallet cannot be unlocked.
+
+    Note: Modifying is allowed even when user liquidity is enabled in specified subnet.
+        Call `toggle_user_liquidity_extrinsic` to enable/disable user liquidity.
+    """
+    if not (unlock := unlock_key(wallet)).success:
+        logging.error(unlock.message)
+        return False, unlock.message
+
+    call = await subtensor.substrate.compose_call(
+        call_module="Swap",
+        call_function="modify_position",
+        call_params={
+            "hotkey": wallet.hotkey.ss58_address,
+            "netuid": netuid,
+            "position_id": position_id,
+            "liquidity_delta": liquidity_delta,
+        },
+    )
+
+    return await subtensor.sign_and_send_extrinsic(
+        call=call,
+        wallet=wallet,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+        use_nonce=True,
+        period=period,
+    )
+
+
 async def remove_liquidity_extrinsic(
     subtensor: "AsyncSubtensor",
     wallet: "Wallet",

--- a/bittensor/core/extrinsics/asyncex/liquidity.py
+++ b/bittensor/core/extrinsics/asyncex/liquidity.py
@@ -15,8 +15,8 @@ async def add_liquidity_extrinsic(
     wallet: "Wallet",
     netuid: int,
     liquidity: Balance,
-    price_low: float,
-    price_high: float,
+    price_low: Balance,
+    price_high: Balance,
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
     period: Optional[int] = None,
@@ -49,8 +49,8 @@ async def add_liquidity_extrinsic(
         logging.error(unlock.message)
         return False, unlock.message
 
-    tick_low = price_to_tick(price_low)
-    tick_high = price_to_tick(price_high)
+    tick_low = price_to_tick(price_low.tao)
+    tick_high = price_to_tick(price_high.tao)
 
     call = await subtensor.substrate.compose_call(
         call_module="Swap",
@@ -60,7 +60,7 @@ async def add_liquidity_extrinsic(
             "netuid": netuid,
             "tick_low": tick_low,
             "tick_high": tick_high,
-            "liquidity": liquidity,
+            "liquidity": liquidity.rao,
         },
     )
 
@@ -117,7 +117,7 @@ async def modify_liquidity_extrinsic(
             "hotkey": wallet.hotkey.ss58_address,
             "netuid": netuid,
             "position_id": position_id,
-            "liquidity_delta": liquidity_delta,
+            "liquidity_delta": liquidity_delta.rao,
         },
     )
 

--- a/bittensor/core/extrinsics/asyncex/liquidity.py
+++ b/bittensor/core/extrinsics/asyncex/liquidity.py
@@ -1,0 +1,174 @@
+from typing import Optional, TYPE_CHECKING
+
+from bittensor.utils import unlock_key
+from bittensor.utils.balance import Balance
+from bittensor.utils.btlogging import logging
+from bittensor.utils.liquidity import price_to_tick
+
+if TYPE_CHECKING:
+    from bittensor_wallet import Wallet
+    from bittensor.core.async_subtensor import AsyncSubtensor
+
+
+async def add_liquidity_extrinsic(
+    subtensor: "AsyncSubtensor",
+    wallet: "Wallet",
+    netuid: int,
+    liquidity: Balance,
+    price_low: float,
+    price_high: float,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = False,
+    period: Optional[int] = None,
+) -> tuple[bool, str]:
+    """
+    Adds liquidity to the specified price range.
+
+    Arguments:
+        subtensor: The Subtensor client instance used for blockchain interaction.
+        wallet: The wallet used to sign the extrinsic (must be unlocked).
+        netuid: The UID of the target subnet for which the call is being initiated.
+        liquidity: The amount of liquidity to be added.
+        price_low: The lower bound of the price tick range.
+        price_high: The upper bound of the price tick range.
+        wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
+        wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+        period: The number of blocks during which the transaction will remain valid after it's submitted. If
+            the transaction is not included in a block within that number of blocks, it will expire and be rejected.
+            You can think of it as an expiration date for the transaction.
+
+    Returns:
+        Tuple[bool, str]:
+            - True and a success message if the extrinsic is successfully submitted or processed.
+            - False and an error message if the submission fails or the wallet cannot be unlocked.
+
+    Note: Adding is allowed even when user liquidity is enabled in specified subnet. Call
+        `toggle_user_liquidity_extrinsic` to enable/disable user liquidity.
+    """
+    if not (unlock := unlock_key(wallet)).success:
+        logging.error(unlock.message)
+        return False, unlock.message
+
+    tick_low = price_to_tick(price_low)
+    tick_high = price_to_tick(price_high)
+
+    call = await subtensor.substrate.compose_call(
+        call_module="Swap",
+        call_function="add_liquidity",
+        call_params={
+            "hotkey": wallet.hotkey.ss58_address,
+            "netuid": netuid,
+            "tick_low": tick_low,
+            "tick_high": tick_high,
+            "liquidity": liquidity,
+        },
+    )
+
+    return await subtensor.sign_and_send_extrinsic(
+        call=call,
+        wallet=wallet,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+        use_nonce=True,
+        period=period,
+    )
+
+
+async def remove_liquidity_extrinsic(
+    subtensor: "AsyncSubtensor",
+    wallet: "Wallet",
+    netuid: int,
+    position_id: int,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = False,
+    period: Optional[int] = None,
+) -> tuple[bool, str]:
+    """Remove liquidity and credit balances back to wallet's hotkey stake.
+
+    Arguments:
+        subtensor: The Subtensor client instance used for blockchain interaction.
+        wallet: The wallet used to sign the extrinsic (must be unlocked).
+        netuid: The UID of the target subnet for which the call is being initiated.
+        position_id: The id of the position record in the pool.
+        wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
+        wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+        period: The number of blocks during which the transaction will remain valid after it's submitted. If
+            the transaction is not included in a block within that number of blocks, it will expire and be rejected.
+            You can think of it as an expiration date for the transaction.
+
+    Returns:
+        Tuple[bool, str]:
+            - True and a success message if the extrinsic is successfully submitted or processed.
+            - False and an error message if the submission fails or the wallet cannot be unlocked.
+
+    Note: Adding is allowed even when user liquidity is enabled in specified subnet.
+        Call `toggle_user_liquidity_extrinsic` to enable/disable user liquidity.
+    """
+    if not (unlock := unlock_key(wallet)).success:
+        logging.error(unlock.message)
+        return False, unlock.message
+
+    call = await subtensor.substrate.compose_call(
+        call_module="Swap",
+        call_function="remove_liquidity",
+        call_params={
+            "hotkey": wallet.hotkey.ss58_address,
+            "netuid": netuid,
+            "position_id": position_id,
+        },
+    )
+
+    return await subtensor.sign_and_send_extrinsic(
+        call=call,
+        wallet=wallet,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+        use_nonce=True,
+        period=period,
+    )
+
+
+async def toggle_user_liquidity_extrinsic(
+    subtensor: "AsyncSubtensor",
+    wallet: "Wallet",
+    netuid: int,
+    enable: bool,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = False,
+    period: Optional[int] = None,
+) -> tuple[bool, str]:
+    """Allow to toggle user liquidity for specified subnet.
+
+    Arguments:
+        subtensor: The Subtensor client instance used for blockchain interaction.
+        wallet: The wallet used to sign the extrinsic (must be unlocked).
+        netuid: The UID of the target subnet for which the call is being initiated.
+        enable: Boolean indicating whether to enable user liquidity.
+        wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
+        wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+        period: The number of blocks during which the transaction will remain valid after it's submitted. If
+            the transaction is not included in a block within that number of blocks, it will expire and be rejected.
+            You can think of it as an expiration date for the transaction.
+
+    Returns:
+        Tuple[bool, str]:
+            - True and a success message if the extrinsic is successfully submitted or processed.
+            - False and an error message if the submission fails or the wallet cannot be unlocked.
+    """
+    if not (unlock := unlock_key(wallet)).success:
+        logging.error(unlock.message)
+        return False, unlock.message
+
+    call = await subtensor.substrate.compose_call(
+        call_module="Swap",
+        call_function="toggle_user_liquidity",
+        call_params={"netuid": netuid, "enable": enable},
+    )
+
+    return await subtensor.sign_and_send_extrinsic(
+        call=call,
+        wallet=wallet,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+        period=period,
+    )

--- a/bittensor/core/extrinsics/liquidity.py
+++ b/bittensor/core/extrinsics/liquidity.py
@@ -103,8 +103,8 @@ def modify_liquidity_extrinsic(
             - True and a success message if the extrinsic is successfully submitted or processed.
             - False and an error message if the submission fails or the wallet cannot be unlocked.
 
-    Note: Modifying is allowed even when user liquidity is enabled in specified subnet.
-        Call `toggle_user_liquidity_extrinsic` to enable/disable user liquidity.
+    Note: Modifying is allowed even when user liquidity is enabled in specified subnet. Call
+        `toggle_user_liquidity_extrinsic` to enable/disable user liquidity.
     """
     if not (unlock := unlock_key(wallet)).success:
         logging.error(unlock.message)

--- a/bittensor/core/extrinsics/liquidity.py
+++ b/bittensor/core/extrinsics/liquidity.py
@@ -15,8 +15,8 @@ def add_liquidity_extrinsic(
     wallet: "Wallet",
     netuid: int,
     liquidity: Balance,
-    price_low: float,
-    price_high: float,
+    price_low: Balance,
+    price_high: Balance,
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
     period: Optional[int] = None,
@@ -49,8 +49,8 @@ def add_liquidity_extrinsic(
         logging.error(unlock.message)
         return False, unlock.message
 
-    tick_low = price_to_tick(price_low)
-    tick_high = price_to_tick(price_high)
+    tick_low = price_to_tick(price_low.tao)
+    tick_high = price_to_tick(price_high.tao)
 
     call = subtensor.substrate.compose_call(
         call_module="Swap",
@@ -60,7 +60,7 @@ def add_liquidity_extrinsic(
             "netuid": netuid,
             "tick_low": tick_low,
             "tick_high": tick_high,
-            "liquidity": liquidity,
+            "liquidity": liquidity.rao,
         },
     )
 
@@ -117,7 +117,7 @@ def modify_liquidity_extrinsic(
             "hotkey": wallet.hotkey.ss58_address,
             "netuid": netuid,
             "position_id": position_id,
-            "liquidity_delta": liquidity_delta,
+            "liquidity_delta": liquidity_delta.rao,
         },
     )
 

--- a/bittensor/core/extrinsics/liquidity.py
+++ b/bittensor/core/extrinsics/liquidity.py
@@ -1,0 +1,170 @@
+from typing import Optional, TYPE_CHECKING
+
+from bittensor.utils import unlock_key
+from bittensor.utils.balance import Balance
+from bittensor.utils.btlogging import logging
+from bittensor.utils.liquidity import price_to_tick
+
+if TYPE_CHECKING:
+    from bittensor_wallet import Wallet
+    from bittensor.core.subtensor import Subtensor
+
+
+def add_liquidity_extrinsic(
+    subtensor: "Subtensor",
+    wallet: "Wallet",
+    netuid: int,
+    liquidity: Balance,
+    price_low: float,
+    price_high: float,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = False,
+    period: Optional[int] = None,
+) -> tuple[bool, str]:
+    """
+    Adds liquidity to the specified price range.
+
+    Arguments:
+        subtensor: The Subtensor client instance used for blockchain interaction.
+        wallet: The wallet used to sign the extrinsic (must be unlocked).
+        netuid: The UID of the target subnet for which the call is being initiated.
+        liquidity: The amount of liquidity to be added.
+        price_low: The lower bound of the price tick range.
+        price_high: The upper bound of the price tick range.
+        wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
+        wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+        period: The number of blocks during which the transaction will remain valid after it's submitted. If
+            the transaction is not included in a block within that number of blocks, it will expire and be rejected.
+            You can think of it as an expiration date for the transaction.
+
+    Returns:
+        Tuple[bool, str]:
+            - True and a success message if the extrinsic is successfully submitted or processed.
+            - False and an error message if the submission fails or the wallet cannot be unlocked.
+
+    Note: Adding is allowed even when user liquidity is enabled in specified subnet. Call
+        `toggle_user_liquidity_extrinsic` to enable/disable user liquidity.
+    """
+    if not (unlock := unlock_key(wallet)).success:
+        logging.error(unlock.message)
+        return False, unlock.message
+
+    tick_low = price_to_tick(price_low)
+    tick_high = price_to_tick(price_high)
+
+    call = subtensor.substrate.compose_call(
+        call_module="Swap",
+        call_function="add_liquidity",
+        call_params={
+            "hotkey": wallet.hotkey.ss58_address,
+            "netuid": netuid,
+            "tick_low": tick_low,
+            "tick_high": tick_high,
+            "liquidity": liquidity,
+        },
+    )
+
+    return subtensor.sign_and_send_extrinsic(
+        call=call,
+        wallet=wallet,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+        use_nonce=True,
+        period=period,
+    )
+
+
+def remove_liquidity_extrinsic(
+    subtensor: "Subtensor",
+    wallet: "Wallet",
+    netuid: int,
+    position_id: int,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = False,
+    period: Optional[int] = None,
+) -> tuple[bool, str]:
+    """Remove liquidity and credit balances back to wallet's hotkey stake.
+
+    Arguments:
+        subtensor: The Subtensor client instance used for blockchain interaction.
+        wallet: The wallet used to sign the extrinsic (must be unlocked).
+        netuid: The UID of the target subnet for which the call is being initiated.
+        position_id: The id of the position record in the pool.
+        wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
+        wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+        period: The number of blocks during which the transaction will remain valid after it's submitted. If
+            the transaction is not included in a block within that number of blocks, it will expire and be rejected.
+            You can think of it as an expiration date for the transaction.
+
+    Returns:
+        Tuple[bool, str]:
+            - True and a success message if the extrinsic is successfully submitted or processed.
+            - False and an error message if the submission fails or the wallet cannot be unlocked.
+
+    Note: Adding is allowed even when user liquidity is enabled in specified subnet.
+        Call `toggle_user_liquidity_extrinsic` to enable/disable user liquidity.
+    """
+    call = subtensor.substrate.compose_call(
+        call_module="Swap",
+        call_function="remove_liquidity",
+        call_params={
+            "hotkey": wallet.hotkey.ss58_address,
+            "netuid": netuid,
+            "position_id": position_id,
+        },
+    )
+
+    return subtensor.sign_and_send_extrinsic(
+        call=call,
+        wallet=wallet,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+        use_nonce=True,
+        period=period,
+    )
+
+
+def toggle_user_liquidity_extrinsic(
+    subtensor: "Subtensor",
+    wallet: "Wallet",
+    netuid: int,
+    enable: bool,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = False,
+    period: Optional[int] = None,
+) -> tuple[bool, str]:
+    """Allow to toggle user liquidity for specified subnet.
+
+    Arguments:
+        subtensor: The Subtensor client instance used for blockchain interaction.
+        wallet: The wallet used to sign the extrinsic (must be unlocked).
+        netuid: The UID of the target subnet for which the call is being initiated.
+        enable: Boolean indicating whether to enable user liquidity.
+        wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
+        wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+        period: The number of blocks during which the transaction will remain valid after it's submitted. If
+            the transaction is not included in a block within that number of blocks, it will expire and be rejected.
+            You can think of it as an expiration date for the transaction.
+
+    Returns:
+        Tuple[bool, str]:
+            - True and a success message if the extrinsic is successfully submitted or processed.
+            - False and an error message if the submission fails or the wallet cannot be unlocked.
+    """
+    if not (unlock := unlock_key(wallet)).success:
+        logging.error(unlock.message)
+        return False, unlock.message
+
+    call = subtensor.substrate.compose_call(
+        call_module="Swap",
+        call_function="toggle_user_liquidity",
+        call_params={"netuid": netuid, "enable": enable},
+    )
+
+    return subtensor.sign_and_send_extrinsic(
+        call=call,
+        wallet=wallet,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+        period=period,
+    )

--- a/bittensor/core/extrinsics/liquidity.py
+++ b/bittensor/core/extrinsics/liquidity.py
@@ -74,6 +74,63 @@ def add_liquidity_extrinsic(
     )
 
 
+def modify_liquidity_extrinsic(
+    subtensor: "Subtensor",
+    wallet: "Wallet",
+    netuid: int,
+    position_id: int,
+    liquidity_delta: Balance,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = False,
+    period: Optional[int] = None,
+) -> tuple[bool, str]:
+    """Modifies liquidity in liquidity position by adding or removing liquidity from it.
+
+    Arguments:
+        subtensor: The Subtensor client instance used for blockchain interaction.
+        wallet: The wallet used to sign the extrinsic (must be unlocked).
+        netuid: The UID of the target subnet for which the call is being initiated.
+        position_id: The id of the position record in the pool.
+        liquidity_delta: The amount of liquidity to be added or removed (add if positive or remove if negative).
+        wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
+        wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+        period: The number of blocks during which the transaction will remain valid after it's submitted. If
+            the transaction is not included in a block within that number of blocks, it will expire and be rejected.
+            You can think of it as an expiration date for the transaction.
+
+    Returns:
+        Tuple[bool, str]:
+            - True and a success message if the extrinsic is successfully submitted or processed.
+            - False and an error message if the submission fails or the wallet cannot be unlocked.
+
+    Note: Modifying is allowed even when user liquidity is enabled in specified subnet.
+        Call `toggle_user_liquidity_extrinsic` to enable/disable user liquidity.
+    """
+    if not (unlock := unlock_key(wallet)).success:
+        logging.error(unlock.message)
+        return False, unlock.message
+
+    call = subtensor.substrate.compose_call(
+        call_module="Swap",
+        call_function="modify_position",
+        call_params={
+            "hotkey": wallet.hotkey.ss58_address,
+            "netuid": netuid,
+            "position_id": position_id,
+            "liquidity_delta": liquidity_delta,
+        },
+    )
+
+    return subtensor.sign_and_send_extrinsic(
+        call=call,
+        wallet=wallet,
+        wait_for_inclusion=wait_for_inclusion,
+        wait_for_finalization=wait_for_finalization,
+        use_nonce=True,
+        period=period,
+    )
+
+
 def remove_liquidity_extrinsic(
     subtensor: "Subtensor",
     wallet: "Wallet",

--- a/bittensor/core/extrinsics/liquidity.py
+++ b/bittensor/core/extrinsics/liquidity.py
@@ -104,6 +104,10 @@ def remove_liquidity_extrinsic(
     Note: Adding is allowed even when user liquidity is enabled in specified subnet.
         Call `toggle_user_liquidity_extrinsic` to enable/disable user liquidity.
     """
+    if not (unlock := unlock_key(wallet)).success:
+        logging.error(unlock.message)
+        return False, unlock.message
+
     call = subtensor.substrate.compose_call(
         call_module="Swap",
         call_function="remove_liquidity",

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1476,9 +1476,11 @@ class Subtensor(SubtensorMixin):
 
         positions = []
         for _, p in positions_response:
-            value = p.value
-            tick_low_idx = value["tick_low"][0]
-            tick_high_idx = value["tick_high"][0]
+            position = p.value
+            print(">>>", _, position)
+
+            tick_low_idx = position["tick_low"][0]
+            tick_high_idx = position["tick_high"][0]
 
             tick_low = query(
                 module="Swap",
@@ -1533,7 +1535,7 @@ class Subtensor(SubtensorMixin):
 
             # Calculate fees earned by position
             fees_tao, fees_alpha = calculate_fees(
-                position=value,
+                position=position,
                 global_fees_tao=fee_global_tao,
                 global_fees_alpha=fee_global_alpha,
                 tao_fees_below_low=tao_below,
@@ -1546,16 +1548,17 @@ class Subtensor(SubtensorMixin):
             positions.append(
                 LiquidityPosition(
                     **{
-                        "id": p.value.get("id")[0],
+                        "id": position.get("id")[0],
                         "price_low": Balance.from_rao(
-                            int(tick_to_price(p.value.get("tick_low")[0]))
+                            int(tick_to_price(position.get("tick_low")[0]))
                         ),
                         "price_high": Balance.from_rao(
-                            int(tick_to_price(p.value.get("tick_high")[0]))
+                            int(tick_to_price(position.get("tick_high")[0]))
                         ),
-                        "liquidity": Balance.from_rao(p.value.get("liquidity")),
+                        "liquidity": Balance.from_rao(position.get("liquidity")),
                         "fees_tao": fees_tao,
                         "fees_alpha": fees_alpha,
+                        "netuid": position.get("netuid"),
                     }
                 )
             )

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -3385,8 +3385,8 @@ class Subtensor(SubtensorMixin):
         wallet: "Wallet",
         netuid: int,
         position_id: int,
-        wait_for_inclusion: bool = False,
-        wait_for_finalization: bool = True,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = False,
         period: Optional[int] = None,
     ) -> tuple[bool, str]:
         """Remove liquidity and credit balances back to wallet's hotkey stake.

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1428,7 +1428,12 @@ class Subtensor(SubtensorMixin):
         Returns:
             List of liquidity positions, or None if subnet does not exist.
         """
-        if not self.subnet_exists(netuid):
+        if not self.subnet_exists(netuid=netuid):
+            logging.debug(f"Subnet {netuid} does not exist.")
+            return None
+
+        if not self.is_subnet_active(netuid=netuid):
+            logging.debug(f"Subnet {netuid} is not active.")
             return None
 
         query = self.substrate.query

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -48,6 +48,7 @@ from bittensor.core.extrinsics.commit_weights import (
 )
 from bittensor.core.extrinsics.liquidity import (
     add_liquidity_extrinsic,
+    modify_liquidity_extrinsic,
     remove_liquidity_extrinsic,
     toggle_user_liquidity_extrinsic,
 )
@@ -3163,6 +3164,74 @@ class Subtensor(SubtensorMixin):
                 retries += 1
 
         return success, message
+
+    def modify_liquidity(
+        self,
+        wallet: "Wallet",
+        netuid: int,
+        position_id: int,
+        liquidity_delta: Balance,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = False,
+        period: Optional[int] = None,
+    ) -> tuple[bool, str]:
+        """Modifies liquidity in liquidity position by adding or removing liquidity from it.
+
+        Arguments:
+            wallet: The wallet used to sign the extrinsic (must be unlocked).
+            netuid: The UID of the target subnet for which the call is being initiated.
+            position_id: The id of the position record in the pool.
+            liquidity_delta: The amount of liquidity to be added or removed (add if positive or remove if negative).
+            wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
+            wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+            period: The number of blocks during which the transaction will remain valid after it's submitted. If
+                the transaction is not included in a block within that number of blocks, it will expire and be rejected.
+                You can think of it as an expiration date for the transaction.
+
+        Returns:
+            Tuple[bool, str]:
+                - True and a success message if the extrinsic is successfully submitted or processed.
+                - False and an error message if the submission fails or the wallet cannot be unlocked.
+
+        Example:
+            import bittensor as bt
+
+            subtensor = bt.subtensor(network="local")
+            my_wallet = bt.Wallet()
+
+            # if `liquidity_delta` is negative
+            my_liquidity_delta = Balance.from_tao(100) * -1
+
+            subtensor.modify_liquidity(
+                wallet=my_wallet,
+                netuid=123,
+                position_id=2,
+                liquidity_delta=my_liquidity_delta
+            )
+
+            # if `liquidity_delta` is positive
+            my_liquidity_delta = Balance.from_tao(120)
+
+            subtensor.modify_liquidity(
+                wallet=my_wallet,
+                netuid=123,
+                position_id=2,
+                liquidity_delta=my_liquidity_delta
+            )
+
+        Note: Modifying is allowed even when user liquidity is enabled in specified subnet. Call `toggle_user_liquidity`
+            to enable/disable user liquidity.
+        """
+        return modify_liquidity_extrinsic(
+            subtensor=self,
+            wallet=wallet,
+            netuid=netuid,
+            position_id=position_id,
+            liquidity_delta=liquidity_delta,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            period=period,
+        )
 
     def move_stake(
         self,

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -115,6 +115,7 @@ from bittensor.utils.liquidity import (
     get_fees,
     tick_to_price,
     price_to_tick,
+    LiquidityPosition,
 )
 from bittensor.utils.weight_utils import generate_weight_hash, convert_uids_and_weights
 
@@ -1413,7 +1414,7 @@ class Subtensor(SubtensorMixin):
         wallet: "Wallet",
         netuid: int,
         block: Optional[int] = None,
-    ) -> Optional[list[dict[str, Any]]]:
+    ) -> Optional[list[LiquidityPosition]]:
         """
         Retrieves all liquidity positions for the given wallet on a specified subnet (netuid).
         Calculates associated fee rewards based on current global and tick-level fee data.
@@ -1537,14 +1538,20 @@ class Subtensor(SubtensorMixin):
             )
 
             positions.append(
-                {
-                    "id": p.value.get("id")[0],
-                    "price_low": tick_to_price(p.value.get("tick_low")[0]),
-                    "price_high": tick_to_price(p.value.get("tick_high")[0]),
-                    "liquidity": Balance.from_rao(p.value.get("liquidity")),
-                    "fees_tao": fees_tao,
-                    "fees_alpha": fees_alpha,
-                }
+                LiquidityPosition(
+                    **{
+                        "id": p.value.get("id")[0],
+                        "price_low": Balance.from_rao(
+                            int(tick_to_price(p.value.get("tick_low")[0]))
+                        ),
+                        "price_high": Balance.from_rao(
+                            int(tick_to_price(p.value.get("tick_high")[0]))
+                        ),
+                        "liquidity": Balance.from_rao(p.value.get("liquidity")),
+                        "fees_tao": fees_tao,
+                        "fees_alpha": fees_alpha,
+                    }
+                )
             )
 
         return positions

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1479,30 +1479,27 @@ class Subtensor(SubtensorMixin):
         block_hash = self.determine_block_hash(block)
 
         # Fetch global fees and current price
-        fee_global_tao = fixed_to_float(
-            query(
-                module="Swap",
-                storage_function="FeeGlobalTao",
-                params=[netuid],
-                block_hash=block_hash,
-            )
+        fee_global_tao_query = query(
+            module="Swap",
+            storage_function="FeeGlobalTao",
+            params=[netuid],
+            block_hash=block_hash,
         )
-        fee_global_alpha = fixed_to_float(
-            query(
-                module="Swap",
-                storage_function="FeeGlobalAlpha",
-                params=[netuid],
-                block_hash=block_hash,
-            )
+        fee_global_alpha_query = query(
+            module="Swap",
+            storage_function="FeeGlobalAlpha",
+            params=[netuid],
+            block_hash=block_hash,
         )
-        sqrt_price = fixed_to_float(
-            query(
-                module="Swap",
-                storage_function="AlphaSqrtPrice",
-                params=[netuid],
-                block_hash=block_hash,
-            )
+        sqrt_price_query = query(
+            module="Swap",
+            storage_function="AlphaSqrtPrice",
+            params=[netuid],
+            block_hash=block_hash,
         )
+        fee_global_tao = fixed_to_float(fee_global_tao_query)
+        fee_global_alpha = fixed_to_float(fee_global_alpha_query)
+        sqrt_price = fixed_to_float(sqrt_price_query)
         current_tick = price_to_tick(sqrt_price**2)
 
         # Fetch positions
@@ -1587,11 +1584,11 @@ class Subtensor(SubtensorMixin):
                 LiquidityPosition(
                     **{
                         "id": position.get("id")[0],
-                        "price_low": Balance.from_rao(
-                            int(tick_to_price(position.get("tick_low")[0]))
+                        "price_low": Balance.from_tao(
+                            tick_to_price(position.get("tick_low")[0])
                         ),
-                        "price_high": Balance.from_rao(
-                            int(tick_to_price(position.get("tick_high")[0]))
+                        "price_high": Balance.from_tao(
+                            tick_to_price(position.get("tick_high")[0])
                         ),
                         "liquidity": Balance.from_rao(position.get("liquidity")),
                         "fees_tao": fees_tao,
@@ -3003,8 +3000,8 @@ class Subtensor(SubtensorMixin):
         wallet: "Wallet",
         netuid: int,
         liquidity: Balance,
-        price_low: float,
-        price_high: float,
+        price_low: Balance,
+        price_high: Balance,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
         period: Optional[int] = None,
@@ -3016,8 +3013,8 @@ class Subtensor(SubtensorMixin):
             wallet: The wallet used to sign the extrinsic (must be unlocked).
             netuid: The UID of the target subnet for which the call is being initiated.
             liquidity: The amount of liquidity to be added.
-            price_low: The lower bound of the price tick range.
-            price_high: The upper bound of the price tick range.
+            price_low: The lower bound of the price tick range. In TAO.
+            price_high: The upper bound of the price tick range. In TAO.
             wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
             wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
             period: The number of blocks during which the transaction will remain valid after it's submitted. If

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1390,12 +1390,12 @@ class Subtensor(SubtensorMixin):
         Calculates associated fee rewards based on current global and tick-level fee data.
 
         Args:
-            wallet (Wallet): Wallet instance to fetch positions for.
-            netuid (int): Subnet identifier.
+            wallet: Wallet instance to fetch positions for.
+            netuid: Subnet unique id.
             block: The blockchain block number for the query.
 
         Returns:
-            Optional[list[LiquidityPosition]]: List of liquidity positions, or None if subnet does not exist.
+            List of liquidity positions, or None if subnet does not exist.
         """
         if not self.subnet_exists(netuid):
             return None

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1477,7 +1477,6 @@ class Subtensor(SubtensorMixin):
         positions = []
         for _, p in positions_response:
             position = p.value
-            print(">>>", _, position)
 
             tick_low_idx = position["tick_low"][0]
             tick_high_idx = position["tick_high"][0]

--- a/bittensor/core/subtensor_api/extrinsics.py
+++ b/bittensor/core/subtensor_api/extrinsics.py
@@ -7,6 +7,7 @@ class Extrinsics:
     """Class for managing extrinsic operations."""
 
     def __init__(self, subtensor: Union["_Subtensor", "_AsyncSubtensor"]):
+        self.add_liquidity = subtensor.add_liquidity
         self.add_stake = subtensor.add_stake
         self.add_stake_multiple = subtensor.add_stake_multiple
         self.burned_register = subtensor.burned_register
@@ -14,6 +15,7 @@ class Extrinsics:
         self.move_stake = subtensor.move_stake
         self.register = subtensor.register
         self.register_subnet = subtensor.register_subnet
+        self.remove_liquidity = subtensor.remove_liquidity
         self.reveal_weights = subtensor.reveal_weights
         self.root_register = subtensor.root_register
         self.root_set_weights = subtensor.root_set_weights
@@ -26,6 +28,7 @@ class Extrinsics:
         self.serve_axon = subtensor.serve_axon
         self.start_call = subtensor.start_call
         self.swap_stake = subtensor.swap_stake
+        self.toggle_user_liquidity = subtensor.toggle_user_liquidity
         self.transfer = subtensor.transfer
         self.transfer_stake = subtensor.transfer_stake
         self.unstake = subtensor.unstake

--- a/bittensor/core/subtensor_api/extrinsics.py
+++ b/bittensor/core/subtensor_api/extrinsics.py
@@ -12,6 +12,7 @@ class Extrinsics:
         self.add_stake_multiple = subtensor.add_stake_multiple
         self.burned_register = subtensor.burned_register
         self.commit_weights = subtensor.commit_weights
+        self.modify_liquidity = subtensor.modify_liquidity
         self.move_stake = subtensor.move_stake
         self.register = subtensor.register
         self.register_subnet = subtensor.register_subnet

--- a/bittensor/core/subtensor_api/subnets.py
+++ b/bittensor/core/subtensor_api/subnets.py
@@ -19,6 +19,7 @@ class Subnets:
         self.get_children_pending = subtensor.get_children_pending
         self.get_current_weight_commit_info = subtensor.get_current_weight_commit_info
         self.get_hyperparameter = subtensor.get_hyperparameter
+        self.get_liquidity_list = subtensor.get_liquidity_list
         self.get_neuron_for_pubkey_and_subnet = (
             subtensor.get_neuron_for_pubkey_and_subnet
         )

--- a/bittensor/core/subtensor_api/utils.py
+++ b/bittensor/core/subtensor_api/utils.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
 
 def add_legacy_methods(subtensor: "SubtensorApi"):
     """If SubtensorApi get `subtensor_fields=True` arguments, then all classic Subtensor fields added to root level."""
+    subtensor.add_liquidity = subtensor._subtensor.add_liquidity
     subtensor.add_stake = subtensor._subtensor.add_stake
     subtensor.add_stake_multiple = subtensor._subtensor.add_stake_multiple
     subtensor.all_subnets = subtensor._subtensor.all_subnets
@@ -53,6 +54,7 @@ def add_legacy_methods(subtensor: "SubtensorApi"):
     subtensor.get_hotkey_owner = subtensor._subtensor.get_hotkey_owner
     subtensor.get_hotkey_stake = subtensor._subtensor.get_hotkey_stake
     subtensor.get_hyperparameter = subtensor._subtensor.get_hyperparameter
+    subtensor.get_liquidity_list = subtensor._subtensor.get_liquidity_list
     subtensor.get_metagraph_info = subtensor._subtensor.get_metagraph_info
     subtensor.get_minimum_required_stake = (
         subtensor._subtensor.get_minimum_required_stake
@@ -129,6 +131,7 @@ def add_legacy_methods(subtensor: "SubtensorApi"):
     subtensor.query_runtime_api = subtensor._subtensor.query_runtime_api
     subtensor.query_subtensor = subtensor._subtensor.query_subtensor
     subtensor.recycle = subtensor._subtensor.recycle
+    subtensor.remove_liquidity = subtensor._subtensor.remove_liquidity
     subtensor.register = subtensor._subtensor.register
     subtensor.register_subnet = subtensor._subtensor.register_subnet
     subtensor.reveal_weights = subtensor._subtensor.reveal_weights
@@ -154,6 +157,7 @@ def add_legacy_methods(subtensor: "SubtensorApi"):
     subtensor.substrate = subtensor._subtensor.substrate
     subtensor.swap_stake = subtensor._subtensor.swap_stake
     subtensor.tempo = subtensor._subtensor.tempo
+    subtensor.toggle_user_liquidity = subtensor._subtensor.toggle_user_liquidity
     subtensor.transfer = subtensor._subtensor.transfer
     subtensor.transfer_stake = subtensor._subtensor.transfer_stake
     subtensor.tx_rate_limit = subtensor._subtensor.tx_rate_limit

--- a/bittensor/core/subtensor_api/utils.py
+++ b/bittensor/core/subtensor_api/utils.py
@@ -121,6 +121,7 @@ def add_legacy_methods(subtensor: "SubtensorApi"):
     subtensor.max_weight_limit = subtensor._subtensor.max_weight_limit
     subtensor.metagraph = subtensor._subtensor.metagraph
     subtensor.min_allowed_weights = subtensor._subtensor.min_allowed_weights
+    subtensor.modify_liquidity = subtensor._subtensor.modify_liquidity
     subtensor.move_stake = subtensor._subtensor.move_stake
     subtensor.network = subtensor._subtensor.network
     subtensor.neurons = subtensor._subtensor.neurons

--- a/bittensor/utils/balance.py
+++ b/bittensor/utils/balance.py
@@ -69,7 +69,7 @@ class Balance:
             self.rao = int(balance * pow(10, 9))
         else:
             raise TypeError(
-                f"Balance must be an int (rao) or a float (tao). You passed: `{type(balance)}`."
+                f"Balance must be an int (rao) or a float (tao), not  `{type(balance)}`."
             )
 
     @property

--- a/bittensor/utils/balance.py
+++ b/bittensor/utils/balance.py
@@ -68,7 +68,7 @@ class Balance:
             # Assume tao value for the float
             self.rao = int(balance * pow(10, 9))
         else:
-            raise TypeError("balance must be an int (rao) or a float (tao)")
+            raise TypeError(f"Balance must be an int (rao) or a float (tao). You passed: `{type(balance)}`.")
 
     @property
     def tao(self):

--- a/bittensor/utils/balance.py
+++ b/bittensor/utils/balance.py
@@ -68,7 +68,9 @@ class Balance:
             # Assume tao value for the float
             self.rao = int(balance * pow(10, 9))
         else:
-            raise TypeError(f"Balance must be an int (rao) or a float (tao). You passed: `{type(balance)}`.")
+            raise TypeError(
+                f"Balance must be an int (rao) or a float (tao). You passed: `{type(balance)}`."
+            )
 
     @property
     def tao(self):

--- a/bittensor/utils/liquidity.py
+++ b/bittensor/utils/liquidity.py
@@ -64,16 +64,14 @@ class LiquidityPosition:
 def price_to_tick(price: float) -> int:
     """Converts a float price to the nearest Uniswap V3 tick index."""
     if price <= 0:
-        raise ValueError(f"Price must be positive, got {price}")
+        raise ValueError(f"Price must be positive, got `{price}`.")
 
-    log_base = math.log1p(PRICE_STEP - 1)  # safer for small deltas
-    tick = round(math.log(price) / log_base)
+    tick = int(math.log(price) / math.log(PRICE_STEP))
 
-    if tick < MIN_TICK or tick > MAX_TICK:
+    if not (MIN_TICK <= tick <= MAX_TICK):
         raise ValueError(
             f"Resulting tick {tick} is out of allowed range ({MIN_TICK} to {MAX_TICK})"
         )
-
     return tick
 
 
@@ -133,8 +131,7 @@ def calculate_fees(
     alpha_fees_below_low: float,
     alpha_fees_above_high: float,
     netuid: int,
-) -> list[Balance]:
-    """Calculate fees from position and fees values."""
+) -> tuple[Balance, Balance]:
     fee_tao_agg = get_fees_in_range(
         quote=True,
         global_fees_tao=global_fees_tao,
@@ -142,6 +139,7 @@ def calculate_fees(
         fees_below_low=tao_fees_below_low,
         fees_above_high=tao_fees_above_high,
     )
+
     fee_alpha_agg = get_fees_in_range(
         quote=False,
         global_fees_tao=global_fees_tao,
@@ -157,4 +155,4 @@ def calculate_fees(
     fee_tao = liquidity_frac * fee_tao
     fee_alpha = liquidity_frac * fee_alpha
 
-    return [Balance.from_rao(fee_tao), Balance.from_rao(fee_alpha, netuid)]
+    return Balance.from_rao(int(fee_tao)), Balance.from_rao(int(fee_alpha), netuid)

--- a/bittensor/utils/liquidity.py
+++ b/bittensor/utils/liquidity.py
@@ -41,14 +41,22 @@ def get_fees(
     above: bool,
 ) -> float:
     """Returns the liquidity fee."""
-    tick_fee_key = 'fees_out_tao' if quote else 'fees_out_alpha'
+    tick_fee_key = "fees_out_tao" if quote else "fees_out_alpha"
     tick_fee_value = fixed_to_float(tick.get(tick_fee_key))
     global_fee_value = global_fees_tao if quote else global_fees_alpha
 
     if above:
-        return global_fee_value - tick_fee_value if tick_index <= current_tick else tick_fee_value
+        return (
+            global_fee_value - tick_fee_value
+            if tick_index <= current_tick
+            else tick_fee_value
+        )
     else:
-        return tick_fee_value if tick_index <= current_tick else global_fee_value - tick_fee_value
+        return (
+            tick_fee_value
+            if tick_index <= current_tick
+            else global_fee_value - tick_fee_value
+        )
 
 
 def get_fees_in_range(

--- a/bittensor/utils/liquidity.py
+++ b/bittensor/utils/liquidity.py
@@ -24,15 +24,15 @@ class LiquidityPosition:
     liquidity: Balance  # TAO + ALPHA (sqrt by TAO balance * Alpha Balance -> math under the hood)
     fees_tao: Balance  # RAO
     fees_alpha: Balance  # RAO
+    netuid: int
 
     def to_token_amounts(
-        self, current_subnet_price: Balance, netuid: int
+        self, current_subnet_price: Balance
     ) -> tuple[Balance, Balance]:
         """Convert a position to token amounts.
 
         Arguments:
             current_subnet_price: current subnet price in Alpha.
-            netuid: Subnet uid.
 
         Returns:
             tuple[int, int]:
@@ -56,7 +56,7 @@ class LiquidityPosition:
                 1 / sqrt_current_subnet_price - 1 / sqrt_price_high
             )
             amount_tao = self.liquidity * (sqrt_current_subnet_price - sqrt_price_low)
-        return Balance.from_rao(int(amount_alpha), netuid), Balance.from_rao(
+        return Balance.from_rao(int(amount_alpha), self.netuid), Balance.from_rao(
             int(amount_tao)
         )
 

--- a/bittensor/utils/liquidity.py
+++ b/bittensor/utils/liquidity.py
@@ -1,0 +1,121 @@
+import math
+from typing import Any
+
+from bittensor.utils.balance import Balance, fixed_to_float
+
+MIN_TICK = -887272
+MAX_TICK = 887272
+PRICE_STEP = 1.0001
+
+
+def price_to_tick(price: float) -> int:
+    """Converts a float price to the nearest Uniswap V3 tick index."""
+    if price <= 0:
+        raise ValueError(f"Price must be positive, got {price}")
+
+    log_base = math.log1p(PRICE_STEP - 1)  # safer for small deltas
+    tick = round(math.log(price) / log_base)
+
+    if tick < MIN_TICK or tick > MAX_TICK:
+        raise ValueError(
+            f"Resulting tick {tick} is out of allowed range ({MIN_TICK} to {MAX_TICK})"
+        )
+
+    return tick
+
+
+def tick_to_price(tick: int) -> float:
+    """Convert an integer Uniswap V3 tick index to float price."""
+    if not (MIN_TICK <= tick <= MAX_TICK):
+        raise ValueError("Tick is out of allowed range")
+    return PRICE_STEP**tick
+
+
+def get_fees_above(
+    current_tick: int,
+    tick: dict,
+    tick_index: int,
+    quote: bool,
+    global_fees_tao: float,
+    global_fees_alpha: float,
+) -> float:
+    """Returns the upper value of the liquidity fee."""
+    if tick_index <= current_tick:
+        if quote:
+            return global_fees_tao - fixed_to_float(tick.get("fees_out_tao"))
+        else:
+            return global_fees_alpha - fixed_to_float(tick.get("fees_out_alpha"))
+    elif quote:
+        return fixed_to_float(tick.get("fees_out_tao"))
+    else:
+        return fixed_to_float(tick.get("fees_out_alpha"))
+
+
+def get_fees_below(
+    current_tick: int,
+    tick: dict,
+    tick_index: int,
+    quote: bool,
+    global_fees_tao: float,
+    global_fees_alpha: float,
+) -> float:
+    """Returns the upper value of the liquidity fee."""
+    if tick_index <= current_tick:
+        if quote:
+            return fixed_to_float(tick.get("fees_out_tao"))
+        else:
+            return fixed_to_float(tick.get("fees_out_alpha"))
+    elif quote:
+        return global_fees_tao - fixed_to_float(tick.get("fees_out_tao"))
+    else:
+        return global_fees_alpha - fixed_to_float(tick.get("fees_out_alpha"))
+
+
+def get_fees_in_range(
+    quote: bool,
+    global_fees_tao: float,
+    global_fees_alpha: float,
+    fees_below_low: float,
+    fees_above_high: float,
+) -> float:
+    """Returns the liquidity fee value in a range."""
+    global_fees = global_fees_tao if quote else global_fees_alpha
+    return global_fees - fees_below_low - fees_above_high
+
+
+# Calculate fees for a position
+def calculate_fees(
+    position: dict[str, Any],
+    global_fees_tao: float,
+    global_fees_alpha: float,
+    tao_fees_below_low: float,
+    tao_fees_above_high: float,
+    alpha_fees_below_low: float,
+    alpha_fees_above_high: float,
+    netuid: int,
+) -> list[Balance]:
+    """Calculate fees from position and fees values."""
+    fee_tao_agg = get_fees_in_range(
+        quote=True,
+        global_fees_tao=global_fees_tao,
+        global_fees_alpha=global_fees_alpha,
+        fees_below_low=tao_fees_below_low,
+        fees_above_high=tao_fees_above_high,
+    )
+    fee_alpha_agg = get_fees_in_range(
+        quote=False,
+        global_fees_tao=global_fees_tao,
+        global_fees_alpha=global_fees_alpha,
+        fees_below_low=alpha_fees_below_low,
+        fees_above_high=alpha_fees_above_high,
+    )
+
+    fee_tao = fee_tao_agg - fixed_to_float(position["fees_tao"])
+    fee_alpha = fee_alpha_agg - fixed_to_float(position["fees_alpha"])
+
+    liquidity_frac = position["liquidity"]
+
+    fee_tao = liquidity_frac * fee_tao
+    fee_alpha = liquidity_frac * fee_alpha
+
+    return [Balance.from_rao(fee_tao), Balance.from_rao(fee_alpha, netuid)]

--- a/bittensor/utils/liquidity.py
+++ b/bittensor/utils/liquidity.py
@@ -25,7 +25,9 @@ class LiquidityPosition:
     fees_tao: Balance  # RAO
     fees_alpha: Balance  # RAO
 
-    def to_token_amounts(self, current_subnet_price: Balance, netuid: int) -> tuple[Balance, Balance]:
+    def to_token_amounts(
+        self, current_subnet_price: Balance, netuid: int
+    ) -> tuple[Balance, Balance]:
         """Convert a position to token amounts.
 
         Arguments:
@@ -50,9 +52,13 @@ class LiquidityPosition:
             amount_alpha = 0
             amount_tao = self.liquidity * (sqrt_price_high - sqrt_price_low)
         else:
-            amount_alpha = self.liquidity * (1 / sqrt_current_subnet_price - 1 / sqrt_price_high)
+            amount_alpha = self.liquidity * (
+                1 / sqrt_current_subnet_price - 1 / sqrt_price_high
+            )
             amount_tao = self.liquidity * (sqrt_current_subnet_price - sqrt_price_low)
-        return Balance.from_rao(int(amount_alpha), netuid), Balance.from_rao(int(amount_tao))
+        return Balance.from_rao(int(amount_alpha), netuid), Balance.from_rao(
+            int(amount_tao)
+        )
 
 
 def price_to_tick(price: float) -> int:

--- a/bittensor/utils/liquidity.py
+++ b/bittensor/utils/liquidity.py
@@ -31,44 +31,24 @@ def tick_to_price(tick: int) -> float:
     return PRICE_STEP**tick
 
 
-def get_fees_above(
+def get_fees(
     current_tick: int,
     tick: dict,
     tick_index: int,
     quote: bool,
     global_fees_tao: float,
     global_fees_alpha: float,
+    above: bool,
 ) -> float:
-    """Returns the upper value of the liquidity fee."""
-    if tick_index <= current_tick:
-        if quote:
-            return global_fees_tao - fixed_to_float(tick.get("fees_out_tao"))
-        else:
-            return global_fees_alpha - fixed_to_float(tick.get("fees_out_alpha"))
-    elif quote:
-        return fixed_to_float(tick.get("fees_out_tao"))
-    else:
-        return fixed_to_float(tick.get("fees_out_alpha"))
+    """Returns the liquidity fee."""
+    tick_fee_key = 'fees_out_tao' if quote else 'fees_out_alpha'
+    tick_fee_value = fixed_to_float(tick.get(tick_fee_key))
+    global_fee_value = global_fees_tao if quote else global_fees_alpha
 
-
-def get_fees_below(
-    current_tick: int,
-    tick: dict,
-    tick_index: int,
-    quote: bool,
-    global_fees_tao: float,
-    global_fees_alpha: float,
-) -> float:
-    """Returns the upper value of the liquidity fee."""
-    if tick_index <= current_tick:
-        if quote:
-            return fixed_to_float(tick.get("fees_out_tao"))
-        else:
-            return fixed_to_float(tick.get("fees_out_alpha"))
-    elif quote:
-        return global_fees_tao - fixed_to_float(tick.get("fees_out_tao"))
+    if above:
+        return global_fee_value - tick_fee_value if tick_index <= current_tick else tick_fee_value
     else:
-        return global_fees_alpha - fixed_to_float(tick.get("fees_out_alpha"))
+        return tick_fee_value if tick_index <= current_tick else global_fee_value - tick_fee_value
 
 
 def get_fees_in_range(

--- a/tests/e2e_tests/test_liquidity.py
+++ b/tests/e2e_tests/test_liquidity.py
@@ -65,6 +65,15 @@ async def test_liquidity(local_chain, subtensor, alice_wallet, bob_wallet):
     assert success, message
     assert message == "", "❌ Cannot enable user liquidity."
 
+    # Add stake to herself to have Alpha (affect non-fast-blocks chain)
+    assert subtensor.extrinsics.add_stake(
+        wallet=alice_wallet,
+        netuid=alice_subnet_netuid,
+        amount=Balance.from_tao(100),
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+    ), "❌ Cannot add stake."
+
     # Add liquidity
     success, message = subtensor.extrinsics.add_liquidity(
         wallet=alice_wallet,

--- a/tests/e2e_tests/test_liquidity.py
+++ b/tests/e2e_tests/test_liquidity.py
@@ -1,0 +1,215 @@
+import pytest
+
+from bittensor import Balance
+from tests.e2e_tests.utils.e2e_test_utils import wait_to_start_call
+from bittensor.utils.liquidity import LiquidityPosition
+
+
+@pytest.mark.asyncio
+async def test_liquidity(local_chain, subtensor, alice_wallet, bob_wallet):
+    """
+    Tests the liquidity mechanism
+
+    Steps:
+        1. Check `get_liquidity_list` return None if SN doesn't exist.
+        2. Register a subnet through Alice.
+        3. Make sure `get_liquidity_list` return None without activ SN.
+        4. Wait until start call availability and do this call.
+        5. Add liquidity to the subnet and check `get_liquidity_list` return liquidity positions.
+        6. Modify liquidity and check `get_liquidity_list` return new liquidity positions with modified liquidity value.
+        7. Add second liquidity position and check `get_liquidity_list` return new liquidity positions with 0 index.
+        8. Remove all liquidity positions and check `get_liquidity_list` return empty list.
+    """
+
+    alice_subnet_netuid = subtensor.get_total_subnets()  # 2
+
+    # Make sure `get_liquidity_list` return None if SN doesn't exist
+    assert (
+        subtensor.get_liquidity_list(wallet=alice_wallet, netuid=alice_subnet_netuid)
+        is None
+    ), "❌ `get_liquidity_list` is not None for unexisting subnet."
+
+    # Register root as Alice
+    assert subtensor.register_subnet(alice_wallet), "❌ Unable to register the subnet"
+
+    # Verify subnet 2 created successfully
+    assert subtensor.subnets.subnet_exists(alice_subnet_netuid), (
+        f"❌ Subnet {alice_subnet_netuid} wasn't created successfully"
+    )
+
+    # Make sure `get_liquidity_list` return None without activ SN
+    assert (
+        subtensor.subnets.get_liquidity_list(
+            wallet=alice_wallet, netuid=alice_subnet_netuid
+        )
+        is None
+    ), "❌ `get_liquidity_list` is not None when no activ subnet."
+
+    # Wait until start call availability and do this call
+    assert wait_to_start_call(subtensor, alice_wallet, alice_subnet_netuid)
+
+    # Make sure `get_liquidity_list` return None without activ SN
+    assert (
+        subtensor.subnets.get_liquidity_list(
+            wallet=alice_wallet, netuid=alice_subnet_netuid
+        )
+        == []
+    ), "❌ `get_liquidity_list` is not empty list before fist liquidity add."
+
+    # enable user liquidity in SN
+    success, message = subtensor.extrinsics.toggle_user_liquidity(
+        wallet=alice_wallet,
+        netuid=alice_subnet_netuid,
+        enable=True,
+    )
+    assert success, message
+    assert message == "", "❌ Cannot enable user liquidity."
+
+    # Add liquidity
+    success, message = subtensor.extrinsics.add_liquidity(
+        wallet=alice_wallet,
+        netuid=alice_subnet_netuid,
+        liquidity=Balance.from_tao(1000),
+        price_low=900_000_000,
+        price_high=1100_000_000,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+    )
+    assert success, message
+    assert message == "", "❌ Cannot add liquidity."
+
+    # Add liquidity
+    liquidity_positions = subtensor.subnets.get_liquidity_list(
+        wallet=alice_wallet, netuid=alice_subnet_netuid
+    )
+
+    assert len(liquidity_positions) == 1, (
+        "❌ liquidity_positions has more than one element."
+    )
+
+    # Check if liquidity is correct
+    liquidity_position = liquidity_positions[0]
+    assert liquidity_position == LiquidityPosition(
+        id=2,
+        price_low=liquidity_position.price_low,
+        price_high=liquidity_position.price_high,
+        liquidity=Balance.from_tao(1000),
+        fees_tao=Balance.from_tao(0),
+        fees_alpha=Balance.from_tao(0, netuid=alice_subnet_netuid),
+        netuid=alice_subnet_netuid,
+    ), "❌ `get_liquidity_list` still empty list after liquidity add."
+
+    # Modify liquidity position with positive value
+    success, message = subtensor.extrinsics.modify_liquidity(
+        wallet=alice_wallet,
+        netuid=alice_subnet_netuid,
+        position_id=liquidity_position.id,
+        liquidity_delta=Balance.from_tao(500),
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+    )
+    assert success, message
+    assert message == "", "❌ cannot modify liquidity position."
+
+    liquidity_positions = subtensor.subnets.get_liquidity_list(
+        wallet=alice_wallet, netuid=alice_subnet_netuid
+    )
+
+    assert len(liquidity_positions) == 1, (
+        "❌ liquidity_positions has more than one element."
+    )
+    liquidity_position = liquidity_positions[0]
+
+    assert liquidity_position == LiquidityPosition(
+        id=2,
+        price_low=liquidity_position.price_low,
+        price_high=liquidity_position.price_high,
+        liquidity=Balance.from_tao(1500),
+        fees_tao=Balance.from_tao(0),
+        fees_alpha=Balance.from_tao(0, netuid=alice_subnet_netuid),
+        netuid=alice_subnet_netuid,
+    )
+
+    # Modify liquidity position with negative value
+    success, message = subtensor.extrinsics.modify_liquidity(
+        wallet=alice_wallet,
+        netuid=alice_subnet_netuid,
+        position_id=liquidity_position.id,
+        liquidity_delta=-Balance.from_tao(750),
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+    )
+    assert success, message
+    assert message == "", "❌ cannot modify liquidity position."
+
+    liquidity_positions = subtensor.subnets.get_liquidity_list(
+        wallet=alice_wallet, netuid=alice_subnet_netuid
+    )
+
+    assert len(liquidity_positions) == 1, (
+        "❌ liquidity_positions has more than one element."
+    )
+    liquidity_position = liquidity_positions[0]
+
+    assert liquidity_position == LiquidityPosition(
+        id=2,
+        price_low=liquidity_position.price_low,
+        price_high=liquidity_position.price_high,
+        liquidity=Balance.from_tao(750),
+        fees_tao=Balance.from_tao(0),
+        fees_alpha=Balance.from_tao(0, netuid=alice_subnet_netuid),
+        netuid=alice_subnet_netuid,
+    )
+
+    # Add second liquidity position
+    success, message = subtensor.extrinsics.add_liquidity(
+        wallet=alice_wallet,
+        netuid=alice_subnet_netuid,
+        liquidity=Balance.from_tao(150),
+        price_low=800_000_000,
+        price_high=1200_000_000,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+    )
+    assert success, message
+    assert message == "", "❌ Cannot add liquidity."
+
+    liquidity_positions = subtensor.subnets.get_liquidity_list(
+        wallet=alice_wallet, netuid=alice_subnet_netuid
+    )
+
+    assert len(liquidity_positions) == 2, (
+        f"❌ liquidity_positions should have 2 elements, but has only {len(liquidity_positions)} element."
+    )
+
+    # All new liquidity inserts on the 0 index
+    liquidity_position = liquidity_positions[0]
+    assert liquidity_position == LiquidityPosition(
+        id=3,
+        price_low=liquidity_position.price_low,
+        price_high=liquidity_position.price_high,
+        liquidity=Balance.from_tao(150),
+        fees_tao=Balance.from_tao(0),
+        fees_alpha=Balance.from_tao(0, netuid=alice_subnet_netuid),
+        netuid=alice_subnet_netuid,
+    )
+
+    # Remove all liquidity positions
+    for p in liquidity_positions:
+        success, message = subtensor.extrinsics.remove_liquidity(
+            wallet=alice_wallet,
+            netuid=alice_subnet_netuid,
+            position_id=p.id,
+            wait_for_inclusion=True,
+            wait_for_finalization=True,
+        )
+        assert success, message
+        assert message == "", "❌ Cannot remove liquidity."
+
+    # Make sure all liquidity positions removed
+    assert (
+        subtensor.subnets.get_liquidity_list(
+            wallet=alice_wallet, netuid=alice_subnet_netuid
+        )
+        == []
+    ), "❌ Not all liquidity positions removed."

--- a/tests/e2e_tests/test_liquidity.py
+++ b/tests/e2e_tests/test_liquidity.py
@@ -79,8 +79,8 @@ async def test_liquidity(local_chain, subtensor, alice_wallet, bob_wallet):
         wallet=alice_wallet,
         netuid=alice_subnet_netuid,
         liquidity=Balance.from_tao(1000),
-        price_low=900_000_000,
-        price_high=1100_000_000,
+        price_low=Balance.from_tao(0.9),
+        price_high=Balance.from_tao(1.1),
         wait_for_inclusion=True,
         wait_for_finalization=True,
     )
@@ -175,8 +175,8 @@ async def test_liquidity(local_chain, subtensor, alice_wallet, bob_wallet):
         wallet=alice_wallet,
         netuid=alice_subnet_netuid,
         liquidity=Balance.from_tao(150),
-        price_low=800_000_000,
-        price_high=1200_000_000,
+        price_low=Balance.from_tao(0.8),
+        price_high=Balance.from_tao(1.2),
         wait_for_inclusion=True,
         wait_for_finalization=True,
     )

--- a/tests/e2e_tests/test_liquidity.py
+++ b/tests/e2e_tests/test_liquidity.py
@@ -67,6 +67,17 @@ async def test_liquidity(local_chain, subtensor, alice_wallet, bob_wallet):
     assert success, message
     assert message == "", "❌ Cannot enable user liquidity."
 
+    # In non fast-blocks node Alice doesn't have stake
+    if not subtensor.chain.is_fast_blocks():
+        assert subtensor.extrinsics.add_stake(
+            wallet=alice_wallet,
+            hotkey_ss58=alice_wallet.hotkey.ss58_address,
+            netuid=alice_subnet_netuid,
+            amount=Balance.from_tao(1000),
+            wait_for_inclusion=True,
+            wait_for_finalization=True,
+        ), "❌ Cannot cannot add stake to Alice from Alice."
+
     # Add liquidity
     success, message = subtensor.extrinsics.add_liquidity(
         wallet=alice_wallet,

--- a/tests/unit_tests/extrinsics/asyncex/test_liquidity.py
+++ b/tests/unit_tests/extrinsics/asyncex/test_liquidity.py
@@ -36,7 +36,7 @@ async def test_add_liquidity_extrinsic(subtensor, fake_wallet, mocker):
             "netuid": fake_netuid,
             "tick_low": mocked_price_to_tick.return_value,
             "tick_high": mocked_price_to_tick.return_value,
-            "liquidity": fake_liquidity,
+            "liquidity": fake_liquidity.rao,
         },
     )
     mocked_sign_and_send_extrinsic.assert_awaited_once_with(
@@ -80,7 +80,7 @@ async def test_modify_liquidity_extrinsic(subtensor, fake_wallet, mocker):
             "hotkey": fake_wallet.hotkey.ss58_address,
             "netuid": fake_netuid,
             "position_id": fake_position_id,
-            "liquidity_delta": fake_liquidity_delta,
+            "liquidity_delta": fake_liquidity_delta.rao,
         },
     )
     mocked_sign_and_send_extrinsic.assert_awaited_once_with(

--- a/tests/unit_tests/extrinsics/asyncex/test_liquidity.py
+++ b/tests/unit_tests/extrinsics/asyncex/test_liquidity.py
@@ -1,0 +1,174 @@
+import pytest
+from bittensor.core.extrinsics.asyncex import liquidity
+
+
+@pytest.mark.asyncio
+async def test_add_liquidity_extrinsic(subtensor, fake_wallet, mocker):
+    """Test that the add `add_liquidity_extrinsic` executes correct calls."""
+    # Preps
+    fake_netuid = 1
+    fake_liquidity = mocker.Mock()
+    fake_price_low = mocker.Mock()
+    fake_price_high = mocker.Mock()
+
+    mocked_compose_call = mocker.patch.object(subtensor.substrate, "compose_call")
+    mocked_sign_and_send_extrinsic = mocker.patch.object(
+        subtensor, "sign_and_send_extrinsic"
+    )
+    mocked_price_to_tick = mocker.patch.object(liquidity, "price_to_tick")
+
+    # Call
+    result = await liquidity.add_liquidity_extrinsic(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=fake_netuid,
+        liquidity=fake_liquidity,
+        price_low=fake_price_low,
+        price_high=fake_price_high,
+    )
+
+    # Asserts
+    mocked_compose_call.assert_awaited_once_with(
+        call_module="Swap",
+        call_function="add_liquidity",
+        call_params={
+            "hotkey": fake_wallet.hotkey.ss58_address,
+            "netuid": fake_netuid,
+            "tick_low": mocked_price_to_tick.return_value,
+            "tick_high": mocked_price_to_tick.return_value,
+            "liquidity": fake_liquidity,
+        },
+    )
+    mocked_sign_and_send_extrinsic.assert_awaited_once_with(
+        call=mocked_compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        use_nonce=True,
+        period=None,
+    )
+    assert result == mocked_sign_and_send_extrinsic.return_value
+
+
+@pytest.mark.asyncio
+async def test_modify_liquidity_extrinsic(subtensor, fake_wallet, mocker):
+    """Test that the add `modify_liquidity_extrinsic` executes correct calls."""
+    # Preps
+    fake_netuid = 1
+    fake_position_id = 2
+    fake_liquidity_delta = mocker.Mock()
+
+    mocked_compose_call = mocker.patch.object(subtensor.substrate, "compose_call")
+    mocked_sign_and_send_extrinsic = mocker.patch.object(
+        subtensor, "sign_and_send_extrinsic"
+    )
+
+    # Call
+    result = await liquidity.modify_liquidity_extrinsic(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=fake_netuid,
+        position_id=fake_position_id,
+        liquidity_delta=fake_liquidity_delta,
+    )
+
+    # Asserts
+    mocked_compose_call.assert_awaited_once_with(
+        call_module="Swap",
+        call_function="modify_position",
+        call_params={
+            "hotkey": fake_wallet.hotkey.ss58_address,
+            "netuid": fake_netuid,
+            "position_id": fake_position_id,
+            "liquidity_delta": fake_liquidity_delta,
+        },
+    )
+    mocked_sign_and_send_extrinsic.assert_awaited_once_with(
+        call=mocked_compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        use_nonce=True,
+        period=None,
+    )
+    assert result == mocked_sign_and_send_extrinsic.return_value
+
+
+@pytest.mark.asyncio
+async def test_remove_liquidity_extrinsic(subtensor, fake_wallet, mocker):
+    """Test that the add `remove_liquidity_extrinsic` executes correct calls."""
+    # Preps
+    fake_netuid = 1
+    fake_position_id = 2
+
+    mocked_compose_call = mocker.patch.object(subtensor.substrate, "compose_call")
+    mocked_sign_and_send_extrinsic = mocker.patch.object(
+        subtensor, "sign_and_send_extrinsic"
+    )
+
+    # Call
+    result = await liquidity.remove_liquidity_extrinsic(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=fake_netuid,
+        position_id=fake_position_id,
+    )
+
+    # Asserts
+    mocked_compose_call.assert_awaited_once_with(
+        call_module="Swap",
+        call_function="remove_liquidity",
+        call_params={
+            "hotkey": fake_wallet.hotkey.ss58_address,
+            "netuid": fake_netuid,
+            "position_id": fake_position_id,
+        },
+    )
+    mocked_sign_and_send_extrinsic.assert_awaited_once_with(
+        call=mocked_compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        use_nonce=True,
+        period=None,
+    )
+    assert result == mocked_sign_and_send_extrinsic.return_value
+
+
+@pytest.mark.asyncio
+async def test_toggle_user_liquidity_extrinsic(subtensor, fake_wallet, mocker):
+    """Test that the add `toggle_user_liquidity_extrinsic` executes correct calls."""
+    # Preps
+    fake_netuid = 1
+    fake_enable = mocker.Mock()
+
+    mocked_compose_call = mocker.patch.object(subtensor.substrate, "compose_call")
+    mocked_sign_and_send_extrinsic = mocker.patch.object(
+        subtensor, "sign_and_send_extrinsic"
+    )
+
+    # Call
+    result = await liquidity.toggle_user_liquidity_extrinsic(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=fake_netuid,
+        enable=fake_enable,
+    )
+
+    # Asserts
+    mocked_compose_call.assert_awaited_once_with(
+        call_module="Swap",
+        call_function="toggle_user_liquidity",
+        call_params={
+            "netuid": fake_netuid,
+            "enable": fake_enable,
+        },
+    )
+    mocked_sign_and_send_extrinsic.assert_awaited_once_with(
+        call=mocked_compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        period=None,
+    )
+    assert result == mocked_sign_and_send_extrinsic.return_value

--- a/tests/unit_tests/extrinsics/test_liquidity.py
+++ b/tests/unit_tests/extrinsics/test_liquidity.py
@@ -1,0 +1,169 @@
+from bittensor.core.extrinsics import liquidity
+
+
+def test_add_liquidity_extrinsic(subtensor, fake_wallet, mocker):
+    """Test that the add `add_liquidity_extrinsic` executes correct calls."""
+    # Preps
+    fake_netuid = 1
+    fake_liquidity = mocker.Mock()
+    fake_price_low = mocker.Mock()
+    fake_price_high = mocker.Mock()
+
+    mocked_compose_call = mocker.patch.object(subtensor.substrate, "compose_call")
+    mocked_sign_and_send_extrinsic = mocker.patch.object(
+        subtensor, "sign_and_send_extrinsic"
+    )
+    mocked_price_to_tick = mocker.patch.object(liquidity, "price_to_tick")
+
+    # Call
+    result = liquidity.add_liquidity_extrinsic(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=fake_netuid,
+        liquidity=fake_liquidity,
+        price_low=fake_price_low,
+        price_high=fake_price_high,
+    )
+
+    # Asserts
+    mocked_compose_call.assert_called_once_with(
+        call_module="Swap",
+        call_function="add_liquidity",
+        call_params={
+            "hotkey": fake_wallet.hotkey.ss58_address,
+            "netuid": fake_netuid,
+            "tick_low": mocked_price_to_tick.return_value,
+            "tick_high": mocked_price_to_tick.return_value,
+            "liquidity": fake_liquidity,
+        },
+    )
+    mocked_sign_and_send_extrinsic.assert_called_once_with(
+        call=mocked_compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        use_nonce=True,
+        period=None,
+    )
+    assert result == mocked_sign_and_send_extrinsic.return_value
+
+
+def test_modify_liquidity_extrinsic(subtensor, fake_wallet, mocker):
+    """Test that the add `modify_liquidity_extrinsic` executes correct calls."""
+    # Preps
+    fake_netuid = 1
+    fake_position_id = 2
+    fake_liquidity_delta = mocker.Mock()
+
+    mocked_compose_call = mocker.patch.object(subtensor.substrate, "compose_call")
+    mocked_sign_and_send_extrinsic = mocker.patch.object(
+        subtensor, "sign_and_send_extrinsic"
+    )
+
+    # Call
+    result = liquidity.modify_liquidity_extrinsic(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=fake_netuid,
+        position_id=fake_position_id,
+        liquidity_delta=fake_liquidity_delta,
+    )
+
+    # Asserts
+    mocked_compose_call.assert_called_once_with(
+        call_module="Swap",
+        call_function="modify_position",
+        call_params={
+            "hotkey": fake_wallet.hotkey.ss58_address,
+            "netuid": fake_netuid,
+            "position_id": fake_position_id,
+            "liquidity_delta": fake_liquidity_delta,
+        },
+    )
+    mocked_sign_and_send_extrinsic.assert_called_once_with(
+        call=mocked_compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        use_nonce=True,
+        period=None,
+    )
+    assert result == mocked_sign_and_send_extrinsic.return_value
+
+
+def test_remove_liquidity_extrinsic(subtensor, fake_wallet, mocker):
+    """Test that the add `remove_liquidity_extrinsic` executes correct calls."""
+    # Preps
+    fake_netuid = 1
+    fake_position_id = 2
+
+    mocked_compose_call = mocker.patch.object(subtensor.substrate, "compose_call")
+    mocked_sign_and_send_extrinsic = mocker.patch.object(
+        subtensor, "sign_and_send_extrinsic"
+    )
+
+    # Call
+    result = liquidity.remove_liquidity_extrinsic(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=fake_netuid,
+        position_id=fake_position_id,
+    )
+
+    # Asserts
+    mocked_compose_call.assert_called_once_with(
+        call_module="Swap",
+        call_function="remove_liquidity",
+        call_params={
+            "hotkey": fake_wallet.hotkey.ss58_address,
+            "netuid": fake_netuid,
+            "position_id": fake_position_id,
+        },
+    )
+    mocked_sign_and_send_extrinsic.assert_called_once_with(
+        call=mocked_compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        use_nonce=True,
+        period=None,
+    )
+    assert result == mocked_sign_and_send_extrinsic.return_value
+
+
+def test_toggle_user_liquidity_extrinsic(subtensor, fake_wallet, mocker):
+    """Test that the add `toggle_user_liquidity_extrinsic` executes correct calls."""
+    # Preps
+    fake_netuid = 1
+    fake_enable = mocker.Mock()
+
+    mocked_compose_call = mocker.patch.object(subtensor.substrate, "compose_call")
+    mocked_sign_and_send_extrinsic = mocker.patch.object(
+        subtensor, "sign_and_send_extrinsic"
+    )
+
+    # Call
+    result = liquidity.toggle_user_liquidity_extrinsic(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=fake_netuid,
+        enable=fake_enable,
+    )
+
+    # Asserts
+    mocked_compose_call.assert_called_once_with(
+        call_module="Swap",
+        call_function="toggle_user_liquidity",
+        call_params={
+            "netuid": fake_netuid,
+            "enable": fake_enable,
+        },
+    )
+    mocked_sign_and_send_extrinsic.assert_called_once_with(
+        call=mocked_compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        period=None,
+    )
+    assert result == mocked_sign_and_send_extrinsic.return_value

--- a/tests/unit_tests/extrinsics/test_liquidity.py
+++ b/tests/unit_tests/extrinsics/test_liquidity.py
@@ -34,7 +34,7 @@ def test_add_liquidity_extrinsic(subtensor, fake_wallet, mocker):
             "netuid": fake_netuid,
             "tick_low": mocked_price_to_tick.return_value,
             "tick_high": mocked_price_to_tick.return_value,
-            "liquidity": fake_liquidity,
+            "liquidity": fake_liquidity.rao,
         },
     )
     mocked_sign_and_send_extrinsic.assert_called_once_with(
@@ -77,7 +77,7 @@ def test_modify_liquidity_extrinsic(subtensor, fake_wallet, mocker):
             "hotkey": fake_wallet.hotkey.ss58_address,
             "netuid": fake_netuid,
             "position_id": fake_position_id,
-            "liquidity_delta": fake_liquidity_delta,
+            "liquidity_delta": fake_liquidity_delta.rao,
         },
     )
     mocked_sign_and_send_extrinsic.assert_called_once_with(

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -3490,3 +3490,167 @@ async def test_get_next_epoch_start_block(mocker, subtensor, call_return, expect
         netuid=netuid, block=block, block_hash=fake_block_hash, reuse_block=False
     )
     assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_get_liquidity_list_subnet_does_not_exits(subtensor, mocker):
+    """Test get_liquidity_list returns None when subnet doesn't exist."""
+    # Preps
+    mocker.patch.object(subtensor, "subnet_exists", return_value=False)
+
+    # Call
+    result = await subtensor.get_liquidity_list(wallet=mocker.Mock(), netuid=1)
+
+    # Asserts
+    subtensor.subnet_exists.assert_awaited_once_with(netuid=1)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_liquidity_list_subnet_is_not_active(subtensor, mocker):
+    """Test get_liquidity_list returns None when subnet is not active."""
+    # Preps
+    mocker.patch.object(subtensor, "subnet_exists", return_value=True)
+    mocker.patch.object(subtensor, "is_subnet_active", return_value=False)
+
+    # Call
+    result = await subtensor.get_liquidity_list(wallet=mocker.Mock(), netuid=1)
+
+    # Asserts
+    subtensor.subnet_exists.assert_awaited_once_with(netuid=1)
+    subtensor.is_subnet_active.assert_awaited_once_with(netuid=1)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_liquidity_list_happy_path(subtensor, fake_wallet, mocker):
+    """Tests `get_liquidity_list` returns the correct value."""
+    # Preps
+    netuid = 2
+
+    mocker.patch.object(subtensor, "subnet_exists", return_value=True)
+    mocker.patch.object(subtensor, "is_subnet_active", return_value=True)
+    mocker.patch.object(subtensor, "determine_block_hash")
+
+    mocker.patch.object(
+        async_subtensor, "price_to_tick", return_value=Balance.from_tao(1.0, netuid)
+    )
+    mocker.patch.object(
+        async_subtensor,
+        "calculate_fees",
+        return_value=(Balance.from_tao(0.0), Balance.from_tao(0.0, netuid)),
+    )
+
+    mocked_substrate_query = mocker.AsyncMock(
+        side_effect=[
+            # for gather
+            {"bits": 0},
+            {"bits": 0},
+            {"bits": 18446744073709551616},
+            # for loop
+            {
+                "liquidity_net": 1000000000000,
+                "liquidity_gross": 1000000000000,
+                "fees_out_tao": {"bits": 0},
+                "fees_out_alpha": {"bits": 0},
+            },
+            {
+                "liquidity_net": -1000000000000,
+                "liquidity_gross": 1000000000000,
+                "fees_out_tao": {"bits": 0},
+                "fees_out_alpha": {"bits": 0},
+            },
+            {
+                "liquidity_net": 1000000000000,
+                "liquidity_gross": 1000000000000,
+                "fees_out_tao": {"bits": 0},
+                "fees_out_alpha": {"bits": 0},
+            },
+            {
+                "liquidity_net": -1000000000000,
+                "liquidity_gross": 1000000000000,
+                "fees_out_tao": {"bits": 0},
+                "fees_out_alpha": {"bits": 0},
+            },
+            {
+                "liquidity_net": 1000000000000,
+                "liquidity_gross": 1000000000000,
+                "fees_out_tao": {"bits": 0},
+                "fees_out_alpha": {"bits": 0},
+            },
+            {
+                "liquidity_net": -1000000000000,
+                "liquidity_gross": 1000000000000,
+                "fees_out_tao": {"bits": 0},
+                "fees_out_alpha": {"bits": 0},
+            },
+        ]
+    )
+    mocker.patch.object(subtensor.substrate, "query", mocked_substrate_query)
+
+    fake_positions = [
+        [
+            (2,),
+            mocker.Mock(
+                value={
+                    "id": (2,),
+                    "netuid": 2,
+                    "tick_low": (206189,),
+                    "tick_high": (208196,),
+                    "liquidity": 1000000000000,
+                    "fees_tao": {"bits": 0},
+                    "fees_alpha": {"bits": 0},
+                }
+            ),
+        ],
+        [
+            (2,),
+            mocker.Mock(
+                value={
+                    "id": (2,),
+                    "netuid": 2,
+                    "tick_low": (216189,),
+                    "tick_high": (198196,),
+                    "liquidity": 2000000000000,
+                    "fees_tao": {"bits": 0},
+                    "fees_alpha": {"bits": 0},
+                }
+            ),
+        ],
+        [
+            (2,),
+            mocker.Mock(
+                value={
+                    "id": (2,),
+                    "netuid": 2,
+                    "tick_low": (226189,),
+                    "tick_high": (188196,),
+                    "liquidity": 3000000000000,
+                    "fees_tao": {"bits": 0},
+                    "fees_alpha": {"bits": 0},
+                }
+            ),
+        ],
+    ]
+    mocked_query_map = mocker.AsyncMock(return_value=fake_positions)
+    mocker.patch.object(subtensor, "query_map", new=mocked_query_map)
+
+    # Call
+
+    result = await subtensor.get_liquidity_list(wallet=fake_wallet, netuid=netuid)
+
+    # Asserts
+    subtensor.determine_block_hash.assert_awaited_once_with(
+        block=None, block_hash=None, reuse_block=False
+    )
+    assert async_subtensor.price_to_tick.call_count == 1
+    assert async_subtensor.calculate_fees.call_count == len(fake_positions)
+
+    mocked_query_map.assert_awaited_once_with(
+        module="Swap",
+        name="Positions",
+        block=None,
+        params=[netuid, fake_wallet.coldkeypub.ss58_address],
+    )
+    assert len(result) == len(fake_positions)
+    assert all([isinstance(p, async_subtensor.LiquidityPosition) for p in result])

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -3654,3 +3654,126 @@ async def test_get_liquidity_list_happy_path(subtensor, fake_wallet, mocker):
     )
     assert len(result) == len(fake_positions)
     assert all([isinstance(p, async_subtensor.LiquidityPosition) for p in result])
+
+
+@pytest.mark.asyncio
+async def test_add_liquidity(subtensor, fake_wallet, mocker):
+    """Test add_liquidity extrinsic calls properly."""
+    # preps
+    netuid = 123
+    mocked_extrinsic = mocker.patch.object(async_subtensor, "add_liquidity_extrinsic")
+
+    # Call
+    result = await subtensor.add_liquidity(
+        wallet=fake_wallet,
+        netuid=netuid,
+        liquidity=Balance.from_tao(150),
+        price_low=Balance.from_tao(180).rao,
+        price_high=Balance.from_tao(130).rao,
+    )
+
+    # Asserts
+    mocked_extrinsic.assert_awaited_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=netuid,
+        liquidity=Balance.from_tao(150),
+        price_low=Balance.from_tao(180).rao,
+        price_high=Balance.from_tao(130).rao,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        period=None,
+    )
+    assert result == mocked_extrinsic.return_value
+
+
+@pytest.mark.asyncio
+async def test_modify_liquidity(subtensor, fake_wallet, mocker):
+    """Test modify_liquidity extrinsic calls properly."""
+    # preps
+    netuid = 123
+    mocked_extrinsic = mocker.patch.object(
+        async_subtensor, "modify_liquidity_extrinsic"
+    )
+    position_id = 2
+
+    # Call
+    result = await subtensor.modify_liquidity(
+        wallet=fake_wallet,
+        netuid=netuid,
+        position_id=position_id,
+        liquidity_delta=Balance.from_tao(150),
+    )
+
+    # Asserts
+    mocked_extrinsic.assert_awaited_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=netuid,
+        position_id=position_id,
+        liquidity_delta=Balance.from_tao(150),
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        period=None,
+    )
+    assert result == mocked_extrinsic.return_value
+
+
+@pytest.mark.asyncio
+async def test_remove_liquidity(subtensor, fake_wallet, mocker):
+    """Test remove_liquidity extrinsic calls properly."""
+    # preps
+    netuid = 123
+    mocked_extrinsic = mocker.patch.object(
+        async_subtensor, "remove_liquidity_extrinsic"
+    )
+    position_id = 2
+
+    # Call
+    result = await subtensor.remove_liquidity(
+        wallet=fake_wallet,
+        netuid=netuid,
+        position_id=position_id,
+    )
+
+    # Asserts
+    mocked_extrinsic.assert_awaited_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=netuid,
+        position_id=position_id,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        period=None,
+    )
+    assert result == mocked_extrinsic.return_value
+
+
+@pytest.mark.asyncio
+async def test_toggle_user_liquidity(subtensor, fake_wallet, mocker):
+    """Test toggle_user_liquidity extrinsic calls properly."""
+    # preps
+    netuid = 123
+    mocked_extrinsic = mocker.patch.object(
+        async_subtensor, "toggle_user_liquidity_extrinsic"
+    )
+    enable = mocker.Mock()
+
+    # Call
+    result = await subtensor.toggle_user_liquidity(
+        wallet=fake_wallet,
+        netuid=netuid,
+        enable=enable,
+    )
+
+    # Asserts
+    mocked_extrinsic.assert_awaited_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=netuid,
+        enable=enable,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        period=None,
+    )
+    assert result == mocked_extrinsic.return_value

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -3661,7 +3661,11 @@ async def test_get_liquidity_list_happy_path(subtensor, fake_wallet, mocker):
             ),
         ],
     ]
-    mocked_query_map = mocker.AsyncMock(return_value=fake_positions)
+
+    fake_result = mocker.AsyncMock(autospec=list)
+    fake_result.__aiter__.return_value = iter(fake_positions)
+
+    mocked_query_map = mocker.AsyncMock(return_value=fake_result)
     mocker.patch.object(subtensor, "query_map", new=mocked_query_map)
 
     # Call

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -3990,3 +3990,122 @@ def test_get_liquidity_list_happy_path(subtensor, fake_wallet, mocker):
     )
     assert len(result) == len(fake_positions)
     assert all([isinstance(p, subtensor_module.LiquidityPosition) for p in result])
+
+
+def test_add_liquidity(subtensor, fake_wallet, mocker):
+    """Test add_liquidity extrinsic calls properly."""
+    # preps
+    netuid = 123
+    mocked_extrinsic = mocker.patch.object(subtensor_module, "add_liquidity_extrinsic")
+
+    # Call
+    result = subtensor.add_liquidity(
+        wallet=fake_wallet,
+        netuid=netuid,
+        liquidity=Balance.from_tao(150),
+        price_low=Balance.from_tao(180).rao,
+        price_high=Balance.from_tao(130).rao,
+    )
+
+    # Asserts
+    mocked_extrinsic.assert_called_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=netuid,
+        liquidity=Balance.from_tao(150),
+        price_low=Balance.from_tao(180).rao,
+        price_high=Balance.from_tao(130).rao,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        period=None,
+    )
+    assert result == mocked_extrinsic.return_value
+
+
+def test_modify_liquidity(subtensor, fake_wallet, mocker):
+    """Test modify_liquidity extrinsic calls properly."""
+    # preps
+    netuid = 123
+    mocked_extrinsic = mocker.patch.object(
+        subtensor_module, "modify_liquidity_extrinsic"
+    )
+    position_id = 2
+
+    # Call
+    result = subtensor.modify_liquidity(
+        wallet=fake_wallet,
+        netuid=netuid,
+        position_id=position_id,
+        liquidity_delta=Balance.from_tao(150),
+    )
+
+    # Asserts
+    mocked_extrinsic.assert_called_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=netuid,
+        position_id=position_id,
+        liquidity_delta=Balance.from_tao(150),
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        period=None,
+    )
+    assert result == mocked_extrinsic.return_value
+
+
+def test_remove_liquidity(subtensor, fake_wallet, mocker):
+    """Test remove_liquidity extrinsic calls properly."""
+    # preps
+    netuid = 123
+    mocked_extrinsic = mocker.patch.object(
+        subtensor_module, "remove_liquidity_extrinsic"
+    )
+    position_id = 2
+
+    # Call
+    result = subtensor.remove_liquidity(
+        wallet=fake_wallet,
+        netuid=netuid,
+        position_id=position_id,
+    )
+
+    # Asserts
+    mocked_extrinsic.assert_called_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=netuid,
+        position_id=position_id,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        period=None,
+    )
+    assert result == mocked_extrinsic.return_value
+
+
+def test_toggle_user_liquidity(subtensor, fake_wallet, mocker):
+    """Test toggle_user_liquidity extrinsic calls properly."""
+    # preps
+    netuid = 123
+    mocked_extrinsic = mocker.patch.object(
+        subtensor_module, "toggle_user_liquidity_extrinsic"
+    )
+    enable = mocker.Mock()
+
+    # Call
+    result = subtensor.toggle_user_liquidity(
+        wallet=fake_wallet,
+        netuid=netuid,
+        enable=enable,
+    )
+
+    # Asserts
+    mocked_extrinsic.assert_called_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=netuid,
+        enable=enable,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+        period=None,
+    )
+    assert result == mocked_extrinsic.return_value

--- a/tests/unit_tests/utils/test_liquidity_utils.py
+++ b/tests/unit_tests/utils/test_liquidity_utils.py
@@ -1,0 +1,124 @@
+import math
+
+import pytest
+
+from bittensor.utils.balance import Balance
+from bittensor.utils.liquidity import (
+    LiquidityPosition,
+    price_to_tick,
+    tick_to_price,
+    get_fees,
+    get_fees_in_range,
+    calculate_fees,
+)
+
+
+def test_liquidity_position_to_token_amounts():
+    """Test conversion of liquidity position to token amounts."""
+    # Preps
+    pos = LiquidityPosition(
+        id=1,
+        price_low=Balance.from_tao(10000),
+        price_high=Balance.from_tao(40000),
+        liquidity=Balance.from_tao(25000),
+        fees_tao=Balance.from_tao(0),
+        fees_alpha=Balance.from_tao(0),
+        netuid=1,
+    )
+    current_price = Balance.from_tao(20000)
+    # Call
+    alpha, tao = pos.to_token_amounts(current_price)
+    # Asserts
+    assert isinstance(alpha, Balance)
+    assert isinstance(tao, Balance)
+    assert alpha.rao >= 0 and tao.rao >= 0
+
+
+def test_price_to_tick_and_back():
+    """Test price to tick conversion and back."""
+    # Preps
+    price = 1.25
+    # Call
+    tick = price_to_tick(price)
+    restored_price = tick_to_price(tick)
+    # Asserts
+    assert math.isclose(restored_price, price, rel_tol=1e-3)
+
+
+def test_price_to_tick_invalid():
+    """Test price to tick conversion with invalid input."""
+    with pytest.raises(ValueError):
+        price_to_tick(0)
+
+
+def test_tick_to_price_invalid():
+    """Test tick to price conversion with invalid input."""
+    with pytest.raises(ValueError):
+        tick_to_price(1_000_000)
+
+
+def test_get_fees_above_true():
+    """Test fee calculation for above position."""
+    # Preps
+    tick = {
+        "liquidity_net": 1000000000000,
+        "liquidity_gross": 1000000000000,
+        "fees_out_tao": {"bits": 0},
+        "fees_out_alpha": {"bits": 0},
+    }
+    # Call
+    result = get_fees(
+        current_tick=100,
+        tick=tick,
+        tick_index=90,
+        quote=True,
+        global_fees_tao=8000,
+        global_fees_alpha=6000,
+        above=True,
+    )
+    # Asserts
+    assert result == 8000
+
+
+def test_get_fees_in_range():
+    """Test fee calculation within a range."""
+    # Call
+    value = get_fees_in_range(
+        quote=True,
+        global_fees_tao=10000,
+        global_fees_alpha=5000,
+        fees_below_low=2000,
+        fees_above_high=1000,
+    )
+    # Asserts
+    assert value == 7000
+
+
+def test_calculate_fees():
+    """Test calculation of fees for a position."""
+    # Preps
+    position = {
+        "id": (2,),
+        "netuid": 2,
+        "tick_low": (206189,),
+        "tick_high": (208196,),
+        "liquidity": 1000000000000,
+        "fees_tao": {"bits": 0},
+        "fees_alpha": {"bits": 0},
+    }
+    # Call
+    result = calculate_fees(
+        position=position,
+        global_fees_tao=5000,
+        global_fees_alpha=8000,
+        tao_fees_below_low=1000,
+        tao_fees_above_high=1000,
+        alpha_fees_below_low=2000,
+        alpha_fees_above_high=1000,
+        netuid=1,
+    )
+    # Asserts
+    assert isinstance(result[0], Balance)
+    assert isinstance(result[1], Balance)
+    assert result[0].rao > 0
+    assert result[1].rao > 0


### PR DESCRIPTION
### Content

#### Extrinsics:
- `add_liquidity_extrinsic`
- `modify_liquidity_extrinsic`
- `remove_liquidity_extrinsic`
- `toggle_user_liquidity_extrinsic`

#### Subtensor methods:
- `add_liquidity`
- `modify_liquidity`
- `remove_liquidity`
- `toggle_user_liquidity`
- `get_liquidity_list`

#### Helpers
- `bittensor.utils.liquidity`

This [docement](https://github.com/user-attachments/files/20988630/swapv3.pdf) describes the mathematical functions used for calculations. 

### AC:
- [x] liquidity logic
- unit tests:
  - [x] subtensor
  - [x] async subtensor
  - [x] extrinsic module
  - [x] async extrinsic mudule
  - [x] liquidity utils
- [x] e2e tests (also tested locally with non-fast-blocks node)
- [x] ready to merge - subtensor PR is merged to `devnet-ready`
- [ ] ready to release - subtensor PR is deployed to `finney`