### PR TITLE
Improves `determine_block_hash` method of `AsyncSubtensor`

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -2567,6 +2567,7 @@ class AsyncSubtensor(SubtensorMixin):
             return await self.neuron_for_uid(
                 uid=uid,
                 netuid=netuid,
+                # do not pass block=block in this as block_hash is already determined above from the block if specified
                 block_hash=block_hash,
                 reuse_block=reuse_block,
             )

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -308,7 +308,7 @@ class AsyncSubtensor(SubtensorMixin):
 
     async def determine_block_hash(
         self,
-        block: Optional[int],
+        block: Optional[int] = None,
         block_hash: Optional[str] = None,
         reuse_block: bool = False,
     ) -> Optional[str]:

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -341,7 +341,7 @@ class AsyncSubtensor(SubtensorMixin):
             # Reuse last block hash
             block_hash = await subtensor.determine_block_hash(reuse_block=True)
         """
-        if reuse_block and any([block_hash, block_hash]):
+        if reuse_block and any([block, block_hash]):
             raise ValueError("Cannot specify both reuse_block and block_hash/block")
         if block and block_hash:
             retrieved_block_hash = await self.get_block_hash(block)

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -336,23 +336,23 @@ class AsyncSubtensor(SubtensorMixin):
             block_hash = await subtensor.determine_block_hash(block=1000000)
 
             # Use provided block hash
-            hash_ = await subtensor.determine_block_hash(block_hash="0x1234...")
+            block_hash = await subtensor.determine_block_hash(block_hash="0x1234...")
 
             # Reuse last block hash
-            hash_ = await subtensor.determine_block_hash(reuse_block=True)
+            block_hash = await subtensor.determine_block_hash(reuse_block=True)
         """
         if reuse_block and any([block_hash, block_hash]):
             raise ValueError("Cannot specify both reuse_block and block_hash/block")
         if block and block_hash:
-            bh = await self.get_block_hash(block)
-            if bh != block_hash:
+            retrieved_block_hash = await self.get_block_hash(block)
+            if retrieved_block_hash != block_hash:
                 raise ValueError(
                     "You have supplied a `block_hash` and a `block`, but the block does not map to the same hash as "
                     f"the one you supplied. You supplied `block_hash={block_hash}` for `block={block}`, but this block"
-                    f"maps to the block hash {bh}."
+                    f"maps to the block hash {retrieved_block_hash}."
                 )
             else:
-                return bh
+                return retrieved_block_hash
 
         # Return the appropriate value.
         if block_hash:


### PR DESCRIPTION
Issue #3083 raised the issue of `block_hash` and `block` being passed to `determine_block_hash` when supplying a `block` to `get_neuron_for_pubkey_and_subnet`. 

The short fix for this was #3084, but improving on this is better.

Because `AsyncSubtensor.get_block_hash` is cached, there's really no performance loss in checking the block hash if both the block and block_hash are supplied to `determine_block_hash`.

With this PR, if both a block and block_hash are passed to `determine_block_hash`, it will verify that the actual block hash maps to the corresponding supplied block hash for the given block, raising a ValueError if not.