### PR TITLE
Improve e2e workflow

### DIFF
--- a/.github/workflows/_run-e2e-single.yaml
+++ b/.github/workflows/_run-e2e-single.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
 
       - name: Cache uv and venv
         uses: actions/cache@v4

--- a/.github/workflows/_run-e2e-single.yaml
+++ b/.github/workflows/_run-e2e-single.yaml
@@ -38,6 +38,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
+          ignore-nothing-to-cache: true
 
       - name: Cache uv and venv
         uses: actions/cache@v4

--- a/.github/workflows/_run-e2e-single.yaml
+++ b/.github/workflows/_run-e2e-single.yaml
@@ -9,9 +9,6 @@ on:
       image-name:
         required: true
         type: string
-      python-versions:
-        required: true
-        type: string
 
 jobs:
   run-e2e:
@@ -22,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJson(inputs.python-versions) }}
+        python-version: ${{ fromJson(vars.SDK_SUPPORTED_PYTHON_VERSIONS) }}
 
     steps:
       - name: Check-out repository
@@ -36,9 +33,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-          ignore-nothing-to-cache: true
+          enable-cache: false
 
       - name: Cache uv and venv
         uses: actions/cache@v4
@@ -47,8 +42,7 @@ jobs:
             ~/.cache/uv
             .venv
           key: uv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            uv-${{ runner.os }}-py${{ matrix.python-version }}-
+          restore-keys: uv-${{ runner.os }}-py${{ matrix.python-version }}-
 
       - name: Install dependencies
         run: uv sync --extra dev --dev

--- a/.github/workflows/_run-e2e-single.yaml
+++ b/.github/workflows/_run-e2e-single.yaml
@@ -9,6 +9,9 @@ on:
       image-name:
         required: true
         type: string
+      python-versions:
+        required: true
+        type: string
 
 jobs:
   run-e2e:
@@ -19,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ fromJson(inputs.python-versions) }}
 
     steps:
       - name: Check-out repository
@@ -32,6 +35,18 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Cache uv and venv
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            uv-${{ runner.os }}-py${{ matrix.python-version }}-
 
       - name: Install dependencies
         run: uv sync --extra dev --dev

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ fromJson(vars.SDK_SUPPORTED_PYTHON_VERSIONS) }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJson(needs.decide-versions.outputs.py_json) }}
+        python-version: ${{ fromJson(needs.supported-versions.outputs.py_json) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +66,6 @@ jobs:
 
   # Looking for e2e tests
   find-tests:
-    needs: prepare-deps
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.draft == false }}
     outputs:
@@ -203,5 +202,5 @@ jobs:
     with:
       nodeid: ${{ matrix.nodeid }}
       image-name: ${{ needs.pull-docker-image.outputs.image-name }}
-      python-versions: ${{ needs.decide-versions.outputs.py_json }}
+      python-versions: ${{ needs.supported-versions.outputs.py_json }}
     secrets: inherit

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - id: set
         run: |
-          echo 'py_json=["3.11","3.12","3.13"]' >> "$GITHUB_OUTPUT"
+          echo 'py_json=["3.10", "3.11","3.12","3.13"]' >> "$GITHUB_OUTPUT"
 
   # prepare dependencies for all jobs ib cache
   prepare-deps:
@@ -49,6 +49,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
 
       - name: Cache uv and venv
         uses: actions/cache@v4

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -196,7 +196,7 @@ jobs:
       - pull-docker-image
     strategy:
       fail-fast: false
-      max-parallel: 16
+      max-parallel: 32
       matrix:
         include: ${{ fromJson(needs.find-tests.outputs.test-files) }}
     uses: ./.github/workflows/_run-e2e-single.yaml

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -84,6 +84,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
 
       - name: Cache uv and venv
         uses: actions/cache@v4
@@ -91,9 +92,9 @@ jobs:
           path: |
             ~/.cache/uv
             .venv
-          key: uv-${{ runner.os }}-py3.11-${{ hashFiles('pyproject.toml') }}
+          key: uv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            uv-${{ runner.os }}-py3.11-
+            uv-${{ runner.os }}-py${{ matrix.python-version }}-
 
       - name: Install dependencies (faster if cache hit)
         run: uv sync --extra dev --dev

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -17,18 +17,26 @@ on:
         required: false
         default: ""
 
-env:
-  PY_VERSIONS: '["3.11","3.12","3.13"]'
-
 # job to run tests in parallel
 jobs:
+  # keep python version in one place
+  decide-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      py_json: ${{ steps.set.outputs.py_json }}
+    steps:
+      - id: set
+        run: |
+          echo 'py_json=["3.11","3.12","3.13"]' >> "$GITHUB_OUTPUT"
+
   # prepare dependencies for all jobs ib cache
   prepare-deps:
