### PR TITLE
`LoggingMachine` initialization updated to explicitly call both parent constructors

### DIFF
--- a/.github/workflows/flake8-and-mypy.yml
+++ b/.github/workflows/flake8-and-mypy.yml
@@ -42,7 +42,8 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           python -m pip install --upgrade pip
-          python -m pip install uv
+          # uv==0.8.6 is the last version that supports python 3.9
+          python -m pip install uv==0.8.6
           python -m uv sync --extra dev --active
 
       - name: Flake8

--- a/.github/workflows/unit-and-integration-tests.yml
+++ b/.github/workflows/unit-and-integration-tests.yml
@@ -39,7 +39,8 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           python -m pip install --upgrade pip
-          python -m pip install uv
+          # uv==0.8.6 is the last version that supports python 3.9
+          python -m pip install uv==0.8.6
           python -m uv sync --extra dev --active
 
       - name: Unit tests

--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -137,7 +137,8 @@ class LoggingMachine(StateMachine, Logger):
 
     def __init__(self, config: "Config", name: str = BITTENSOR_LOGGER_NAME):
         # basics
-        super(LoggingMachine, self).__init__()
+        StateMachine.__init__(self)
+        stdlogging.Logger.__init__(self, name)
         self._queue = mp.Queue(-1)
         self._primary_loggers = {name}
         self._config = self._extract_logging_config(config)


### PR DESCRIPTION
Issue: https://github.com/opentensor/bittensor/issues/3003

### Note:
2 hours ago [`uv=0.8.7` released](https://pypi.org/project/uv/#history). This version doesn't support Python 3.9. We have to pin 0.8.6 while we support Python 3.9