### PR TITLE
Clarify subnet hyperparameter descriptions

### DIFF
--- a/bittensor/core/chain_data/subnet_hyperparameters.py
+++ b/bittensor/core/chain_data/subnet_hyperparameters.py
@@ -12,8 +12,8 @@ class SubnetHyperparameters(InfoBase):
         rho: The rate of decay of some value.
         kappa: A constant multiplier used in calculations.
         immunity_period: The period during which immunity is active.
-        min_allowed_weights: Minimum allowed weights.
-        max_weight_limit: Maximum weight limit.
+        min_allowed_weights: The minimum number of weights allowed to be set by a validator.
+        max_weight_limit: The maximum weight that can be assigned to a single neuron.
         tempo: The tempo or rate of operation.
         min_difficulty: Minimum difficulty for some operations.
         max_difficulty: Maximum difficulty for some operations.


### PR DESCRIPTION
This PR clarifies the docstrings for `max_weight_limit` and `min_allowed_weights` in the `SubnetHyperparameters` dataclass. The previous descriptions were identical and confusing.

The new descriptions more accurately reflect how these hyperparameters are used in the codebase:

- `min_allowed_weights`: The minimum number of weights a validator must set to be considered active.
- `max_weight_limit`: The maximum proportion of the total weight that a single validator can assign to any single neuron.