+    needs: decide-versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJson(env.PY_VERSIONS) }}
+        python-version: ${{ fromJson(needs.decide-versions.outputs.py_json) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -181,6 +189,7 @@ jobs:
   e2e-test:
     name: ${{ matrix.label }}
     needs:
+      - decide-versions
       - find-tests
       - pull-docker-image
     strategy:
@@ -192,5 +201,5 @@ jobs:
     with:
       nodeid: ${{ matrix.nodeid }}
       image-name: ${{ needs.pull-docker-image.outputs.image-name }}
-      python-versions: ${{ env.PY_VERSIONS }}
+      python-versions: ${{ needs.decide-versions.outputs.py_json }}
     secrets: inherit

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -149,7 +149,7 @@ jobs:
       - pull-docker-image
     strategy:
       fail-fast: false
-      max-parallel: 16
+      max-parallel: 8
       matrix:
         include: ${{ fromJson(needs.find-tests.outputs.test-files) }}
     uses: ./.github/workflows/_run-e2e-single.yaml

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -18,19 +18,17 @@ on:
         default: ""
 
 env:
-  CARGO_TERM_COLOR: always
-  VERBOSE: ${{ github.event.inputs.verbose }}
-  PY_VERSION: '["3.11","3.12","3.13"]'
+  PY_VERSIONS: '["3.11","3.12","3.13"]'
 
 # job to run tests in parallel
 jobs:
-
+  # prepare dependencies for all jobs ib cache
   prepare-deps:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJson(env.PY_VERSION) }}
+        python-version: ${{ fromJson(env.PY_VERSIONS) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -84,7 +82,7 @@ jobs:
           path: |
             ~/.cache/uv
             .venv
-          key: uv-${{ runner.os }}-py3.11-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+          key: uv-${{ runner.os }}-py3.11-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             uv-${{ runner.os }}-py3.11-
 
@@ -174,6 +172,7 @@ jobs:
         with:
           name: subtensor-localnet
           path: subtensor-localnet.tar
+          compression-level: 0
 
   # Job to run tests in parallel
   # Since GH Actions matrix has a limit of 256 jobs, we need to split the tests into multiple jobs with different
@@ -193,5 +192,5 @@ jobs:
     with:
       nodeid: ${{ matrix.nodeid }}
       image-name: ${{ needs.pull-docker-image.outputs.image-name }}
-      python-versions: env.PY_VERSION)
+      python-versions: ${{ env.PY_VERSIONS }}
     secrets: inherit

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJson(env.PY_VERSIONS_JSON) }}
+        python-version: ${{ fromJson(env.PY_VERSION) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -72,6 +72,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
 
       - name: Cache uv and venv
         uses: actions/cache@v4
@@ -188,5 +193,5 @@ jobs:
     with:
       nodeid: ${{ matrix.nodeid }}
       image-name: ${{ needs.pull-docker-image.outputs.image-name }}
-      python-versions: env.PY_VERSIONS_JSON)
+      python-versions: env.PY_VERSION)
     secrets: inherit

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -190,6 +190,7 @@ jobs:
   e2e-test:
     name: ${{ matrix.label }}
     needs:
+      - supported-versions
       - prepare-deps
       - find-tests
       - pull-docker-image

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -20,7 +20,7 @@ on:
 # job to run tests in parallel
 jobs:
   # keep python version in one place
-  decide-versions:
+  supported-versions:
     runs-on: ubuntu-latest
     outputs:
       py_json: ${{ steps.set.outputs.py_json }}
@@ -31,7 +31,7 @@ jobs:
 
   # prepare dependencies for all jobs ib cache
   prepare-deps:
-    needs: decide-versions
+    needs: supported-versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -191,7 +191,7 @@ jobs:
   e2e-test:
     name: ${{ matrix.label }}
     needs:
-      - decide-versions
+      - supported-versions
       - find-tests
       - pull-docker-image
     strategy:

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -190,7 +190,7 @@ jobs:
   e2e-test:
     name: ${{ matrix.label }}
     needs:
-      - supported-versions
+      - prepare-deps
       - find-tests
       - pull-docker-image
     strategy:

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -20,11 +20,46 @@ on:
 env:
   CARGO_TERM_COLOR: always
   VERBOSE: ${{ github.event.inputs.verbose }}
+  PY_VERSION: '["3.11","3.12","3.13"]'
 
 # job to run tests in parallel
 jobs:
+
+  prepare-deps:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJson(env.PY_VERSIONS_JSON) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Cache uv and venv
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            uv-${{ runner.os }}-py${{ matrix.python-version }}-
+
+      - name: Sync deps (populate cache on miss)
+        run: uv sync --extra dev --dev
+
   # Looking for e2e tests
   find-tests:
+    needs: prepare-deps
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.draft == false }}
     outputs:
