### PR TITLE
Add labels checker

### DIFF
--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -1,7 +1,7 @@
 name: E2E Subtensor Tests
 
 concurrency:
-  : e2e-subtensor-${{ github.event.pull_request.number || github.ref }}
+  group: e2e-subtensor-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 on:
@@ -50,10 +50,10 @@ jobs:
   pull-docker-image:
     runs-on: ubuntu-latest
     outputs:
-      image-name: ${{ steps.set-output.outputs.image-name }}
+      image-name: ${{ steps.set-image.outputs.image }}
     steps:
       - name: Set Docker image tag based on label or branch
-        id: set-output
+        id: set-image
         run: |
           echo "Event: $GITHUB_EVENT_NAME"
           echo "Branch: $GITHUB_REF_NAME"
@@ -72,12 +72,15 @@ jobs:
             case "$label" in
               "subtensor-localnet:main")
                 image="ghcr.io/opentensor/subtensor-localnet:main"
+                break
                 ;;
               "subtensor-localnet:testnet")
                 image="ghcr.io/opentensor/subtensor-localnet:testnet"
+                break
                 ;;
               "subtensor-localnet:devnet")
                 image="ghcr.io/opentensor/subtensor-localnet:devnet"
+                break
                 ;;
             esac
           done
@@ -98,10 +101,10 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
       - name: Pull Docker Image
-        run: docker pull ${{ steps.set-output.outputs.image-name }}
+        run: docker pull ${{ steps.set-image.outputs.image }}
 
       - name: Save Docker Image to Cache
-        run: docker save -o subtensor-localnet.tar ${{ steps.set-output.outputs.image-name }}
+        run: docker save -o subtensor-localnet.tar ${{ steps.set-image.outputs.image }}
 
       - name: Upload Docker Image as Artifact
         uses: actions/upload-artifact@v4
@@ -154,8 +157,9 @@ jobs:
         run: |
           set +e
           for i in 1 2 3; do
-            echo "🔁 Attempt $i: Running tests"
+            echo "::group::🔁 Test attempt $i"
             uv run pytest ${{ matrix.test-file }} -s
+            echo "::endgroup::"
             status=$?
             if [ $status -eq 0 ]; then
               echo "✅ Tests passed on attempt $i"

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -95,7 +95,7 @@ jobs:
           fi
     
           echo "✅ Final selected image: $image"
-          echo "image-name=$image" >> "$GITHUB_OUTPUT"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -5,9 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - '**'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -152,23 +152,21 @@ jobs:
         env:
           LOCALNET_IMAGE_NAME: ${{ needs.pull-docker-image.outputs.image-name }}
         run: |
-          set +e
           for i in 1 2 3; do
             echo "::group::🔁 Test attempt $i"
-            uv run pytest ${{ matrix.test-file }} -s
-            echo "::endgroup::"
-            status=$?
-            if [ $status -eq 0 ]; then
+            if uv run pytest ${{ matrix.test-file }} -s; then
               echo "✅ Tests passed on attempt $i"
-              break
+              echo "::endgroup::"
+              exit 0
             else
               echo "❌ Tests failed on attempt $i"
-              if [ $i -eq 3 ]; then
-                echo "Tests failed after 3 attempts"
-                exit 1
+              echo "::endgroup::"
+              if [ "$i" -lt 3 ]; then
+                echo "Retrying..."
+                sleep 5
               fi
-              echo "Retrying..."
-              sleep 5
             fi
           done
 
+          echo "Tests failed after 3 attempts"
+          exit 1

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -11,7 +11,7 @@ on:
   pull_request:
     branches:
       - '**'
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [ opened, synchronize, reopened, ready_for_review, labeled, unlabeled ]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -1,7 +1,7 @@
 name: E2E Subtensor Tests
 
 concurrency:
-  group: e2e-subtensor-${{ github.ref }}
+  : e2e-subtensor-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -29,7 +29,7 @@ jobs:
   # Looking for e2e tests
   find-tests:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false }}
     outputs:
       test-files: ${{ steps.get-tests.outputs.test-files }}
     steps:

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -52,16 +52,46 @@ jobs:
     outputs:
       image-name: ${{ steps.set-output.outputs.image-name }}
     steps:
-      - name: Set Docker image tag based on branch
+      - name: Set Docker image tag based on label or branch
         id: set-output
         run: |
-          ref="${{ github.ref_name }}"
-          if [[ "$ref" == "master" ]]; then
-            image="ghcr.io/opentensor/subtensor-localnet:main"
+          echo "Event: $GITHUB_EVENT_NAME"
+          echo "Branch: $GITHUB_REF_NAME"
+          
+          echo "Reading labels ..."
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            labels=$(jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH")
           else
-            image="ghcr.io/opentensor/subtensor-localnet:devnet-ready"
+            labels=""
           fi
-          echo "Using image: $image"
+    
+          image=""
+    
+          for label in $labels; do
+            echo "Found label: $label"
+            case "$label" in
+              "subtensor-localnet:main")
+                image="ghcr.io/opentensor/subtensor-localnet:main"
+                ;;
+              "subtensor-localnet:testnet")
+                image="ghcr.io/opentensor/subtensor-localnet:testnet"
+                ;;
+              "subtensor-localnet:devnet")
+                image="ghcr.io/opentensor/subtensor-localnet:devnet"
+                ;;
+            esac
+          done
+    
+          if [[ -z "$image" ]]; then
+            # fallback to default based on branch
+            if [[ "${GITHUB_REF_NAME}" == "master" ]]; then
+              image="ghcr.io/opentensor/subtensor-localnet:main"
+            else
+              image="ghcr.io/opentensor/subtensor-localnet:devnet-ready"
+            fi
+          fi
+    
+          echo "✅ Final selected image: $image"
           echo "image-name=$image" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry


### PR DESCRIPTION
Repo has 3 new labels:
- `subtensor-localnet:main`
- `subtensor-localnet:devnet`
- `subtensor-localnet:testnet`

Workflow checks for added labels. The first one found from added ones triggers the selection of the docker image.

If none of the labels are added, then the selection is based on the base PR branch.
- if `master` -> `subtensor-localnet:main`
- all others -> `subtensor-localnet:devnet-ready`

Fixed:
- no double run for tests