### PR TITLE
decode metadata with empty value

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1201,7 +1201,7 @@ class AsyncSubtensor(SubtensorMixin):
         )
         result = {}
         async for id_, value in query:
-            result[decode_account_id(id_[0])] = decode_metadata(value)
+            result[decode_account_id(id_[0])] = decode_metadata(value.value)
         return result
 
     async def get_revealed_commitment_by_hotkey(

--- a/bittensor/core/chain_data/utils.py
+++ b/bittensor/core/chain_data/utils.py
@@ -136,7 +136,8 @@ def process_stake_data(stake_data: list) -> dict:
 
 def decode_metadata(metadata: dict) -> str:
     commitment = metadata["info"]["fields"][0][0]
-    bytes_tuple = commitment[next(iter(commitment.keys()))][0]
+    bytes_tuple_ = commitment[next(iter(commitment.keys()))]
+    bytes_tuple = bytes_tuple_[0] if len(bytes_tuple_) > 0 else bytes_tuple_
     return bytes(bytes_tuple).decode()
 
 

--- a/tests/unit_tests/chain_data/test_utils.py
+++ b/tests/unit_tests/chain_data/test_utils.py
@@ -1,0 +1,103 @@
+import pytest
+
+from bittensor.core.chain_data import utils
+
+
+@pytest.mark.parametrize(
+    "metadata, response",
+    [
+        (
+            {
+                "deposit": 0,
+                "block": 5415815,
+                "info": {
+                    "fields": (
+                        (
+                            {
+                                "Raw64": (
+                                    (
+                                        51,
+                                        98,
+                                        99,
+                                        54,
+                                        49,
+                                        48,
+                                        57,
+                                        102,
+                                        49,
+                                        101,
+                                        49,
+                                        51,
+                                        102,
+                                        102,
+                                        56,
+                                        102,
+                                        55,
+                                        101,
+                                        98,
+                                        54,
+                                        97,
+                                        102,
+                                        54,
+                                        49,
+                                        53,
+                                        101,
+                                        49,
+                                        102,
+                                        56,
+                                        101,
+                                        49,
+                                        55,
+                                        99,
+                                        57,
+                                        97,
+                                        100,
+                                        100,
+                                        48,
+                                        97,
+                                        50,
+                                        56,
+                                        98,
+                                        99,
+                                        48,
+                                        50,
+                                        54,
+                                        55,
+                                        57,
+                                        52,
+                                        99,
+                                        56,
+                                        54,
+                                        97,
+                                        101,
+                                        50,
+                                        56,
+                                        57,
+                                        57,
+                                        50,
+                                        99,
+                                        102,
+                                        48,
+                                        52,
+                                        53,
+                                    ),
+                                )
+                            },
+                        ),
+                    )
+                },
+            },
+            "3bc6109f1e13ff8f7eb6af615e1f8e17c9add0a28bc026794c86ae28992cf045",
+        ),
+        (
+            {
+                "deposit": 0,
+                "block": 5866237,
+                "info": {"fields": (({"ResetBondsFlag": ()},),)},
+            },
+            "",
+        ),
+    ],
+)
+def test_decode_metadata(metadata, response):
+    assert utils.decode_metadata(metadata) == response


### PR DESCRIPTION
Came across an odd commitment on block 5866237 which contained no data in the value. This breaks our current metadata decoding. 
Fixed this + test.