### PR TITLE
Update get_neuron_for_pubkey_and_subnet to use block_hash instead of block and block_hash

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -2530,7 +2530,6 @@ class AsyncSubtensor(SubtensorMixin):
             return await self.neuron_for_uid(
                 uid=uid,
                 netuid=netuid,
-                block=block,
                 block_hash=block_hash,
                 reuse_block=reuse_block,
             )


### PR DESCRIPTION
block_hash is retrieved above and adding both blockhash and block to the neron_for_uid call results in you getting "Only one of ``block``, ``block_hash``, or ``reuse_block`` can be specified." when the determine_block_hash call occurs later

fixes #3083
