### PR TITLE
Add async crv4 e2e test

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -2519,6 +2519,7 @@ class AsyncSubtensor(SubtensorMixin):
             netuid=netuid, block=block, block_hash=block_hash, reuse_block=reuse_block
         )
 
+        block = block or await self.substrate.get_block_number(block_hash=block_hash)
         if block and blocks_since_last_step is not None and tempo:
             return block - blocks_since_last_step + tempo + 1
         return None

--- a/tests/e2e_tests/test_commit_reveal.py
+++ b/tests/e2e_tests/test_commit_reveal.py
@@ -6,6 +6,7 @@ import pytest
 from bittensor.utils.btlogging import logging
 from bittensor.utils.weight_utils import convert_weights_and_uids_for_emit
 from tests.e2e_tests.utils.chain_interactions import (
+    async_wait_interval,
     sudo_set_admin_utils,
     sudo_set_hyperparameter_bool,
     wait_interval,
@@ -230,3 +231,234 @@ async def test_commit_and_reveal_weights_cr4(local_chain, subtensor, alice_walle
     )
 
     logging.console.success("✅ Passed `test_commit_and_reveal_weights_cr4`")
+
+
+@pytest.mark.asyncio
+async def test_async_commit_and_reveal_weights_cr4(
+    local_chain, async_subtensor, alice_wallet
+):
+    """
+    Tests the commit/reveal weights mechanism (CR3)
+
+    Steps:
+        1. Register a subnet through Alice
+        2. Register Alice's neuron and add stake
+        3. Enable a commit-reveal mechanism on subnet
+        4. Lower weights rate limit
+        5. Change the tempo for subnet 1
+        5. Commit weights and ensure they are committed.
+        6. Wait interval & reveal weights and verify
+    Raises:
+        AssertionError: If any of the checks or verifications fail
+    """
+    logging.console.info("Testing `test_commit_and_reveal_weights_cr4`")
+
+    async with async_subtensor:
+        # 12 for non-fast-block, 0.25 for fast block
+        BLOCK_TIME, TEMPO_TO_SET = (
+            (0.25, 100) if await async_subtensor.chain.is_fast_blocks() else (12.0, 20)
+        )
+
+        logging.console.info(f"Using block time: {BLOCK_TIME}")
+
+        alice_subnet_netuid = await async_subtensor.subnets.get_total_subnets()  # 2
+
+        # Register root as Alice
+        assert await async_subtensor.extrinsics.register_subnet(alice_wallet), (
+            "Unable to register the subnet"
+        )
+
+        # Verify subnet 2 created successfully
+        assert await async_subtensor.subnet_exists(alice_subnet_netuid), (
+            f"SN #{alice_subnet_netuid} wasn't created successfully"
+        )
+
+        logging.console.success(f"SN #{alice_subnet_netuid} is registered.")
+
+        # Enable commit_reveal on the subnet
+        assert sudo_set_hyperparameter_bool(
+            substrate=local_chain,
+            wallet=alice_wallet,
+            call_function="sudo_set_commit_reveal_weights_enabled",
+            value=True,
+            netuid=alice_subnet_netuid,
+        ), f"Unable to enable commit reveal on the SN #{alice_subnet_netuid}"
+
+        # Verify commit_reveal was enabled
+        assert await async_subtensor.subnets.commit_reveal_enabled(
+            alice_subnet_netuid
+        ), "Failed to enable commit/reveal"
+        logging.console.success("Commit reveal enabled")
+
+        cr_version = await async_subtensor.substrate.query(
+            module="SubtensorModule", storage_function="CommitRevealWeightsVersion"
+        )
+        assert cr_version == 4, f"Commit reveal version is not 3, got {cr_version}"
+
+        # Change the weights rate limit on the subnet
+        status, error = sudo_set_admin_utils(
+            substrate=local_chain,
+            wallet=alice_wallet,
+            call_function="sudo_set_weights_set_rate_limit",
+            call_params={"netuid": alice_subnet_netuid, "weights_set_rate_limit": "0"},
+        )
+
+        assert status is True
+        assert error is None
+
+        # Verify weights rate limit was changed
+        assert (
+            await async_subtensor.subnets.get_subnet_hyperparameters(
+                netuid=alice_subnet_netuid
+            )
+        ).weights_rate_limit == 0, "Failed to set weights_rate_limit"
+        assert await async_subtensor.weights_rate_limit(netuid=alice_subnet_netuid) == 0
+        logging.console.success("sudo_set_weights_set_rate_limit executed: set to 0")
+
+        # Change the tempo of the subnet
+        assert (
+            sudo_set_admin_utils(
+                local_chain,
+                alice_wallet,
+                call_function="sudo_set_tempo",
+                call_params={"netuid": alice_subnet_netuid, "tempo": TEMPO_TO_SET},
+            )[0]
+            is True
+        )
+
+        tempo = (
+            await async_subtensor.subnets.get_subnet_hyperparameters(
+                netuid=alice_subnet_netuid
+            )
+        ).tempo
+        assert tempo == TEMPO_TO_SET, "SN tempos has not been changed."
+        logging.console.success(
+            f"SN #{alice_subnet_netuid} tempo set to {TEMPO_TO_SET}"
+        )
+
+        # Commit-reveal values - setting weights to self
+        uids = np.array([0], dtype=np.int64)
+        weights = np.array([0.1], dtype=np.float32)
+
+        weight_uids, weight_vals = convert_weights_and_uids_for_emit(
+            uids=uids, weights=weights
+        )
+        logging.console.info(
+            f"Committing weights: uids {weight_uids}, weights {weight_vals}"
+        )
+
+        # Fetch current block and calculate next tempo for the subnet
+        current_block = await async_subtensor.chain.get_current_block()
+        upcoming_tempo = next_tempo(current_block, tempo)
+        logging.console.info(
+            f"Checking if window is too low with Current block: {current_block}, next tempo: {upcoming_tempo}"
+        )
+
+        # Lower than this might mean weights will get revealed before we can check them
+        if upcoming_tempo - current_block < 6:
+            await async_wait_interval(
+                tempo,
+                async_subtensor,
+                netuid=alice_subnet_netuid,
+                reporting_interval=1,
+            )
+        current_block = await async_subtensor.chain.get_current_block()
+        latest_drand_round = await async_subtensor.chain.last_drand_round()
+        upcoming_tempo = next_tempo(current_block, tempo)
+        logging.console.info(
+            f"Post first wait_interval (to ensure window isn't too low): {current_block}, next tempo: {upcoming_tempo}, drand: {latest_drand_round}"
+        )
+
+        # commit_block is the block when weights were committed on the chain (transaction block)
+        expected_commit_block = await async_subtensor.block + 1
+        # Commit weights
+        success, message = await async_subtensor.extrinsics.set_weights(
+            wallet=alice_wallet,
+            netuid=alice_subnet_netuid,
+            uids=weight_uids,
+            weights=weight_vals,
+            wait_for_inclusion=True,
+            wait_for_finalization=True,
+            block_time=BLOCK_TIME,
+            period=16,
+        )
+
+        # Assert committing was a success
+        assert success is True, message
+        assert bool(re.match(r"reveal_round:\d+", message))
+
+        # Parse expected reveal_round
+        expected_reveal_round = int(message.split(":")[1])
+        logging.console.success(
+            f"Successfully set weights: uids {weight_uids}, weights {weight_vals}, reveal_round: {expected_reveal_round}"
+        )
+
+        # Fetch current commits pending on the chain
+        commits_on_chain = (
+            await async_subtensor.commitments.get_current_weight_commit_info_v2(
+                netuid=alice_subnet_netuid
+            )
+        )
+        address, commit_block, commit, reveal_round = commits_on_chain[0]
+
+        # Assert correct values are committed on the chain
+        assert expected_reveal_round == reveal_round
+        assert address == alice_wallet.hotkey.ss58_address
+
+        # bc of the drand delay, the commit block can be either the previous block or the current block
+        # assert expected_commit_block in [commit_block - 1, commit_block, commit_block + 1]
+
+        # Ensure no weights are available as of now
+        assert await async_subtensor.weights(netuid=alice_subnet_netuid) == []
+        logging.console.success("No weights are available before next epoch.")
+
+        # 5 is safety drand offset
+        expected_reveal_block = (
+            await async_subtensor.subnets.get_next_epoch_start_block(
+                alice_subnet_netuid
+            )
+            + 5
+        )
+
+        logging.console.info(
+            f"Waiting for the next epoch to ensure weights are revealed: block {expected_reveal_block}"
+        )
+        await async_subtensor.wait_for_block(expected_reveal_block)
+
+        # Fetch the latest drand pulse
+        latest_drand_round = await async_subtensor.chain.last_drand_round()
+        logging.console.info(
+            f"Latest drand round after waiting for tempo: {latest_drand_round}"
+        )
+
+        # Fetch weights on the chain as they should be revealed now
+        subnet_weights = await async_subtensor.subnets.weights(
+            netuid=alice_subnet_netuid
+        )
+        assert subnet_weights != [], "Weights are not available yet."
+
+        logging.console.info(f"Revealed weights: {subnet_weights}")
+
+        revealed_weights = subnet_weights[0][1]
+        # Assert correct weights were revealed
+        assert weight_uids[0] == revealed_weights[0][0]
+        assert weight_vals[0] == revealed_weights[0][1]
+
+        logging.console.success(
+            f"Successfully revealed weights: uids {weight_uids}, weights {weight_vals}"
+        )
+
+        # Now that the commit has been revealed, there shouldn't be any pending commits
+        assert (
+            await async_subtensor.commitments.get_current_weight_commit_info_v2(
+                netuid=alice_subnet_netuid
+            )
+            == []
+        )
+
+        # Ensure the drand_round is always in the positive w.r.t expected when revealed
+        assert latest_drand_round - expected_reveal_round >= -3, (
+            f"latest_drand_round ({latest_drand_round}) is less than expected_reveal_round ({expected_reveal_round})"
+        )
+
+        logging.console.success("✅ Passed `test_commit_and_reveal_weights_cr4`")

--- a/tests/e2e_tests/utils/chain_interactions.py
+++ b/tests/e2e_tests/utils/chain_interactions.py
@@ -14,6 +14,7 @@ from bittensor.utils.btlogging import logging
 # for typing purposes
 if TYPE_CHECKING:
     from bittensor import Wallet
+    from bittensor.core.async_subtensor import AsyncSubtensor
     from bittensor.core.subtensor import Subtensor
     from async_substrate_interface import SubstrateInterface, ExtrinsicReceipt
 
@@ -136,6 +137,44 @@ async def wait_interval(
             sleep,
         )  # Wait before checking the block number again
         current_block = subtensor.get_current_block()
+        if last_reported is None or current_block - last_reported >= reporting_interval:
+            last_reported = current_block
+            print(
+                f"Current Block: {current_block}  Next tempo for netuid {netuid} at: {next_tempo_block_start}"
+            )
+            logging.info(
+                f"Current Block: {current_block}  Next tempo for netuid {netuid} at: {next_tempo_block_start}"
+            )
+
+
+async def async_wait_interval(
+    tempo: int,
+    subtensor: "AsyncSubtensor",
+    netuid: int = 1,
+    reporting_interval: int = 1,
+    sleep: float = 0.25,
+    times: int = 1,
+):
+    """
+    Waits until the next tempo interval starts for a specific subnet.
+
+    Calculates the next tempo block start based on the current block number
+    and the provided tempo, then enters a loop where it periodically checks
+    the current block number until the next tempo interval starts.
+    """
+    current_block = await subtensor.get_current_block()
+    next_tempo_block_start = current_block
+
+    for _ in range(times):
+        next_tempo_block_start = next_tempo(next_tempo_block_start, tempo)
+
+    last_reported = None
+
+    while current_block < next_tempo_block_start:
+        await asyncio.sleep(
+            sleep,
+        )  # Wait before checking the block number again
+        current_block = await subtensor.get_current_block()
         if last_reported is None or current_block - last_reported >= reporting_interval:
             last_reported = current_block
             print(


### PR DESCRIPTION
During the implementation of e2e tests with an asynchronous subtensor, a bug was found.

We need to implement all tests using asynchronous subtensor. This will improve the quality of SDK code.

Included to https://github.com/opentensor/bittensor/issues/2461