### PR TITLE
Transfers improvements

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -3157,7 +3157,7 @@ class AsyncSubtensor(SubtensorMixin):
         wallet has sufficient funds to cover both the transfer amount and the associated costs. This function provides
         a crucial tool for managing financial operations within the Bittensor network.
         """
-        call_params = {"dest": dest}
+        call_params: dict[str, Union[int, str, bool]] = {"dest": dest}
         if value is None:
             call_function = "transfer_all"
             if keep_alive:

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -5455,7 +5455,7 @@ class AsyncSubtensor(SubtensorMixin):
         self,
         wallet: "Wallet",
         dest: str,
-        amount: Balance,
+        amount: Optional[Balance],
         transfer_all: bool = False,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
@@ -5468,7 +5468,7 @@ class AsyncSubtensor(SubtensorMixin):
         Arguments:
             wallet: Source wallet for the transfer.
             dest: Destination address for the transfer.
-            amount: Number of tokens to transfer.
+            amount: Number of tokens to transfer. `None` is transferring all.
             transfer_all: Flag to transfer all tokens. Default is `False`.
             wait_for_inclusion: Waits for the transaction to be included in a block. Defaults to `True`.
             wait_for_finalization: Waits for the transaction to be finalized on the blockchain. Defaults to `False`.
@@ -5479,7 +5479,8 @@ class AsyncSubtensor(SubtensorMixin):
         Returns:
             `True` if the transferring was successful, otherwise `False`.
         """
