### PR TITLE
pin `"numpy>=2.0.1,<2.3.1"` in deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "colorama~=0.4.6",
     "fastapi~=0.110.1",
     "munch~=2.5.0",
-    "numpy>=2.0.1,<3.0.0",
+    "numpy>=2.0.1,<2.3.1",
     "msgpack-numpy-opentensor~=0.5.0",
     "nest_asyncio==1.6.0",
     "netaddr==1.3.0",


### PR DESCRIPTION

Github started to use numpy 2.3.2 as default version
Failed Subtensor test: https://github.com/opentensor/subtensor/actions/runs/16507108706/job/46681272592?pr=1882