### PR TITLE
Missed await

### DIFF
--- a/tests/e2e_tests/utils/e2e_test_utils.py
+++ b/tests/e2e_tests/utils/e2e_test_utils.py
@@ -274,13 +274,14 @@ async def async_wait_to_start_call(
     if await subtensor.is_fast_blocks() is False:
         in_blocks = 5
 
+    current_block = await subtensor.block
+
     bittensor.logging.console.info(
         f"Waiting for [blue]{in_blocks}[/blue] blocks before [red]start call[/red]. "
-        f"Current block: [blue]{await subtensor.block}[/blue]."
+        f"Current block: [blue]{current_block}[/blue]."
     )
 
     # make sure we passed start_call limit
-    current_block = await subtensor.block
     await subtensor.wait_for_block(current_block + in_blocks + 1)
     status, message = await subtensor.start_call(
         wallet=subnet_owner_wallet,

--- a/tests/e2e_tests/utils/e2e_test_utils.py
+++ b/tests/e2e_tests/utils/e2e_test_utils.py
@@ -276,7 +276,7 @@ async def async_wait_to_start_call(
 
     bittensor.logging.console.info(
         f"Waiting for [blue]{in_blocks}[/blue] blocks before [red]start call[/red]. "
-        f"Current block: [blue]{subtensor.block}[/blue]."
+        f"Current block: [blue]{await subtensor.block}[/blue]."
     )
 
     # make sure we passed start_call limit


### PR DESCRIPTION
When running tests, I noticed the log:
```
2025-08-04 16:32:16.873 |       INFO       | bittensor:console.py:53 | Waiting for 10 blocks before start call. Current block: <coroutine object AsyncSubtensor.block at 0x7fba8d9a2200>.
```

This fixes that.