@@ -38,15 +73,17 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install deps for collection
-        run: |
-         python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+      - name: Cache uv and venv
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-py3.11-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+          restore-keys: |
+            uv-${{ runner.os }}-py3.11-
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Install dependencies
+      - name: Install dependencies (faster if cache hit)
         run: uv sync --extra dev --dev
 
       - name: Find test files
@@ -151,4 +188,5 @@ jobs:
     with:
       nodeid: ${{ matrix.nodeid }}
       image-name: ${{ needs.pull-docker-image.outputs.image-name }}
+      python-versions: env.PY_VERSIONS_JSON)
     secrets: inherit

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -43,6 +43,12 @@ jobs:
          python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --extra dev --dev
+
       - name: Find test files
         id: get-tests
         shell: bash

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -50,6 +50,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
+          ignore-nothing-to-cache: true
 
       - name: Cache uv and venv
         uses: actions/cache@v4
@@ -84,6 +85,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
+          ignore-nothing-to-cache: true
 
       - name: Cache uv and venv
         uses: actions/cache@v4
@@ -196,7 +198,7 @@ jobs:
       - pull-docker-image
     strategy:
       fail-fast: false
-      max-parallel: 32
+      max-parallel: 24
       matrix:
         include: ${{ fromJson(needs.find-tests.outputs.test-files) }}
     uses: ./.github/workflows/_run-e2e-single.yaml

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -19,52 +19,6 @@ on:
 
 # job to run tests in parallel
 jobs:
-  # keep python version in one place
-  supported-versions:
-    runs-on: ubuntu-latest
-    outputs:
-      py_json: ${{ steps.set.outputs.py_json }}
-    steps:
-      - id: set
-        run: |
-          echo 'py_json=["3.10", "3.11","3.12","3.13"]' >> "$GITHUB_OUTPUT"
-
-  # prepare dependencies for all jobs ib cache
-  prepare-deps:
-    needs: supported-versions
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ${{ fromJson(needs.supported-versions.outputs.py_json) }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-          ignore-nothing-to-cache: true
-
-      - name: Cache uv and venv
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/uv
-            .venv
-          key: uv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            uv-${{ runner.os }}-py${{ matrix.python-version }}-
-
-      - name: Sync deps (populate cache on miss)
-        run: uv sync --extra dev --dev
-
   # Looking for e2e tests
   find-tests:
     runs-on: ubuntu-latest
@@ -78,12 +32,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.10'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
+          enable-cache: false
           cache-dependency-glob: '**/pyproject.toml'
           ignore-nothing-to-cache: true
 
@@ -93,9 +47,8 @@ jobs:
           path: |
             ~/.cache/uv
             .venv
-          key: uv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            uv-${{ runner.os }}-py${{ matrix.python-version }}-
+          key: uv-${{ runner.os }}-py3.10-${{ hashFiles('pyproject.toml') }}
+          restore-keys: uv-${{ runner.os }}-py3.10-
 
       - name: Install dependencies (faster if cache hit)
         run: uv sync --extra dev --dev
@@ -192,8 +145,6 @@ jobs:
   e2e-test:
     name: ${{ matrix.label }}
     needs:
-      - supported-versions
-      - prepare-deps
       - find-tests
       - pull-docker-image
     strategy:
@@ -205,5 +156,4 @@ jobs:
     with:
       nodeid: ${{ matrix.nodeid }}
       image-name: ${{ needs.pull-docker-image.outputs.image-name }}
-      python-versions: ${{ needs.supported-versions.outputs.py_json }}
     secrets: inherit

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -198,7 +198,7 @@ jobs:
       - pull-docker-image
     strategy:
       fail-fast: false
-      max-parallel: 24
+      max-parallel: 16
       matrix:
         include: ${{ fromJson(needs.find-tests.outputs.test-files) }}
     uses: ./.github/workflows/_run-e2e-single.yaml

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -149,7 +149,7 @@ jobs:
       - pull-docker-image
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 16
       matrix:
         include: ${{ fromJson(needs.find-tests.outputs.test-files) }}
     uses: ./.github/workflows/_run-e2e-single.yaml

--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -105,7 +105,7 @@ jobs:
         run: |
           set -euo pipefail
           test_matrix=$(
-            pytest -q --collect-only tests/e2e_tests \
+            uv run pytest -q --collect-only tests/e2e_tests \
             | sed -n '/^e2e_tests\//p' \
             | sed 's|^|tests/|' \
             | jq -R -s -c '

--- a/.github/workflows/flake8-and-mypy.yml
+++ b/.github/workflows/flake8-and-mypy.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: ${{ fromJson(vars.SDK_SUPPORTED_PYTHON_VERSIONS) }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/flake8-and-mypy.yml
+++ b/.github/workflows/flake8-and-mypy.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - name: Checkout repository
@@ -26,31 +26,25 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Cache venv
-        id: cache
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: false
+
+      - name: Cache uv and .venv
         uses: actions/cache@v4
         with:
-          path: venv
-          key: |
-            v3-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            v3-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}-
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: uv-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-
 
-      - name: Install deps (flake8 + mypy + project.dev)
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        run: |
-          python -m venv venv
-          source venv/bin/activate
-          python -m pip install --upgrade pip
-          python -m pip install uv==0.8.14
-          python -m uv sync --extra dev --active
+      - name: Sync dev deps
+        run: uv sync --extra dev --dev
 
       - name: Flake8
-        run: |
-          source venv/bin/activate
-          python -m flake8 bittensor/ --count
+        run: uv run flake8 bittensor/ --count
 
-      - name: mypy
-        run: |
-          source venv/bin/activate
-          python -m mypy --ignore-missing-imports bittensor/
+      - name: Mypy
+        run: uv run mypy --ignore-missing-imports bittensor/

--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -19,9 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ fromJson(vars.SDK_SUPPORTED_PYTHON_VERSIONS) }}
     outputs:
-      py39: ${{ steps.set-output.outputs.py39 }}
       py310: ${{ steps.set-output.outputs.py310 }}
       py311: ${{ steps.set-output.outputs.py311 }}
       py312: ${{ steps.set-output.outputs.py312 }}

--- a/.github/workflows/nightly-e2e-tests-subtensor-main.yml
+++ b/.github/workflows/nightly-e2e-tests-subtensor-main.yml
@@ -118,7 +118,7 @@ jobs:
         os:
           - ubuntu-latest
         test-file: ${{ fromJson(needs.find-tests.outputs.test-files) }}
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ fromJson(vars.SDK_SUPPORTED_PYTHON_VERSIONS) }}
     steps:
       - name: Check-out repository
         uses: actions/checkout@v4
@@ -191,7 +191,7 @@ jobs:
         os:
           - ubuntu-latest
         test-file: ${{ fromJson(needs.find-tests.outputs.test-files) }}
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ fromJson(vars.SDK_SUPPORTED_PYTHON_VERSIONS) }}
     steps:
       - name: Check-out repository
         uses: actions/checkout@v4
@@ -266,7 +266,7 @@ jobs:
         os:
           - ubuntu-latest
         test-file: ${{ fromJson(needs.find-tests.outputs.test-files) }}
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ fromJson(vars.SDK_SUPPORTED_PYTHON_VERSIONS) }}
 
     steps:
       - name: Check-out repository
@@ -342,7 +342,7 @@ jobs:
         os:
           - ubuntu-latest
         test-file: ${{ fromJson(needs.find-tests.outputs.test-files) }}
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ fromJson(vars.SDK_SUPPORTED_PYTHON_VERSIONS) }}
 
     steps:
       - name: Check-out repository

--- a/.github/workflows/unit-and-integration-tests.yml
+++ b/.github/workflows/unit-and-integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ fromJson(vars.SDK_SUPPORTED_PYTHON_VERSIONS) }}
 
     steps:
       - name: Checkout repository
@@ -24,36 +24,36 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
-      - name: Cache venv
-        id: cache
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: false
+
+      - name: Cache uv and .venv
         uses: actions/cache@v4
         with:
-          path: venv
-          key: v2-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            uv-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-
 
-      - name: Install deps
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        run: |
-          python -m venv venv
-          source venv/bin/activate
-          python -m pip install --upgrade pip
-          python -m pip install uv>=0.8.14
-          python -m uv sync --extra dev --active
+      - name: Sync dev deps (idempotent; fast on cache hit)
+        run: uv sync --extra dev --dev
 
       - name: Unit tests
         timeout-minutes: 20
         env:
           PYTHONUNBUFFERED: "1"
         run: |
-          source venv/bin/activate
-          python -m uv run pytest -n 2 tests/unit_tests/ --reruns 3
+          uv run pytest -n 2 tests/unit_tests/ --reruns 3
 
       - name: Integration tests
         timeout-minutes: 20
         env:
           PYTHONUNBUFFERED: "1"
         run: |
-          source venv/bin/activate
-          python -m uv run pytest -n 2 tests/integration_tests/ --reruns 3
+          uv run pytest -n 2 tests/integration_tests/ --reruns 3


### PR DESCRIPTION
As the number of tests and checks has grown, the overall pipeline execution time has increased significantly. This led to the idea of optimizing the process by reusing resources and automating through the use of repository-level environment variables. Configuration (such as the list of supported Python versions) is now centralized and consistently applied across all workflows, reducing duplication and simplifying maintenance.

- Caching the virtual env for each Python version helps reduce the time of all e2e tests from `~30` to `~<14 minutes`.
- Using shared cache and `vars.SDK_SUPPORTED_PYTHON_VERSIONS` to pass python versions from `Settings->Settings->Secret and variables->Actions->Repository variables`