-        amount = check_and_convert_to_balance(amount)
+        if amount is not None:
+            amount = check_and_convert_to_balance(amount)
         return await transfer_extrinsic(
             subtensor=self,
             wallet=wallet,

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -98,6 +98,7 @@ from bittensor.utils import (
     torch,
     u16_normalized_float,
     u64_normalized_float,
+    get_transfer_fn_params,
 )
 from bittensor.core.extrinsics.asyncex.liquidity import (
     add_liquidity_extrinsic,
@@ -3157,20 +3158,10 @@ class AsyncSubtensor(SubtensorMixin):
         wallet has sufficient funds to cover both the transfer amount and the associated costs. This function provides
         a crucial tool for managing financial operations within the Bittensor network.
         """
-        call_params: dict[str, Union[int, str, bool]] = {"dest": dest}
-        if value is None:
-            call_function = "transfer_all"
-            if keep_alive:
-                call_params["keep_alive"] = True
-            else:
-                call_params["keep_alive"] = False
-        else:
+        if value is not None:
             value = check_and_convert_to_balance(value)
-            call_params["value"] = value.rao
-            if keep_alive:
-                call_function = "transfer_keep_alive"
-            else:
-                call_function = "transfer_allow_death"
+        call_params: dict[str, Union[int, str, bool]]
+        call_function, call_params = get_transfer_fn_params(value, dest, keep_alive)
 
         call = await self.substrate.compose_call(
             call_module="Balances",

--- a/bittensor/core/extrinsics/asyncex/transfer.py
+++ b/bittensor/core/extrinsics/asyncex/transfer.py
@@ -6,6 +6,7 @@ from bittensor.utils import (
     get_explorer_url_for_network,
     is_valid_bittensor_address_or_public_key,
     unlock_key,
+    get_transfer_fn_params,
 )
 from bittensor.utils.balance import Balance
 from bittensor.utils.btlogging import logging
@@ -45,19 +46,7 @@ async def _do_transfer(
     Returns:
         success, block hash, formatted error message
     """
-    call_params = {"dest": destination}
-    if amount is None:
-        call_function = "transfer_all"
-        if keep_alive:
-            call_params["keep_alive"] = True
-        else:
-            call_params["keep_alive"] = False
-    else:
-        call_params["value"] = amount.rao
-        if keep_alive:
-            call_function = "transfer_keep_alive"
-        else:
-            call_function = "transfer_allow_death"
+    call_function, call_params = get_transfer_fn_params(amount, destination, keep_alive)
 
     call = await subtensor.substrate.compose_call(
         call_module="Balances",

--- a/bittensor/core/extrinsics/asyncex/transfer.py
+++ b/bittensor/core/extrinsics/asyncex/transfer.py
@@ -53,7 +53,7 @@ async def _do_transfer(
         else:
             call_params["keep_alive"] = False
     else:
-        call_params["amount"] = amount.rao
+        call_params["value"] = amount.rao
         if keep_alive:
             call_function = "transfer_keep_alive"
         else:

--- a/bittensor/core/extrinsics/asyncex/transfer.py
+++ b/bittensor/core/extrinsics/asyncex/transfer.py
@@ -175,6 +175,7 @@ async def transfer_extrinsic(
         wallet=wallet,
         destination=destination,
         amount=amount,
+        keep_alive=keep_alive,
         wait_for_finalization=wait_for_finalization,
         wait_for_inclusion=wait_for_inclusion,
         period=period,

--- a/bittensor/core/extrinsics/asyncex/transfer.py
+++ b/bittensor/core/extrinsics/asyncex/transfer.py
@@ -150,7 +150,7 @@ async def transfer_extrinsic(
     )
 
     fee = await subtensor.get_transfer_fee(
-        wallet=wallet, dest=destination, value=amount
+        wallet=wallet, dest=destination, value=amount, keep_alive=keep_alive
     )
 
     if not keep_alive:

--- a/bittensor/core/extrinsics/asyncex/transfer.py
+++ b/bittensor/core/extrinsics/asyncex/transfer.py
@@ -20,10 +20,10 @@ async def _do_transfer(
     wallet: "Wallet",
     destination: str,
     amount: Optional[Balance],
-    keep_alive: bool = True,
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
     period: Optional[int] = None,
+    keep_alive: bool = True,
 ) -> tuple[bool, str, str]:
     """
     Makes transfer from wallet to destination public key address.
@@ -33,7 +33,6 @@ async def _do_transfer(
         wallet (bittensor_wallet.Wallet): Bittensor wallet object to make transfer from.
         destination (str): Destination public key address (ss58_address or ed25519) of recipient.
         amount (bittensor.utils.balance.Balance): Amount to stake as Bittensor balance.
-        keep_alive (bool): If `True`, will keep the existential deposit in the account.
         wait_for_inclusion (bool): If set, waits for the extrinsic to enter a block before returning `True`, or returns
             `False` if the extrinsic fails to enter the block within the timeout.
         wait_for_finalization (bool): If set, waits for the extrinsic to be finalized on the chain before returning
@@ -41,6 +40,7 @@ async def _do_transfer(
         period (Optional[int]): The number of blocks during which the transaction will remain valid after it's submitted.
             If the transaction is not included in a block within that number of blocks, it will expire and be rejected.
             You can think of it as an expiration date for the transaction.
+        keep_alive (bool): If `True`, will keep the existential deposit in the account.
 
     Returns:
         success, block hash, formatted error message

--- a/bittensor/core/extrinsics/asyncex/transfer.py
+++ b/bittensor/core/extrinsics/asyncex/transfer.py
@@ -19,7 +19,8 @@ async def _do_transfer(
     subtensor: "AsyncSubtensor",
     wallet: "Wallet",
     destination: str,
-    amount: "Balance",
+    amount: Optional[Balance],
+    keep_alive: bool = True,
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
     period: Optional[int] = None,
@@ -32,6 +33,7 @@ async def _do_transfer(
         wallet (bittensor_wallet.Wallet): Bittensor wallet object to make transfer from.
         destination (str): Destination public key address (ss58_address or ed25519) of recipient.
         amount (bittensor.utils.balance.Balance): Amount to stake as Bittensor balance.
+        keep_alive (bool): If `True`, will keep the existential deposit in the account.
         wait_for_inclusion (bool): If set, waits for the extrinsic to enter a block before returning `True`, or returns
             `False` if the extrinsic fails to enter the block within the timeout.
         wait_for_finalization (bool): If set, waits for the extrinsic to be finalized on the chain before returning
@@ -43,10 +45,24 @@ async def _do_transfer(
     Returns:
         success, block hash, formatted error message
     """
+    call_params = {"dest": destination}
+    if amount is None:
+        call_function = "transfer_all"
+        if keep_alive:
+            call_params["keep_alive"] = True
+        else:
+            call_params["keep_alive"] = False
+    else:
+        call_params["amount"] = amount.rao
+        if keep_alive:
+            call_function = "transfer_keep_alive"
+        else:
+            call_function = "transfer_allow_death"
+
     call = await subtensor.substrate.compose_call(
         call_module="Balances",
-        call_function="transfer_keep_alive",
-        call_params={"dest": destination, "value": amount.rao},
+        call_function=call_function,
+        call_params=call_params,
     )
 
     success, message = await subtensor.sign_and_send_extrinsic(
@@ -73,7 +89,7 @@ async def transfer_extrinsic(
     subtensor: "AsyncSubtensor",
     wallet: "Wallet",
     dest: str,
-    amount: "Balance",
+    amount: Optional[Balance],
     transfer_all: bool = False,
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
@@ -86,7 +102,8 @@ async def transfer_extrinsic(
         subtensor (bittensor.core.async_subtensor.AsyncSubtensor): initialized AsyncSubtensor object used for transfer
         wallet (bittensor_wallet.Wallet): Bittensor wallet object to make transfer from.
         dest (str): Destination public key address (ss58_address or ed25519) of recipient.
-        amount (bittensor.utils.balance.Balance): Amount to stake as Bittensor balance.
+        amount (Optional[bittensor.utils.balance.Balance]): Amount to stake as Bittensor balance. `None` if
+            transferring all.
         transfer_all (bool): Whether to transfer all funds from this wallet to the destination address.
         wait_for_inclusion (bool): If set, waits for the extrinsic to enter a block before returning `True`, or returns
             `False` if the extrinsic fails to enter the block within the timeout.
@@ -102,6 +119,11 @@ async def transfer_extrinsic(
             finalization / inclusion, the response is `True`, regardless of its inclusion.
     """
     destination = dest
+
+    if amount is None and not transfer_all:
+        logging.error("If not transferring all, `amount` must be specified.")
+        return False
+
     # Validate destination address.
     if not is_valid_bittensor_address_or_public_key(destination):
         logging.error(
@@ -137,12 +159,10 @@ async def transfer_extrinsic(
 
     # Check if we have enough balance.
     if transfer_all is True:
-        amount = account_balance - fee - existential_deposit
-        if amount < Balance(0):
+        if (account_balance - fee) < existential_deposit:
             logging.error("Not enough balance to transfer")
             return False
-
-    if account_balance < (amount + fee + existential_deposit):
+    elif account_balance < (amount + fee + existential_deposit):
         logging.error(":cross_mark: [red]Not enough balance[/red]")
         logging.error(f"\t\tBalance:\t[blue]{account_balance}[/blue]")
         logging.error(f"\t\tAmount:\t[blue]{amount}[/blue]")

--- a/bittensor/core/extrinsics/transfer.py
+++ b/bittensor/core/extrinsics/transfer.py
@@ -19,10 +19,10 @@ def _do_transfer(
     wallet: "Wallet",
     destination: str,
     amount: Optional[Balance],
-    keep_alive: bool = True,
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
     period: Optional[int] = None,
+    keep_alive: bool = True,
 ) -> tuple[bool, str, str]:
     """
     Makes transfer from wallet to destination public key address.
@@ -32,7 +32,6 @@ def _do_transfer(
         wallet (bittensor_wallet.Wallet): Bittensor wallet object to make transfer from.
         destination (str): Destination public key address (ss58_address or ed25519) of recipient.
         amount (bittensor.utils.balance.Balance): Amount to stake as Bittensor balance. `None` if transferring all.
-        keep_alive (bool): If `True`, will keep the existential deposit in the account.
         wait_for_inclusion (bool): If set, waits for the extrinsic to enter a block before returning `True`, or returns
             `False` if the extrinsic fails to enter the block within the timeout.
         wait_for_finalization (bool): If set, waits for the extrinsic to be finalized on the chain before returning
@@ -40,6 +39,7 @@ def _do_transfer(
         period (Optional[int]): The number of blocks during which the transaction will remain valid after it's submitted.
             If the transaction is not included in a block within that number of blocks, it will expire and be rejected.
             You can think of it as an expiration date for the transaction.
+        keep_alive (bool): If `True`, will keep the existential deposit in the account.
 
     Returns:
         success, block hash, formatted error message

--- a/bittensor/core/extrinsics/transfer.py
+++ b/bittensor/core/extrinsics/transfer.py
@@ -5,6 +5,7 @@ from bittensor.utils import (
     is_valid_bittensor_address_or_public_key,
     unlock_key,
     get_explorer_url_for_network,
+    get_transfer_fn_params,
 )
 from bittensor.utils.balance import Balance
 from bittensor.utils.btlogging import logging
@@ -44,19 +45,7 @@ def _do_transfer(
     Returns:
         success, block hash, formatted error message
     """
-    call_params = {"dest": destination}
-    if amount is None:
-        call_function = "transfer_all"
-        if keep_alive:
-            call_params["keep_alive"] = True
-        else:
-            call_params["keep_alive"] = False
-    else:
-        call_params["value"] = amount.rao
-        if keep_alive:
-            call_function = "transfer_keep_alive"
-        else:
-            call_function = "transfer_allow_death"
+    call_function, call_params = get_transfer_fn_params(amount, destination, keep_alive)
 
     call = subtensor.substrate.compose_call(
         call_module="Balances",

--- a/bittensor/core/extrinsics/transfer.py
+++ b/bittensor/core/extrinsics/transfer.py
@@ -147,7 +147,9 @@ def transfer_extrinsic(
     else:
         existential_deposit = subtensor.get_existential_deposit(block=block)
 
-    fee = subtensor.get_transfer_fee(wallet=wallet, dest=dest, value=amount)
+    fee = subtensor.get_transfer_fee(
+        wallet=wallet, dest=dest, value=amount, keep_alive=keep_alive
+    )
 
     # Check if we have enough balance.
     if transfer_all is True:

--- a/bittensor/core/extrinsics/transfer.py
+++ b/bittensor/core/extrinsics/transfer.py
@@ -52,7 +52,7 @@ def _do_transfer(
         else:
             call_params["keep_alive"] = False
     else:
-        call_params["amount"] = amount.rao
+        call_params["value"] = amount.rao
         if keep_alive:
             call_function = "transfer_keep_alive"
         else:

--- a/bittensor/core/extrinsics/transfer.py
+++ b/bittensor/core/extrinsics/transfer.py
@@ -167,6 +167,7 @@ def transfer_extrinsic(
         wallet=wallet,
         destination=dest,
         amount=amount,
+        keep_alive=keep_alive,
         wait_for_finalization=wait_for_finalization,
         wait_for_inclusion=wait_for_inclusion,
         period=period,

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -2271,7 +2271,7 @@ class Subtensor(SubtensorMixin):
             has sufficient funds to cover both the transfer amount and the associated costs. This function provides a
             crucial tool for managing financial operations within the Bittensor network.
         """
-        call_params = {"dest": dest}
+        call_params: dict[str, Union[int, str, bool]] = {"dest": dest}
         if value is None:
             call_function = "transfer_all"
             if keep_alive:

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -4266,7 +4266,7 @@ class Subtensor(SubtensorMixin):
         self,
         wallet: "Wallet",
         dest: str,
-        amount: Balance,
+        amount: Optional[Balance],
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
         transfer_all: bool = False,
@@ -4292,7 +4292,8 @@ class Subtensor(SubtensorMixin):
         Returns:
             `True` if the transferring was successful, otherwise `False`.
         """
-        amount = check_and_convert_to_balance(amount)
+        if amount is not None:
+            amount = check_and_convert_to_balance(amount)
         return transfer_extrinsic(
             subtensor=self,
             wallet=wallet,

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -107,6 +107,7 @@ from bittensor.utils import (
     u16_normalized_float,
     u64_normalized_float,
     deprecated_message,
+    get_transfer_fn_params,
 )
 from bittensor.utils.balance import (
     Balance,
@@ -2271,20 +2272,11 @@ class Subtensor(SubtensorMixin):
             has sufficient funds to cover both the transfer amount and the associated costs. This function provides a
             crucial tool for managing financial operations within the Bittensor network.
         """
-        call_params: dict[str, Union[int, str, bool]] = {"dest": dest}
-        if value is None:
-            call_function = "transfer_all"
-            if keep_alive:
-                call_params["keep_alive"] = True
-            else:
-                call_params["keep_alive"] = False
-        else:
+        if value is not None:
             value = check_and_convert_to_balance(value)
-            call_params["value"] = value.rao
-            if keep_alive:
-                call_function = "transfer_keep_alive"
-            else:
-                call_function = "transfer_allow_death"
+        call_params: dict[str, Union[int, str, bool]]
+        call_function, call_params = get_transfer_fn_params(value, dest, keep_alive)
+
         call = self.substrate.compose_call(
             call_module="Balances",
             call_function=call_function,

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -22,6 +22,7 @@ from .version import version_checking, check_version, VersionCheckError
 
 if TYPE_CHECKING:
     from bittensor_wallet import Wallet
+    from bittensor.utils.balance import Balance
 
 BT_DOCS_LINK = "https://docs.bittensor.com"
 
@@ -445,3 +446,34 @@ def deprecated_message(message: str) -> None:
     """Shows a deprecation warning message with the given message."""
     warnings.simplefilter("default", DeprecationWarning)
     warnings.warn(message=message, category=DeprecationWarning, stacklevel=2)
+
+
+def get_transfer_fn_params(
+    amount: Optional["Balance"], destination: str, keep_alive: bool
+) -> tuple[str, dict[str, Union[str, int, bool]]]:
+    """
+    Helper function to get the transfer call function and call params, depending on the value and keep_alive flag
+        provided
+
+    Args:
+        amount: the amount of Tao to transfer. `None` if transferring all.
+        destination: the destination SS58 of the transfer
+        keep_alive: whether to enforce a retention of the existential deposit in the account after transfer.
+
+    Returns:
+        tuple[call function, call params]
+    """
+    call_params = {"dest": destination}
+    if amount is None:
+        call_function = "transfer_all"
+        if keep_alive:
+            call_params["keep_alive"] = True
+        else:
+            call_params["keep_alive"] = False
+    else:
+        call_params["value"] = amount.rao
+        if keep_alive:
+            call_function = "transfer_keep_alive"
+        else:
+            call_function = "transfer_allow_death"
+    return call_function, call_params

--- a/tests/unit_tests/extrinsics/test_transfer.py
+++ b/tests/unit_tests/extrinsics/test_transfer.py
@@ -41,9 +41,9 @@ def test_do_transfer_is_success_true(
         fake_wallet,
         fake_dest,
         amount,
-        keep_alive,
         fake_wait_for_inclusion,
         fake_wait_for_finalization,
+        keep_alive=keep_alive,
     )
 
     # Asserts
@@ -81,9 +81,9 @@ def test_do_transfer_is_success_false(subtensor, fake_wallet, mocker):
         fake_wallet,
         fake_dest,
         fake_transfer_balance,
-        keep_alive,
         fake_wait_for_inclusion,
         fake_wait_for_finalization,
+        keep_alive=keep_alive,
     )
 
     # Asserts
@@ -122,9 +122,9 @@ def test_do_transfer_no_waits(subtensor, fake_wallet, mocker):
         fake_wallet,
         fake_dest,
         fake_transfer_balance,
-        keep_alive,
         fake_wait_for_inclusion,
         fake_wait_for_finalization,
+        keep_alive=keep_alive,
     )
 
     # Asserts


### PR DESCRIPTION
Mirrors https://github.com/opentensor/btcli/pull/562

Uses different extrinsics depending on what is selected.

Transfer All uses "Balances.transfer_all", with param `keep_alive` toggled depending on `keep_alive` arg.

Non-Transfer-All with `keep_alive=False` uses "Balances.transfer_allow_death"

Non-Transfer-All with `keep_alive=True` uses "Balances.transfer_keep_alive"