### PR TITLE
chore: fix typo

### DIFF
--- a/contrib/RELEASE_GUIDELINES.md
+++ b/contrib/RELEASE_GUIDELINES.md
@@ -44,7 +44,7 @@ Since you need to use a secret when releasing bittensor (github personal access 
 
 So you can have:
 ```
-GITHUB_ACCESS_TOKEN=$(pass github/your_personal_token_with_permisions)
+GITHUB_ACCESS_TOKEN=$(pass github/your_personal_token_with_permissions)
 ```
 
 or


### PR DESCRIPTION
fixed typo in `your_personal_token_with_permisions`. it has to be `your_personal_token_with_permiSSions`