### PR TITLE
AsyncSubtensor.get_metagraph_info use specified block/hash

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -2035,6 +2035,7 @@ class AsyncSubtensor(SubtensorMixin):
                 "SubnetInfoRuntimeApi",
                 "get_metagraph",
                 params=[netuid],
+                block_hash=block_hash,
             )
 
         if query.value is None:

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -814,7 +814,7 @@ class AsyncSubtensor(SubtensorMixin):
                 method="get_all_dynamic_info",
                 block_hash=block_hash,
             ),
-            self.get_subnet_prices(),
+            self.get_subnet_prices(block_hash=block_hash),
         )
 
         decoded = query.decode()

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -827,7 +827,7 @@ class AsyncSubtensor(SubtensorMixin):
                 )
         else:
             logging.warning(
-                f"Unable to fetch subnet prices for block {block_number}, block hash {block_hash}"
+                f"Unable to fetch subnet prices for block {block_number}, block hash {block_hash}: {subnet_prices}"
             )
         return DynamicInfo.list_from_dicts(decoded)
 
@@ -1159,7 +1159,7 @@ class AsyncSubtensor(SubtensorMixin):
                 subnet.update({"price": prices.get(subnet["netuid"], 0)})
         else:
             logging.warning(
-                f"Unable to fetch subnet prices for block {block}, block hash {block_hash}"
+                f"Unable to fetch subnet prices for block {block}, block hash {block_hash}: {prices}"
             )
 
         return SubnetInfo.list_from_dicts(result)

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -815,12 +815,20 @@ class AsyncSubtensor(SubtensorMixin):
                 block_hash=block_hash,
             ),
             self.get_subnet_prices(block_hash=block_hash),
+            return_exceptions=True,
         )
 
         decoded = query.decode()
 
-        for sn in decoded:
-            sn.update({"price": subnet_prices.get(sn["netuid"], Balance.from_tao(0))})
+        if not isinstance(subnet_prices, SubstrateRequestException):
+            for sn in decoded:
+                sn.update(
+                    {"price": subnet_prices.get(sn["netuid"], Balance.from_tao(0))}
+                )
+        else:
+            logging.warning(
+                f"Unable to fetch subnet prices for block {block_number}, block hash {block_hash}"
+            )
         return DynamicInfo.list_from_dicts(decoded)
 
     async def blocks_since_last_step(
@@ -1129,21 +1137,30 @@ class AsyncSubtensor(SubtensorMixin):
         Notes:
             See also: <https://docs.learnbittensor.org/glossary#subnet>
         """
-        result = await self.query_runtime_api(
-            runtime_api="SubnetInfoRuntimeApi",
-            method="get_subnets_info_v2",
-            params=[],
-            block=block,
-            block_hash=block_hash,
-            reuse_block=reuse_block,
+        result, prices = await asyncio.gather(
+            self.query_runtime_api(
+                runtime_api="SubnetInfoRuntimeApi",
+                method="get_subnets_info_v2",
+                params=[],
+                block=block,
+                block_hash=block_hash,
+                reuse_block=reuse_block,
+            ),
+            self.get_subnet_prices(
+                block=block, block_hash=block_hash, reuse_block=reuse_block
+            ),
+            return_exceptions=True,
         )
         if not result:
             return []
 
-        subnets_prices = await self.get_subnet_prices()
-
-        for subnet in result:
-            subnet.update({"price": subnets_prices.get(subnet["netuid"], 0)})
+        if not isinstance(prices, SubstrateRequestException):
+            for subnet in result:
+                subnet.update({"price": prices.get(subnet["netuid"], 0)})
+        else:
+            logging.warning(
+                f"Unable to fetch subnet prices for block {block}, block hash {block_hash}"
+            )
 
         return SubnetInfo.list_from_dicts(result)
 

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -455,7 +455,7 @@ class Subtensor(SubtensorMixin):
             method="get_all_dynamic_info",
             block_hash=block_hash,
         )
-        subnet_prices = self.get_subnet_prices()
+        subnet_prices = self.get_subnet_prices(block=block)
         decoded = query.decode()
         for sn in decoded:
             sn.update({"price": subnet_prices.get(sn["netuid"], Balance.from_tao(0))})

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -655,7 +655,7 @@ class Subtensor(SubtensorMixin):
 
             for subnet in result:
                 subnet.update({"price": subnets_prices.get(subnet["netuid"], 0)})
-        except SubstrateRequestException:
+        except SubstrateRequestException as e:
             logging.warning(f"Unable to fetch subnet prices for block {block}: {e}")
 
         return SubnetInfo.list_from_dicts(result)

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -462,8 +462,8 @@ class Subtensor(SubtensorMixin):
                 sn.update(
                     {"price": subnet_prices.get(sn["netuid"], Balance.from_tao(0))}
                 )
-        except SubstrateRequestException:
-            logging.warning(f"Unable to fetch subnet prices for block {block}")
+        except SubstrateRequestException as e:
+            logging.warning(f"Unable to fetch subnet prices for block {block}: {e}")
 
         return DynamicInfo.list_from_dicts(decoded)
 
@@ -656,7 +656,7 @@ class Subtensor(SubtensorMixin):
             for subnet in result:
                 subnet.update({"price": subnets_prices.get(subnet["netuid"], 0)})
         except SubstrateRequestException:
-            logging.warning(f"Unable to fetch subnet prices for block {block}")
+            logging.warning(f"Unable to fetch subnet prices for block {block}: {e}")
 
         return SubnetInfo.list_from_dicts(result)
 

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -455,10 +455,16 @@ class Subtensor(SubtensorMixin):
             method="get_all_dynamic_info",
             block_hash=block_hash,
         )
-        subnet_prices = self.get_subnet_prices(block=block)
         decoded = query.decode()
-        for sn in decoded:
-            sn.update({"price": subnet_prices.get(sn["netuid"], Balance.from_tao(0))})
+        try:
+            subnet_prices = self.get_subnet_prices(block=block)
+            for sn in decoded:
+                sn.update(
+                    {"price": subnet_prices.get(sn["netuid"], Balance.from_tao(0))}
+                )
+        except SubstrateRequestException:
+            logging.warning(f"Unable to fetch subnet prices for block {block}")
+
         return DynamicInfo.list_from_dicts(decoded)
 
     def blocks_since_last_step(
@@ -644,11 +650,13 @@ class Subtensor(SubtensorMixin):
         )
         if not result:
             return []
+        try:
+            subnets_prices = self.get_subnet_prices(block=block)
 
-        subnets_prices = self.get_subnet_prices()
-
-        for subnet in result:
-            subnet.update({"price": subnets_prices.get(subnet["netuid"], 0)})
+            for subnet in result:
+                subnet.update({"price": subnets_prices.get(subnet["netuid"], 0)})
+        except SubstrateRequestException:
+            logging.warning(f"Unable to fetch subnet prices for block {block}")
 
         return SubnetInfo.list_from_dicts(result)
 


### PR DESCRIPTION
`AsyncSubtensor.get_metagraph_info` was only using the block/hash specified when columns were specified.

Also fixes price query for `all_subnets` in `AsyncSubtensor` and `Subtensor`

cc: @xavierlyu 