### PR TITLE
Format Error with string docs

### DIFF
--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -255,7 +255,9 @@ def format_error_message(error_message: Union[dict, Exception]) -> str:
             err_type = error_message.get("type", err_type)
             err_name = error_message.get("name", err_name)
             err_docs = error_message.get("docs", [err_description])
-            err_description = " ".join(err_docs)
+            err_description = (
+                err_docs if isinstance(err_docs, str) else " ".join(err_docs)
+            )
             err_description += (
                 f" | Please consult {BT_DOCS_LINK}/errors/subtensor#{err_name.lower()}"
             )

--- a/tests/unit_tests/extrinsics/test__init__.py
+++ b/tests/unit_tests/extrinsics/test__init__.py
@@ -102,3 +102,22 @@ def test_format_error_message_with_custom_error_message_without_index():
         == f"Subtensor returned `SubstrateRequestException({fake_custom_error['message']})` error. This means: "
         f"`{fake_custom_error['data']}`."
     )
+
+
+def test_format_error_with_string_docs():
+    fake_error_message = {
+        "type": "SomeType",
+        "name": "SomeErrorName",
+        "docs": "Some error description.",
+    }
+
+    # Call
+    result = format_error_message(fake_error_message)
+
+    # Assertions
+
+    assert (
+        result == "Subtensor returned `SomeErrorName(SomeType)` error. "
+        "This means: `Some error description."
+        f" | Please consult {BT_DOCS_LINK}/errors/subtensor#someerrorname`."
+    )


### PR DESCRIPTION
Improves the error formatter for instances where the docs are a string (such as is the case with BadOrigin) while retaining the list join for non-strings.