### PR TITLE
Fixed `moving_price` conversion from `I96F32` to float

### DIFF
--- a/bittensor/core/chain_data/dynamic_info.py
+++ b/bittensor/core/chain_data/dynamic_info.py
@@ -126,7 +126,7 @@ class DynamicInfo(InfoBase):
             network_registered_at=int(decoded["network_registered_at"]),
             subnet_identity=subnet_identity,
             subnet_volume=subnet_volume,
-            moving_price=fixed_to_float(decoded["moving_price"]),
+            moving_price=fixed_to_float(decoded["moving_price"], 32),
         )
 
     def tao_to_alpha(self, tao: Union[Balance, float, int]) -> Balance:


### PR DESCRIPTION
The `SubnetMovingPrice` storage uses `I96F32` format (32 fractional bits), but the 
current `DynamicInfo` calls `fixed_to_float()` for `moving_price` without specifying 
fractional bits, defaulting to 64 bits.

This causes `moving_price` values like 0.05 being incorrectly decoded as 0.00000000001.

Related Issue: https://github.com/opentensor/bittensor/issues/3009#issue-3307125144